### PR TITLE
fix: tag type issues + add helper types

### DIFF
--- a/.changeset/smooth-tips-grab.md
+++ b/.changeset/smooth-tips-grab.md
@@ -1,0 +1,9 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/button": patch
+"@telegraph/layout": patch
+"@telegraph/input": patch
+"@telegraph/tag": patch
+---
+
+tag types fixes + helper types

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithAs, Required, Optional } from "@telegraph/helpers";
+import type { Optional, PropsWithAs, Required } from "@telegraph/helpers";
 import { Icon as TelegraphIcon } from "@telegraph/icon";
 import { Text as TypographyText } from "@telegraph/typography";
 import clsx from "clsx";
@@ -132,7 +132,7 @@ const Icon: typeof TelegraphIcon = React.forwardRef<IconRef, IconProps>(
   },
 );
 
-type TextProps = Optional<React.ComponentProps<typeof TypographyText>, "as">
+type TextProps = Optional<React.ComponentProps<typeof TypographyText>, "as">;
 
 type TextRef = React.ElementRef<typeof TypographyText>;
 

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithAs, Required, Optional } from "@telegraph/helpers";
 import { Icon as TelegraphIcon } from "@telegraph/icon";
 import { Text as TypographyText } from "@telegraph/typography";
 import clsx from "clsx";
@@ -12,24 +13,6 @@ import {
   textColorMap,
   textSizeMap,
 } from "./Button.constants";
-
-// The `as` prop is a generic prop that allows you to change the underlying
-// element of a component. This is useful for creating a component that can
-// be used as a button, link, or any other element.
-type AsProp<C extends React.ElementType> = {
-  as?: C;
-};
-
-// The `PropsWithAs` type is a utility type that allows you to create a
-// component that can be used as a button, link, or any other element.
-// It takes a generic type `C` that extends `React.ElementType` and a
-// generic type `P` that extends `object`. It returns a type that includes
-// the `as` prop and all the props of the underlying element type `C`.
-// This allows you to create a component that can be used as a button, link,
-// or any other element, and pass all the props of the underlying element type.
-type PropsWithAs<C extends React.ElementType, P> = AsProp<C> &
-  Omit<React.ComponentProps<C>, keyof AsProp<C>> &
-  P;
 
 type RootBaseProps = {
   variant?: "solid" | "soft" | "outline" | "ghost";
@@ -47,10 +30,6 @@ type InternalProps = {
 type RootProps = RootBaseProps;
 
 type RootRef = React.LegacyRef<HTMLButtonElement>;
-
-type Required<T> = {
-  [P in keyof T]-?: T[P];
-};
 
 const ButtonContext = React.createContext<
   Required<Omit<RootBaseProps, "color" | "as"> & InternalProps>
@@ -153,9 +132,7 @@ const Icon: typeof TelegraphIcon = React.forwardRef<IconRef, IconProps>(
   },
 );
 
-type TextProps = Omit<React.ComponentProps<typeof TypographyText>, "as"> & {
-  as?: React.ComponentProps<typeof TypographyText>["as"];
-};
+type TextProps = Optional<React.ComponentProps<typeof TypographyText>, "as">
 
 type TextRef = React.ElementRef<typeof TypographyText>;
 

--- a/packages/helpers/.eslintrc.js
+++ b/packages/helpers/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -1,0 +1,8 @@
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/helpers.svg)](https://www.npmjs.com/package/@telegraph/helpers)
+
+# @telegraph/helpers
+> Internal helpers for use in telegraph
+
+

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@telegraph/button",
-  "version": "0.0.8",
-  "description": "Button component in Telegraph",
-  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/button",
+  "name": "@telegraph/helpers",
+  "version": "0.0.0",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/helpers",
   "author": "@knocklabs",
   "license": "MIT",
   "main": "./dist/cjs/index.js",
@@ -12,10 +11,8 @@
     ".": {
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/css/default.css"
-    },
-    "./default.css": "./dist/css/default.css"
+      "types": "./dist/types/index.d.ts"
+    }
   },
   "files": [
     "dist",
@@ -26,8 +23,6 @@
     "clean": "rm -rf dist",
     "dev": "vite build --watch --emptyOutDir false",
     "build": "yarn clean && vite build",
-    "test": "vitest run",
-    "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
@@ -37,27 +32,17 @@
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.3",
     "@knocklabs/typescript-config": "^0.0.2",
-    "@telegraph/postcss-config": "workspace:^",
     "@telegraph/prettier-config": "workspace:^",
-    "@telegraph/tailwind-config": "workspace:^",
     "@telegraph/vite-config": "workspace:^",
-    "@telegraph/vitest-config": "workspace:^",
     "@types/react": "^18.2.48",
     "eslint": "^8.56.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "typescript": "^5.3.3",
-    "vite": "^5.0.12",
-    "vitest": "^1.2.2"
+    "vite": "^5.0.12"
   },
   "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
