### PR TITLE
fix: as prop updates typography components to correct element

### DIFF
--- a/.changeset/nice-lies-taste.md
+++ b/.changeset/nice-lies-taste.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/typography": patch
+---
+
+fixes as property not assigning correct element

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import { alignMap, colorMap, sizeMap } from "../helpers/prop-mappings";
 
-type HeadingProps = React.HTMLAttributes<HTMLHeadingElement> & {
+type HeadingProps = React.HTMLAttributes<HeadingRef> & {
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   align?: keyof typeof alignMap;
   size?: keyof typeof sizeMap;
@@ -14,11 +14,20 @@ type HeadingRef = HTMLHeadingElement;
 
 const Heading = React.forwardRef<HeadingRef, HeadingProps>(
   (
-    { color = "default", size = "2", align, className, ...props },
+    {
+      as: Component,
+      color = "default",
+      size = "2",
+      align,
+      className,
+      ...props
+    },
     forwardedRef,
   ) => {
+    if (!Component) throw new Error("as prop is required");
+
     return (
-      <h3
+      <Component
         className={clsx(
           align && alignMap[align],
           color && colorMap[color],

--- a/packages/typography/src/Text/Text.tsx
+++ b/packages/typography/src/Text/Text.tsx
@@ -8,7 +8,7 @@ import {
   weightMap,
 } from "../helpers/prop-mappings";
 
-type TextProps = React.HTMLAttributes<HTMLElement> & {
+type TextProps = React.HTMLAttributes<TextRef> & {
   as:
     | "p"
     | "span"
@@ -26,11 +26,16 @@ type TextProps = React.HTMLAttributes<HTMLElement> & {
   weight?: keyof typeof weightMap;
 };
 
-type TextRef = HTMLElement;
+type TextRef = HTMLParagraphElement &
+  HTMLSpanElement &
+  HTMLDivElement &
+  HTMLLabelElement &
+  HTMLPreElement;
 
 const Text = React.forwardRef<TextRef, TextProps>(
   (
     {
+      as: Component,
       color = "default",
       size = "2",
       weight = "regular",
@@ -40,8 +45,9 @@ const Text = React.forwardRef<TextRef, TextProps>(
     },
     forwardedRef,
   ) => {
+    if (!Component) throw new Error("as prop is required");
     return (
-      <span
+      <Component
         className={clsx(
           align && alignMap[align],
           color && colorMap[color],


### PR DESCRIPTION
The `as` prop wasn't properly updating the underlying component.

- Modifies `Heading` & `Text` components to utilize the as prop in the underlying component
- Updates type defs to support the different elements