### PR TITLE
feat: add new typography colors to support button component

### DIFF
--- a/.changeset/wise-donkeys-exist.md
+++ b/.changeset/wise-donkeys-exist.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/typography": patch
+---
+
+adds white & disabled colors, changes black to default to match figma

--- a/packages/typography/README.md
+++ b/packages/typography/README.md
@@ -6,14 +6,14 @@
 > Heading & Text components that powers typography in telegraph
 
 
-### Installation Instructions
+## Installation Instructions
 
 ```
 npm install @telegraph/typography
 ```
 
 
-#### Add stylesheet
+### Add stylesheet
 Pick one:
 
 Via CSS (preferred):
@@ -26,9 +26,9 @@ Via Javascript:
 import "@telegraph/typography/style.css"
 ```
 
-#### Usage
+### Usage
 
-##### `<Heading/>`
+#### `<Heading/>`
 
 ```
 import { Heading } from "@telegraph/typography"
@@ -38,16 +38,16 @@ import { Heading } from "@telegraph/typography"
 <Heading>Heading</Heading>
 ```
 
-###### Props
+##### Props
 
 | Name | Type | Default | Options |
 | ---- | -----| ------- | ------- |
 | as | string | null | "h1" "h2" "h3" "h4" "h5" "h6" |
 | size | string | "2" | "1" "2" "3" "4" "5" "6" "7" "8" "9" |
-| color | string | "black" | "black" "gray" "red" "beige" "blue" "green" "yellow" "accent" |
+| color | string | "default" | "default" "gray" "red" "beige" "blue" "green" "yellow" "accent" "disabled" "white" |
 | align | string | null | "left" "right" "center" |
 
-##### `<Text/>`
+#### `<Text/>`
 
 ```
 import { Text } from "@telegraph/typography"
@@ -57,12 +57,12 @@ import { Text } from "@telegraph/typography"
 <Text>Text</Text>
 ```
 
-###### Props
+##### Props
 
 | Name | Type | Default | Options |
 | ---- | -----| ------- | ------- |
 | as | string | null | "p" "span" "div" "label" "em" "strong" "b" "i" "pre" "code"
 | size | string | "2" | "1" "2" "3" "4" "5" "6" "7" "8" "9" |
-| color | string | "black" | "black" "gray" "red" "beige" "blue" "green" "yellow" "accent" |
+| color | string | "default" | "default" "gray" "red" "beige" "blue" "green" "yellow" "accent" "disabled" "white" |
 | align | string | null | "left" "right" "center" |
 | weight | string | regular | "regular" "medium" |

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -14,7 +14,7 @@ type HeadingRef = HTMLHeadingElement;
 
 const Heading = React.forwardRef<HeadingRef, HeadingProps>(
   (
-    { color = "black", size = "2", align, className, ...props },
+    { color = "default", size = "2", align, className, ...props },
     forwardedRef,
   ) => {
     return (

--- a/packages/typography/src/Text/Text.tsx
+++ b/packages/typography/src/Text/Text.tsx
@@ -31,7 +31,7 @@ type TextRef = HTMLElement;
 const Text = React.forwardRef<TextRef, TextProps>(
   (
     {
-      color = "black",
+      color = "default",
       size = "2",
       weight = "regular",
       align,

--- a/packages/typography/src/helpers/prop-mappings.ts
+++ b/packages/typography/src/helpers/prop-mappings.ts
@@ -17,7 +17,7 @@ export const weightMap = {
 } as const;
 
 export const colorMap = {
-  black: "text-gray-12",
+  default: "text-gray-12",
   gray: "text-gray-11",
   red: "text-red-11",
   beige: "text-beige-11",
@@ -25,6 +25,8 @@ export const colorMap = {
   green: "text-green-11",
   yellow: "text-yellow-11",
   accent: "text-accent-11",
+  white: "text-white",
+  disabled: "text-gray-9",
 } as const;
 
 export const alignMap = {


### PR DESCRIPTION
The new button component needs a few new colors to exist in our typography components in order to work.

`@telegraph/typography`
- Adds `white` and `disabled` colors to typography components
- Changes `black` to `default` to match figma
- Updates docs