-  },
-  "dependencies": {
-    "@telegraph/helpers": "workspace:^",
-    "@telegraph/icon": "workspace:^",
-    "@telegraph/typography": "workspace:^",
-    "clsx": "^2.1.0"
   }
 }

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+    Required,
+    AsProp,
+    PropsWithAs,
+    Optional,
+} from './types/utility'

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,6 +1,1 @@
-export type {
-    Required,
-    AsProp,
-    PropsWithAs,
-    Optional,
-} from './types/utility'
+export type { Required, AsProp, PropsWithAs, Optional } from "./types/utility";

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -25,4 +25,3 @@ export type AsProp<C extends React.ElementType> = {
 export type PropsWithAs<C extends React.ElementType, P> = AsProp<C> &
   Omit<React.ComponentProps<C>, keyof AsProp<C>> &
   P;
-

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -1,0 +1,28 @@
+// If only T is passed, make all properties required, if K is passed, make only those properties required
+export type Required<T, K = Record<string, unknown>> = K extends keyof T
+  ? Omit<T, K> & Required<Pick<T, K>>
+  : { [P in keyof T]-?: T[P] };
+
+// If only T is passed, make all properties optional, if K is passed, make only those properties optional
+export type Optional<T, K extends keyof T> = K extends keyof T
+  ? Omit<T, K> & Partial<Pick<T, K>>
+  : { [P in keyof T]?: T[P] };
+
+// The `as` prop is a generic prop that allows you to change the underlying
+// element of a component. This is useful for creating a component that can
+// be used as a button, link, or any other element.
+export type AsProp<C extends React.ElementType> = {
+  as?: C;
+};
+
+// The `PropsWithAs` type is a utility type that allows you to create a
+// component that can be used as a button, link, or any other element.
+// It takes a generic type `C` that extends `React.ElementType` and a
+// generic type `P` that extends `object`. It returns a type that includes
+// the `as` prop and all the props of the underlying element type `C`.
+// This allows you to create a component that can be used as a button, link,
+// or any other element, and pass all the props of the underlying element type.
+export type PropsWithAs<C extends React.ElementType, P> = AsProp<C> &
+  Omit<React.ComponentProps<C>, keyof AsProp<C>> &
+  P;
+

--- a/packages/helpers/tsconfig.json
+++ b/packages/helpers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/helpers",
+  "compilerOptions": {
+    "outDir": "dist",
+  },
+  "include": ["src/**/*"],
+  "exclude": [ "src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules" ],
+}

--- a/packages/helpers/vite.config.mts
+++ b/packages/helpers/vite.config.mts
@@ -1,0 +1,4 @@
+import { defaultViteConfig  } from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, {  });

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@radix-ui/react-slot": "^1.0.2",
     "@telegraph/compose-refs": "workspace:^",
+    "@telegraph/helpers": "workspace:^",
     "clsx": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -2,6 +2,7 @@ import { Slot as RadixSlot } from "@radix-ui/react-slot";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import clsx from "clsx";
 import React from "react";
+import type { Required } from '@telegraph/helpers';
 
 import { COLOR, SIZE } from "./Input.constants";
 
