### PR TITLE
fix: stack gap not using css variable tokens

### DIFF
--- a/.changeset/thick-dogs-study.md
+++ b/.changeset/thick-dogs-study.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+fix gap not using token css variable

--- a/packages/layout/src/Stack/Stack.constants.ts
+++ b/packages/layout/src/Stack/Stack.constants.ts
@@ -26,7 +26,7 @@ export const STACK_PROPS = {
   },
   gap: {
     rule: "gap",
-    type: "spacing-gap",
-    valueType: "static",
+    type: "spacing",
+    valueType: "variable",
   },
 } as const;


### PR DESCRIPTION
#### Description
The gap variable on `<Stack/>` was using a static css variable when it should be pointing to using our tokens store in css variables instead. 

#### Tasks
[KNO-5950](https://linear.app/knock/issue/KNO-5950/[telegraph]-fix-gap-not-using-css-variable)