### PR TITLE
fix: change action token to let jobs run bot generated pr

### DIFF
--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -1,7 +1,6 @@
 name: Commitlint PR
 
 on:
-  merge_group:
   pull_request:
     types:
       - opened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,9 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
+          commit: "chore(repo): Version packages"
           version: yarn changeset version
           publish: yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Apparently using the GITHUB_TOKEN to push to the changeset branch doesn't trigger actions to run, but using a Personal Access Token does.

source: https://github.com/changesets/action/issues/70