@@ -20,9 +21,6 @@ type InternalProps = Omit<BaseRootProps, "errored"> & {
   state: "default" | "disabled" | "error";
 };
 
-type Required<T> = {
-  [P in keyof T]-?: T[P];
-};
 
 const InputContext = React.createContext<Required<InternalProps>>({
   state: "default",

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -1,8 +1,8 @@
 import { Slot as RadixSlot } from "@radix-ui/react-slot";
 import { useComposedRefs } from "@telegraph/compose-refs";
+import type { Required } from "@telegraph/helpers";
 import clsx from "clsx";
 import React from "react";
-import type { Required } from '@telegraph/helpers';
 
 import { COLOR, SIZE } from "./Input.constants";
 
@@ -20,7 +20,6 @@ type RootRef = HTMLInputElement;
 type InternalProps = Omit<BaseRootProps, "errored"> & {
   state: "default" | "disabled" | "error";
 };
-
 
 const InputContext = React.createContext<Required<InternalProps>>({
   state: "default",

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -10,8 +10,7 @@ import { BOX_PROPS, VARIANT } from "./Box.constants";
 
 type BoxProp = keyof typeof BOX_PROPS;
 type BoxProps = React.HTMLAttributes<HTMLDivElement> & {
-  [key in BoxProp]?: Responsive<`${keyof typeof t.tokens.spacing}`> &
-    Responsive<"auto">;
+  [key in BoxProp]?: Responsive<`${keyof typeof t.tokens.spacing}` | "auto">;
 } & {
   // More variants wil beed added here once
   // they are designed

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@telegraph/button": "workspace:^",
+    "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/typography": "workspace:^",
     "clsx": "^2.1.0"

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -1,4 +1,5 @@
 import { Button as TelegraphButton } from "@telegraph/button";
+import type { Optional, Required } from "@telegraph/helpers";
 import {
   Icon as TelegraphIcon,
   closeSharp,
@@ -14,10 +15,6 @@ type RootBaseProps = {
   size?: "1" | "2";
   color?: keyof (typeof COLOR.Root)["soft"];
   variant?: keyof typeof COLOR.Root;
-};
-
-type Required<T> = {
-  [P in keyof T]-?: T[P];
 };
 
 type RootProps = React.HTMLAttributes<RootRef> & RootBaseProps;
@@ -53,9 +50,7 @@ const Root = React.forwardRef<RootRef, RootProps>(
   },
 );
 
-type TextProps = Omit<React.ComponentProps<typeof TelegraphText>, "as"> & {
-  as: React.ComponentProps<typeof TelegraphText>["as"];
-};
+type TextProps = Optional<React.ComponentProps<typeof TelegraphText>, "as">;
 
 type TextRef = React.ElementRef<typeof TelegraphText>;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,6 +4616,7 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
@@ -4640,6 +4641,26 @@ __metadata:
 "@telegraph/compose-refs@workspace:^, @telegraph/compose-refs@workspace:packages/compose-refs":
   version: 0.0.0-use.local
   resolution: "@telegraph/compose-refs@workspace:packages/compose-refs"
+  dependencies:
+    "@knocklabs/eslint-config": "npm:^0.0.3"
+    "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/vite-config": "workspace:^"
+    "@types/react": "npm:^18.2.48"
+    eslint: "npm:^8.56.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.3.3"
+    vite: "npm:^5.0.12"
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
+"@telegraph/helpers@workspace:^, @telegraph/helpers@workspace:packages/helpers":
+  version: 0.0.0-use.local
+  resolution: "@telegraph/helpers@workspace:packages/helpers"
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
@@ -4691,6 +4712,7 @@ __metadata:
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@telegraph/compose-refs": "workspace:^"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"
@@ -4815,6 +4837,7 @@ __metadata:
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@telegraph/button": "workspace:^"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"


### PR DESCRIPTION
When @connorlindsey was adding in the `Tag` component to control we were noticing a few minor type issues with required vs optional props. This fixes those type issues and also adds in a `@telegraph/helpers` package where we can re-use types like this across telegraph for more consistency. 