### PR TITLE
feat: migrate to lucide icons

### DIFF
--- a/.changeset/rotten-apples-beam.md
+++ b/.changeset/rotten-apples-beam.md
@@ -1,0 +1,9 @@
+---
+"@telegraph/vite-config": patch
+"@telegraph/button": patch
+"@telegraph/input": patch
+"@telegraph/icon": patch
+"@telegraph/tag": patch
+---
+
+Updates to support lucide icon

--- a/examples/playground/app/page.tsx
+++ b/examples/playground/app/page.tsx
@@ -1,177 +1,35 @@
 "use client";
 import { Heading } from "@telegraph/typography";
 import { Button } from "@telegraph/button";
-import { Icon, addSharp, chevronDown } from "@telegraph/icon";
-import { Tag } from "@telegraph/tag";
-import { Box, Stack } from "@telegraph/layout";
+import { Icon, Lucide } from "@telegraph/icon";
 
 export default function Home() {
   return (
-    <main className="tgph">
-      <Box pl={{ sm: "0", lg: "40" }}>I am a box</Box>
-      <Stack
-        gap="2"
-        align="center"
-        justify="center"
-        p="20"
-        direction={{ md: "column", "2xl": "row" }}
-      >
-        <Box>
-          I am a box
-          <br /> I am a box
-        </Box>
-        <Box>I am a box</Box>
-      </Stack>
-      <div style={{ margin: "80px 200px" }}>
-        <div>
-          <Tag text="Tag" size="1" color="yellow">
-            Tag
-          </Tag>
-        </div>
-      </div>
+    <div className="tgph">
       <Icon
+        icon={Lucide.Bed}
         alt="add icon"
-        icon={addSharp}
-        color="red"
+        color="blue"
         size="9"
-        variant="primary"
+        variant="secondary"
       />
-      <div style={{ display: "block", gap: "0rem" }}>
-        <div>
-          <Button.Root color="green" variant="solid">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="blue" variant="solid">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="yellow" variant="solid">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-        </div>
-        <div>
-          <Button.Root color="green" variant="soft">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="blue" variant="soft">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="yellow" variant="soft">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-        </div>
-        <div>
-          <Button.Root color="green" variant="outline">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="blue" variant="outline">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="yellow" variant="outline">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-        </div>
-        <div>
-          <Button.Root color="green" variant="ghost">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="blue" variant="ghost">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-          <Button.Root color="yellow" variant="ghost">
-            <Button.Icon icon={addSharp} alt="create" />
-            <Button.Text>Button</Button.Text>
-          </Button.Root>
-        </div>
-        <Button.Root color="red" variant="solid" size="2">
-          <Button.Icon icon={addSharp} alt="create" />
-        </Button.Root>
-        <Button.Root color="red" variant="solid" size="2">
-          <Button.Text>Button</Button.Text>
-        </Button.Root>
-        <Button.Root color="red" variant="solid">
-          <Button.Icon icon={addSharp} alt="create" />
-          <Button.Text>Button</Button.Text>
-        </Button.Root>
-        <Button.Root color="red" variant="soft" size="2">
-          <Button.Text>Button</Button.Text>
-          <Button.Icon icon={chevronDown} alt="Arrow pointing down" />
-        </Button.Root>
-        <Button.Root color="gray" variant="outline" size="2">
-          <Button.Icon icon={addSharp} alt="create" />
-          <Button.Text>Button</Button.Text>
-          <Button.Icon icon={chevronDown} alt="Arrow pointing down" />
-        </Button.Root>
-        <Button icon={{ icon: addSharp, alt: "create" }} color="accent" />
-      </div>
-      <Heading as="h3" size="9">
+      <Icon
+        icon={Lucide.Bell}
+        alt="add icon"
+        color="blue"
+        size="9"
+        variant="secondary"
+      />
+      <Button
+        color="blue"
+        leadingIcon={{ icon: Lucide.Info, alt: "Add" }}
+        variant="solid"
+      >
+        Button
+      </Button>
+      <Heading color="blue" as="h2">
         Heading
       </Heading>
-      <Heading as="h3" size="8">
-        Heading
-      </Heading>
-      <Heading as="h3" size="7">
-        Heading
-      </Heading>
-      <Heading as="h3" size="6">
-        Heading
-      </Heading>
-      <Heading as="h3" size="5">
-        Heading
-      </Heading>
-      <Heading as="h3" size="4">
-        Heading
-      </Heading>
-      <Heading as="h3" size="3">
-        Heading
-      </Heading>
-      <Heading as="h3" size="2">
-        Heading
-      </Heading>
-      <Heading as="h3" size="1">
-        Heading
-      </Heading>
-      <Heading as="h3" size="0">
-        Heading
-      </Heading>
-      <Heading as="h3">Heading</Heading>
-      <Heading as="h3" color="red">
-        Heading
-      </Heading>
-      <Heading as="h3" color="beige">
-        Heading
-      </Heading>
-      <Heading as="h3" color="blue">
-        Heading
-      </Heading>
-      <Heading as="h3" color="green">
-        Heading
-      </Heading>
-      <Heading as="h3" color="yellow">
-        Heading
-      </Heading>
-      <Heading as="h3" color="accent">
-        Heading
-      </Heading>
-      <Heading as="h3" align="left">
-        Heading
-      </Heading>
-      <Heading as="h3" align="center">
-        Heading
-      </Heading>
-      <Heading as="h3" align="right">
-        Heading
-      </Heading>
-    </main>
+    </div>
   );
 }

--- a/packages/button/src/Button/Button.stories.tsx
+++ b/packages/button/src/Button/Button.stories.tsx
@@ -1,13 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import * as icons from "@telegraph/icon";
+import { Lucide } from "@telegraph/icon";
 
 import { Button as TelegraphButton } from "./Button";
 import { buttonColorMap, buttonSizeMap } from "./Button.constants";
 
-// Filter out the main Icon component
-const filteredIcons = Object.keys(icons).filter((icon) => {
-  return icon !== "Icon";
-});
+const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphButton> = {
   title: "Components/Button",
@@ -32,7 +29,7 @@ const meta: Meta<typeof TelegraphButton> = {
       },
     },
     leadingIcon: {
-      options: filteredIcons,
+      options: Icons,
       control: {
         type: "select",
       },
@@ -62,28 +59,28 @@ export const Default: Story = {};
 export const WithIcon: Story = {
   render: ({ leadingIcon, ...args }) => {
     const formattedLeadingIcon = {
-      icon: icons[leadingIcon as keyof typeof icons],
+      icon: Icons[leadingIcon as keyof typeof Icons],
       alt: "description",
     };
     // @ts-expect-error: overriding the leadingIcon to make it better UX in storybook
     return <TelegraphButton leadingIcon={formattedLeadingIcon} {...args} />;
   },
   args: {
-    leadingIcon: "informationCircleOutline",
+    leadingIcon: "Info",
   },
 };
 
 export const IconOnly: Story = {
   render: ({ leadingIcon, ...args }) => {
     const formattedLeadingIcon = {
-      icon: icons[leadingIcon as keyof typeof icons],
+      icon: Icons[leadingIcon as keyof typeof Icons],
       alt: "description",
     };
     // @ts-expect-error: overriding the leadingIcon to make it better UX in storybook
     return <TelegraphButton icon={formattedLeadingIcon} {...args} />;
   },
   args: {
-    leadingIcon: "informationCircleOutline",
+    leadingIcon: "Info",
     children: null,
   },
 };

--- a/packages/button/src/Button/Button.stories.tsx
+++ b/packages/button/src/Button/Button.stories.tsx
@@ -29,7 +29,19 @@ const meta: Meta<typeof TelegraphButton> = {
       },
     },
     leadingIcon: {
-      options: Icons,
+      options: ["", ...Object.keys(Icons)],
+      control: {
+        type: "select",
+      },
+    },
+    trailingIcon: {
+      options: ["", ...Object.keys(Icons)],
+      control: {
+        type: "select",
+      },
+    },
+    icon: {
+      options: ["", ...Object.keys(Icons)],
       control: {
         type: "select",
       },
@@ -49,19 +61,51 @@ type StorybookButtonType = Omit<
   React.ComponentProps<typeof TelegraphButton>,
   "leadingIcon"
 > & {
-  leadingIcon: string;
+  leadingIcon?: string;
+  trailingIcon?: string;
+  icon?: string;
 };
 
 type Story = StoryObj<StorybookButtonType>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: ({ leadingIcon, trailingIcon, icon, ...args }) => {
+    const mergedProps = {
+      leadingIcon: leadingIcon
+        ? { icon: Icons[leadingIcon as keyof typeof Icons], alt: "description" }
+        : null,
+      trailingIcon: trailingIcon
+        ? {
+            icon: Icons[trailingIcon as keyof typeof Icons],
+            alt: "description",
+          }
+        : null,
+      icon: icon
+        ? {
+            icon: Icons[icon as keyof typeof Icons],
+            alt: "description",
+          }
+        : null,
+      ...args,
+    };
+    console.log(mergedProps);
+    return <TelegraphButton {...mergedProps} />;
+  },
+  args: {
+    leadingIcon: "",
+    trailingIcon: "",
+    icon: "",
+  },
+};
 
 export const WithIcon: Story = {
   render: ({ leadingIcon, ...args }) => {
-    const formattedLeadingIcon = {
-      icon: Icons[leadingIcon as keyof typeof Icons],
-      alt: "description",
-    };
+    const formattedLeadingIcon = leadingIcon
+      ? {
+          icon: Icons[leadingIcon as keyof typeof Icons],
+          alt: "description",
+        }
+      : null;
     // @ts-expect-error: overriding the leadingIcon to make it better UX in storybook
     return <TelegraphButton leadingIcon={formattedLeadingIcon} {...args} />;
   },
@@ -72,10 +116,12 @@ export const WithIcon: Story = {
 
 export const IconOnly: Story = {
   render: ({ leadingIcon, ...args }) => {
-    const formattedLeadingIcon = {
-      icon: Icons[leadingIcon as keyof typeof Icons],
-      alt: "description",
-    };
+    const formattedLeadingIcon = leadingIcon
+      ? {
+          icon: Icons[leadingIcon as keyof typeof Icons],
+          alt: "description",
+        }
+      : null;
     // @ts-expect-error: overriding the leadingIcon to make it better UX in storybook
     return <TelegraphButton icon={formattedLeadingIcon} {...args} />;
   },

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -1,4 +1,4 @@
-import { addSharp } from "@telegraph/icon";
+import { Lucide } from "@telegraph/icon";
 import { render } from "@testing-library/react";
 import React from "react";
 import { describe, expect, it } from "vitest";
@@ -14,8 +14,8 @@ describe("Button", () => {
   it("icon button is accessible", async () => {
     const { container } = render(
       <Button
-        leadingIcon={{ icon: addSharp, alt: "create" }}
-        trailingIcon={{ icon: addSharp, alt: "create" }}
+        leadingIcon={{ icon: Lucide.Bell, alt: "create" }}
+        trailingIcon={{ icon: Lucide.Bell, alt: "create" }}
       >
         Click me
       </Button>,
@@ -23,16 +23,15 @@ describe("Button", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
   it("icon button without alt is inaccessible", async () => {
-    const { container } = render(
-      <Button leadingIcon={{ icon: addSharp }}>Click me</Button>,
-    );
-    expect(await axe(container)).not.toHaveNoViolations();
+    expect(() =>
+      render(<Button leadingIcon={{ icon: Lucide.Bell }}>Click me</Button>),
+    ).toThrow("@telegraph/icon: alt prop is required");
   });
   it("icon in text button icon has correct text color", async () => {
     const { container } = render(
       <Button
-        leadingIcon={{ icon: addSharp, alt: "create" }}
-        trailingIcon={{ icon: addSharp, alt: "create" }}
+        leadingIcon={{ icon: Lucide.Bell, alt: "create" }}
+        trailingIcon={{ icon: Lucide.Bell, alt: "create" }}
         variant="soft"
       >
         Click me
@@ -43,7 +42,7 @@ describe("Button", () => {
   });
   it("icon in icon only button  has correct text color", async () => {
     const { container } = render(
-      <Button icon={{ icon: addSharp, alt: "create" }} variant="soft" />,
+      <Button icon={{ icon: Lucide.Bell, alt: "create" }} variant="soft" />,
     );
     const icon = container?.querySelector("[data-button-icon]");
     expect(icon).toHaveClass("text-gray-11");
@@ -65,17 +64,16 @@ describe("Button", () => {
   it("overrides on icon work", async () => {
     const { container } = render(
       <Button.Root>
-        <Button.Icon color="red" size="9" icon={addSharp} alt="create" />
+        <Button.Icon color="red" size="9" icon={Lucide.Bell} alt="create" />
       </Button.Root>,
     );
     expect(container.firstChild).toHaveClass("bg-gray-9");
     const icon = container?.querySelector("[data-button-icon]");
     expect(icon).toHaveClass("text-red-11");
-    expect(icon).toHaveClass("text-9");
   });
   it("icon-only button has correct layout", async () => {
     const { container } = render(
-      <Button icon={{ icon: addSharp, alt: "create" }} />,
+      <Button icon={{ icon: Lucide.Bell, alt: "create" }} />,
     );
     expect(container.firstChild).toHaveAttribute(
       "data-tgph-button-layout",
@@ -84,7 +82,7 @@ describe("Button", () => {
   });
   it("text button has correct layout", async () => {
     const { container } = render(
-      <Button icon={{ icon: addSharp, alt: "create" }}>Button</Button>,
+      <Button icon={{ icon: Lucide.Bell, alt: "create" }}>Button</Button>,
     );
     expect(container.firstChild).toHaveAttribute(
       "data-tgph-button-layout",
@@ -93,7 +91,7 @@ describe("Button", () => {
   });
   it("disabled prop displays correct styles", async () => {
     const { container } = render(
-      <Button disabled icon={{ icon: addSharp, alt: "create" }}>
+      <Button disabled icon={{ icon: Lucide.Bell, alt: "create" }}>
         Button
       </Button>,
     );

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -23,18 +23,18 @@ npm install @telegraph/icon
 #### `<Icon/>`
 
 ```
-import { Icon, checkmark } from "@telegraph/icon"
+import { Icon, Lucide } from "@telegraph/icon"
 
 ...
 
-<Icon icon={checkmark} alt="item is selected"/>
+<Icon icon={Lucide.Bell} alt="notifications"/>
 ```
 
 ##### Props
 
 | Name    | Type   | Default     | Options                                                                                     |
 | ------- | ------ | ----------- | ------------------------------------------------------------------------------------------- |
-| icon    | string | `undefined` | See package exports                                                                         |
+| icon    | ReactComponent | `undefined` | See package exports                                                                         |
 | alt     | string | `undefined` |                                                                                             |
 | size    | string | "2"         | "1" "2" "3" "4" "5" "6" "7" "8" "9"                                                         |
 | color   | string | "default"   | "default" "gray" "red" "beige" "blue" "green" "yellow" "purple" "accent" "disabled" "white" |

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -54,7 +54,8 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
+    "@telegraph/layout": "workspace:^",
     "clsx": "^2.1.0",
-    "ionicons": "^7.2.2"
+    "lucide-react": "^0.379.0"
   }
 }

--- a/packages/icon/src/Icon/Icon.constants.ts
+++ b/packages/icon/src/Icon/Icon.constants.ts
@@ -11,18 +11,6 @@ export const sizeMap = {
     "8": "h-9 w-9",
     "9": "h-12 w-12",
   },
-  icon: {
-    "0": "text-[0.8125rem]",
-    "1": "text-2",
-    "2": "text-3",
-    "3": "text-4",
-    "4": "text-5",
-    "5": "text-[1.375rem]",
-    "6": "text-[1.625rem]",
-    "7": "text-[2rem]",
-    "8": "text-8",
-    "9": "text-9",
-  },
 } as const;
 
 export const colorMap = {

--- a/packages/icon/src/Icon/Icon.stories.tsx
+++ b/packages/icon/src/Icon/Icon.stories.tsx
@@ -57,7 +57,7 @@ type Story = StoryObj<StorybookIconType>;
 export const Icon: Story = {
   render: ({ icon, ...props }) => (
     <TelegraphIcon
-    // @ts-expect-error: for illustrative purposes only
+      // @ts-expect-error: for illustrative purposes only
       icon={Icons[icon as keyof typeof Icons]}
       {...props}
       alt="test"

--- a/packages/icon/src/Icon/Icon.stories.tsx
+++ b/packages/icon/src/Icon/Icon.stories.tsx
@@ -1,15 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import * as icons from "ionicons/icons";
+
+import { Lucide } from "../index";
 
 import { Icon as TelegraphIcon } from "./Icon";
 import { colorMap, sizeMap } from "./Icon.constants";
+
+const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphIcon> = {
   title: "Components",
   component: TelegraphIcon,
   argTypes: {
     icon: {
-      options: Object.keys(icons),
+      options: Object.keys(Icons),
       control: {
         type: "select",
       },
@@ -42,11 +45,23 @@ const meta: Meta<typeof TelegraphIcon> = {
 
 export default meta;
 
-type Story = StoryObj<typeof TelegraphIcon>;
+type StorybookIconType = Omit<
+  React.ComponentProps<typeof TelegraphIcon>,
+  "icon"
+> & {
+  icon: string;
+};
+
+type Story = StoryObj<StorybookIconType>;
 
 export const Icon: Story = {
   render: ({ icon, ...props }) => (
-    <TelegraphIcon icon={icons[icon as keyof typeof icons]} {...props} />
+    <TelegraphIcon
+    // @ts-expect-error: for illustrative purposes only
+      icon={Icons[icon as keyof typeof Icons]}
+      {...props}
+      alt="test"
+    />
   ),
-  args: { icon: "informationCircleOutline" },
+  args: { icon: "Bell" },
 };

--- a/packages/icon/src/Icon/Icon.styles.css
+++ b/packages/icon/src/Icon/Icon.styles.css
@@ -1,7 +1,0 @@
-.tgph-stroke-width {
-  stroke-width: 32px;
-}
-
-.tgph-fill-none {
-  fill: none;
-}

--- a/packages/icon/src/Icon/Icon.test.tsx
+++ b/packages/icon/src/Icon/Icon.test.tsx
@@ -1,45 +1,48 @@
 import { render } from "@testing-library/react";
-import { addSharp } from "ionicons/icons";
 import React from "react";
 import { describe, expect, it } from "vitest";
 import { axe } from "vitest-axe";
+
+import { Lucide } from "../index";
 
 import { Icon } from "./Icon";
 
 describe("Heading", () => {
   it("should render without a11y issues", async () => {
     const { container } = render(
-      <Icon icon={addSharp} alt="Create a workflow" />,
+      <Icon icon={Lucide.Bell} alt="Create a workflow" />,
     );
     expect(await axe(container)).toHaveNoViolations();
   });
-  it("not including an alt prop should fail a11y", async () => {
-    const { container } = render(
-      // @ts-expect-error: expected as we're testing the a11y of the component
-      <Icon icon={addSharp} />,
+  it("icon without icon prop throws error", async () => {
+    expect(() => render(<Icon alt="description" />)).toThrow(
+      "@telegraph/icon: icon prop is required",
     );
-    expect(await axe(container)).not.toHaveNoViolations();
+  });
+  it("icon without alt prop throws error", async () => {
+    expect(() => render(<Icon icon={{ icon: Lucide.Bell }} />)).toThrow(
+      "@telegraph/icon: alt prop is required",
+    );
   });
   it("default props applies correct className", () => {
     const { container } = render(
-      <Icon icon={addSharp} alt="Create a workflow" />,
+      <Icon icon={Lucide.Bell} alt="Create a workflow" />,
     );
     expect(container.firstChild).toHaveClass("h-4");
     expect(container.firstChild).toHaveClass("w-4");
-    expect(container.firstChild).toHaveClass("text-3");
     expect(container.firstChild).toHaveClass("text-gray-12");
     expect(container.firstChild).toHaveClass("inline-block");
   });
   it("color prop applies correct className", () => {
     const { container } = render(
-      <Icon icon={addSharp} alt="Create a workflow" color="red" />,
+      <Icon icon={Lucide.Bell} alt="Create a workflow" color="red" />,
     );
     expect(container.firstChild).toHaveClass("text-red-11");
   });
   it("variant prop applies correct className", () => {
     const { container } = render(
       <Icon
-        icon={addSharp}
+        icon={Lucide.Bell}
         alt="Create a workflow"
         color="red"
         variant="secondary"
@@ -49,9 +52,8 @@ describe("Heading", () => {
   });
   it("size prop applies correct className", () => {
     const { container } = render(
-      <Icon icon={addSharp} alt="Create a workflow" size="9" />,
+      <Icon icon={Lucide.Bell} alt="Create a workflow" size="9" />,
     );
-    expect(container.firstChild).toHaveClass("text-9");
     expect(container.firstChild).toHaveClass("h-12");
     expect(container.firstChild).toHaveClass("w-12");
   });

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -12,10 +12,10 @@ type BaseIconProps = {
   size?: keyof (typeof sizeMap)["box"];
   variant?: keyof typeof colorMap;
   color?: keyof (typeof colorMap)["primary"];
-  boxProps: React.ComponentPropsWithRef<typeof Box>;
 };
 
-type IconProps = React.SVGAttributes<SVGSVGElement> & BaseIconProps;
+type IconProps = BaseIconProps &
+  Omit<React.ComponentProps<typeof Box>, "size" | "variant">;
 
 type IconRef = SVGSVGElement;
 
@@ -28,41 +28,42 @@ const Icon = React.forwardRef<IconRef, IconProps>(
       icon,
       alt,
       className,
-      boxProps,
       ...props
     },
     forwardedRef,
   ) => {
-      const IconComponent = icon;
+    const IconComponent = icon;
 
-      if(!IconComponent) {
-          console.error(`@telegraph/icon: icon prop is required`);
-      }
+    if (!IconComponent) {
+      throw new Error(`@telegraph/icon: icon prop is required`);
+    }
 
+    if (!alt) {
+      throw new Error(`@telegraph/icon: alt prop is required`);
+    }
 
     return (
       <Box
         className={clsx(
           size && sizeMap["box"][size],
           color && colorMap[variant][color],
-          boxProps?.className,
+          "inline-block",
+          className,
         )}
-        {...boxProps}
+            data-button-icon
+        {...props}
       >
-      {IconComponent && (
-        <IconComponent
-          aria-label={alt}
-          width="100%"
-          height="100%"
-          className={className}
-          {...props}
-          ref={forwardedRef}
-        />
+        {IconComponent && (
+          <IconComponent
+            aria-label={alt}
+            width="100%"
+            height="100%"
+            ref={forwardedRef}
+          />
         )}
       </Box>
     );
   },
 );
-
 
 export { Icon };

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -14,8 +14,7 @@ type BaseIconProps = {
   color?: keyof (typeof colorMap)["primary"];
 };
 
-type IconProps = BaseIconProps &
-  Omit<React.ComponentProps<typeof Box>, "size" | "variant">;
+type IconProps = BaseIconProps & React.HTMLAttributes<HTMLDivElement>;
 
 type IconRef = SVGSVGElement;
 
@@ -50,7 +49,7 @@ const Icon = React.forwardRef<IconRef, IconProps>(
           "inline-block",
           className,
         )}
-            data-button-icon
+        data-button-icon
         {...props}
       >
         {IconComponent && (

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -1,18 +1,23 @@
+import { Box } from "@telegraph/layout";
 import clsx from "clsx";
+// We use "Bell" in place of any icon so we get correct type checking
+import type { Bell } from "lucide-react";
 import React from "react";
 
 import { colorMap, sizeMap } from "./Icon.constants";
-import "./Icon.styles.css";
 
-type IconProps = React.HTMLAttributes<HTMLSpanElement> & {
-  icon: string;
+type BaseIconProps = {
+  icon: typeof Bell;
   alt: string;
   size?: keyof (typeof sizeMap)["box"];
   variant?: keyof typeof colorMap;
   color?: keyof (typeof colorMap)["primary"];
+  boxProps: React.ComponentPropsWithRef<typeof Box>;
 };
 
-type IconRef = HTMLSpanElement;
+type IconProps = React.SVGAttributes<SVGSVGElement> & BaseIconProps;
+
+type IconRef = SVGSVGElement;
 
 const Icon = React.forwardRef<IconRef, IconProps>(
   (
@@ -23,42 +28,41 @@ const Icon = React.forwardRef<IconRef, IconProps>(
       icon,
       alt,
       className,
+      boxProps,
       ...props
     },
     forwardedRef,
   ) => {
-    // Get SVG part of the icon
-    const unsafeIconMarkup = icon?.split(",")?.[1];
+      const IconComponent = icon;
 
-    // Replace ionicon classes with telegraph classes
-    const iconMarkup = unsafeIconMarkup
-      ?.replace(/class='ionicon'/g, "")
-      ?.replace(/ionicon-stroke-width/g, "tgph-stroke-width")
-      ?.replace(/ionicon-fill-none/g, "tgph-fill-none");
+      if(!IconComponent) {
+          console.error(`@telegraph/icon: icon prop is required`);
+      }
 
-    if (!iconMarkup) {
-      return <></>;
-    }
 
     return (
-      <span
-        role="img"
-        aria-label={alt}
-        dangerouslySetInnerHTML={{ __html: iconMarkup }}
+      <Box
         className={clsx(
-          "box-border",
           size && sizeMap["box"][size],
-          size && sizeMap["icon"][size],
-          variant && color && colorMap[variant][color],
-          "stroke-[currentColor] fill-[currentColor] inline-block",
-          className,
+          color && colorMap[variant][color],
+          boxProps?.className,
         )}
-        data-tgph-icon
-        {...props}
-        ref={forwardedRef}
-      />
+        {...boxProps}
+      >
+      {IconComponent && (
+        <IconComponent
+          aria-label={alt}
+          width="100%"
+          height="100%"
+          className={className}
+          {...props}
+          ref={forwardedRef}
+        />
+        )}
+      </Box>
     );
   },
 );
+
 
 export { Icon };

--- a/packages/icon/src/default.css
+++ b/packages/icon/src/default.css
@@ -1,5 +1,3 @@
-@import "./Icon/Icon.styles.css";
-
 /* Including just "@tailwind utilities;" will build only the classnames within the package */
 @tailwind utilities;
 

--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,4 +1,4 @@
 // Export as "Lucide" so we have the potential
 // to support other icon libraries in the future
-export * as Lucide  from "lucide-react";
+export * as Lucide from "lucide-react";
 export { Icon } from "./Icon";

--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,4 +1,4 @@
+// Export as "Lucide" so we have the potential
+// to support other icon libraries in the future
+export * as Lucide  from "lucide-react";
 export { Icon } from "./Icon";
-
-// Export by ".js" extension to avoid ESM resolution error
-export * from "ionicons/icons/index.js";

--- a/packages/input/src/Input/Input.stories.tsx
+++ b/packages/input/src/Input/Input.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
-import { Icon } from "@telegraph/icon";
-import * as icons from "ionicons/icons";
+import { Icon, Lucide } from "@telegraph/icon";
 
 import { Input as TelegraphInput } from "./Input";
 import { COLOR, SIZE } from "./Input.constants";
+
+const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphInput> = {
   title: "Components/Input",
@@ -33,13 +34,13 @@ const meta: Meta<typeof TelegraphInput> = {
       },
     },
     LeadingComponent: {
-      options: Object.keys(icons),
+      options: Object.keys(Icons),
       control: {
         type: "select",
       },
     },
     TrailingComponent: {
-      options: Object.keys(icons),
+      options: Object.keys(Icons),
       control: {
         type: "select",
       },
@@ -65,16 +66,13 @@ export const LeadingIcon: Story = {
   render: ({ LeadingComponent, ...props }) => (
     <TelegraphInput
       LeadingComponent={
-        <Icon
-          icon={icons[LeadingComponent as unknown as keyof typeof icons]}
-          alt="alt"
-        />
+        <Icon icon={Icons[LeadingComponent as keyof typeof Icons]} alt="alt" />
       }
       {...props}
     />
   ),
   args: {
-    LeadingComponent: "searchSharp",
+    LeadingComponent: "Search",
     TrailingComponent: null,
   },
 };
@@ -83,16 +81,13 @@ export const TrailingAction: Story = {
   render: ({ LeadingComponent, TrailingComponent, ...props }) => (
     <TelegraphInput
       LeadingComponent={
-        <Icon
-          icon={icons[LeadingComponent as unknown as keyof typeof icons]}
-          alt="alt"
-        />
+        <Icon icon={Icons[LeadingComponent as keyof typeof Icons]} alt="alt" />
       }
       TrailingComponent={
         <Button
           variant="ghost"
           icon={{
-            icon: icons[TrailingComponent as unknown as keyof typeof icons],
+            icon: Icons[TrailingComponent as keyof typeof Icons],
             alt: "create",
           }}
         />
@@ -102,6 +97,6 @@ export const TrailingAction: Story = {
   ),
   args: {
     LeadingComponent: null,
-    TrailingComponent: "informationCircleSharp",
+    TrailingComponent: "Info",
   },
 };

--- a/packages/input/src/Input/Input.stories.tsx
+++ b/packages/input/src/Input/Input.stories.tsx
@@ -34,13 +34,13 @@ const meta: Meta<typeof TelegraphInput> = {
       },
     },
     LeadingComponent: {
-      options: Object.keys(Icons),
+      options: ["", ...Object.keys(Icons)],
       control: {
         type: "select",
       },
     },
     TrailingComponent: {
-      options: Object.keys(Icons),
+      options: ["", ...Object.keys(Icons)],
       control: {
         type: "select",
       },
@@ -60,13 +60,44 @@ export default meta;
 
 type Story = StoryObj<typeof TelegraphInput>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  render: ({ LeadingComponent, TrailingComponent, ...props }) => (
+    <TelegraphInput
+      LeadingComponent={
+        LeadingComponent && (
+          <Icon
+            icon={Icons[LeadingComponent as keyof typeof Icons]}
+            alt="alt"
+          />
+        )
+      }
+      TrailingComponent={
+        TrailingComponent && (
+          <Icon
+            icon={Icons[TrailingComponent as keyof typeof Icons]}
+            alt="alt"
+          />
+        )
+      }
+      {...props}
+    />
+  ),
+  args: {
+    LeadingComponent: null,
+    TrailingComponent: null,
+  },
+};
 
 export const LeadingIcon: Story = {
   render: ({ LeadingComponent, ...props }) => (
     <TelegraphInput
       LeadingComponent={
-        <Icon icon={Icons[LeadingComponent as keyof typeof Icons]} alt="alt" />
+        LeadingComponent && (
+          <Icon
+            icon={Icons[LeadingComponent as keyof typeof Icons]}
+            alt="alt"
+          />
+        )
       }
       {...props}
     />
@@ -81,16 +112,23 @@ export const TrailingAction: Story = {
   render: ({ LeadingComponent, TrailingComponent, ...props }) => (
     <TelegraphInput
       LeadingComponent={
-        <Icon icon={Icons[LeadingComponent as keyof typeof Icons]} alt="alt" />
+        LeadingComponent && (
+          <Icon
+            icon={Icons[LeadingComponent as keyof typeof Icons]}
+            alt="alt"
+          />
+        )
       }
       TrailingComponent={
-        <Button
-          variant="ghost"
-          icon={{
-            icon: Icons[TrailingComponent as keyof typeof Icons],
-            alt: "create",
-          }}
-        />
+        TrailingComponent && (
+          <Button
+            variant="ghost"
+            icon={{
+              icon: Icons[TrailingComponent as keyof typeof Icons],
+              alt: "create",
+            }}
+          />
+        )
       }
       {...props}
     />

--- a/packages/tag/README.md
+++ b/packages/tag/README.md
@@ -147,11 +147,11 @@ import { Tag } from '@telegraph/tag'
 
 ```
 import { Tag } from "@telegraph/tag"
-import { addSharp, closeSharp } from '@telegraph/icon'
+import { Lucide  } from '@telegraph/icon'
 
 <Tag.Root color="blue" variant="solid" size="2">
-    <Tag.Icon icon={addSharp} alt="Create"/>
+    <Tag.Icon icon={Lucide.Add} alt="Create"/>
     <Tag.Text>Text</Tag.Text>
-    <Tag.Button icon={{ icon: removeSharp, alt: "remove"}} onClick={() => {}}/>
+    <Tag.Button icon={{ icon: Lucide.X, alt: "remove"}} onClick={() => {}}/>
 </Tag.Root>
 ```

--- a/packages/tag/src/Tag/Tag.stories.tsx
+++ b/packages/tag/src/Tag/Tag.stories.tsx
@@ -67,7 +67,7 @@ export const Tag: Story = {
           ...props,
         }
       : props;
-      // @ts-expect-error: for illustration purposes only
+    // @ts-expect-error: for illustration purposes only
     return <TelegraphTag {...mergedProps} />;
   },
   args: {

--- a/packages/tag/src/Tag/Tag.stories.tsx
+++ b/packages/tag/src/Tag/Tag.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import * as icons from "ionicons/icons";
+import { Lucide } from "@telegraph/icon";
 
 import { Tag as TelegraphTag } from "./Tag";
 import { COLOR, SIZE } from "./Tag.constants";
+
+const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphTag> = {
   title: "Components",
@@ -37,7 +39,7 @@ const meta: Meta<typeof TelegraphTag> = {
       },
     },
     icon: {
-      options: Object.keys(icons),
+      options: Object.keys(Icons),
       control: {
         type: "select",
       },
@@ -48,15 +50,26 @@ const meta: Meta<typeof TelegraphTag> = {
 
 export default meta;
 
-type Story = StoryObj<typeof TelegraphTag>;
+type StorybookTagType = Omit<
+  React.ComponentProps<typeof TelegraphTag>,
+  "icon"
+> & {
+  icon?: string;
+};
+
+type Story = StoryObj<StorybookTagType>;
 
 export const Tag: Story = {
-  render: ({ icon, ...props }) => (
-    <TelegraphTag
-      icon={{ icon: icons[icon as unknown as keyof typeof icons], alt: "alt" }}
-      {...props}
-    />
-  ),
+  render: ({ icon, ...props }) => {
+    const mergedProps = icon
+      ? {
+          icon: { icon: Icons[icon as keyof typeof Icons], alt: "description" },
+          ...props,
+        }
+      : props;
+      // @ts-expect-error: for illustration purposes only
+    return <TelegraphTag {...mergedProps} />;
+  },
   args: {
     children: "Tag",
     variant: "soft",

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -1,10 +1,6 @@
 import { Button as TelegraphButton } from "@telegraph/button";
 import type { Optional, Required } from "@telegraph/helpers";
-import {
-  Icon as TelegraphIcon,
-  closeSharp,
-  copyOutline,
-} from "@telegraph/icon";
+import { Lucide, Icon as TelegraphIcon } from "@telegraph/icon";
 import { Text as TelegraphText } from "@telegraph/typography";
 import { clsx } from "clsx";
 import React from "react";
@@ -81,7 +77,7 @@ const Button = React.forwardRef<ButtonRef, ButtonProps>(
         size={context.size}
         color={COLOR.Button[context.variant][context.color]}
         variant={context.variant}
-        icon={{ icon: closeSharp, alt: "close" }}
+        icon={{ icon: Lucide.X, alt: "close" }}
         className={clsx("rounded-tl-0 rounded-bl-0", className)}
         {...props}
         ref={forwardedRef}
@@ -136,14 +132,11 @@ const Default = React.forwardRef<DefaultRef, DefaultProps>(
         {onRemove && (
           <Button
             onClick={onRemove}
-            icon={{ icon: closeSharp, alt: "Copy Text" }}
+            icon={{ icon: Lucide.Copy, alt: "Copy Text" }}
           />
         )}
         {onCopy && (
-          <Button
-            onClick={onCopy}
-            icon={{ icon: copyOutline, alt: "Remove" }}
-          />
+          <Button onClick={onCopy} icon={{ icon: Lucide.X, alt: "Remove" }} />
         )}
       </Root>
     );

--- a/packages/vite-config/src/vite-config.ts
+++ b/packages/vite-config/src/vite-config.ts
@@ -22,7 +22,6 @@ const allDependencies = [
   // Need to declare these as external as well since they're
   // not explicitly listed in the package.json
   "react/jsx-runtime",
-  "ionicons/icons",
 ];
 
 const buildTimeInfo = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4190,15 +4190,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@stencil/core@npm:^4.0.3":
-  version: 4.12.6
-  resolution: "@stencil/core@npm:4.12.6"
-  bin:
-    stencil: bin/stencil
-  checksum: 10c0/5b8d076a2fee512d81f732c2e8c60dce2f5fc3b8ec42e248c7bf922ab4efd19dfa70b3df88ff65c05b36785e85c699ce06b3438fa37d776203feaef6013b59eb
-  languageName: node
-  linkType: hard
-
 "@storybook/addon-actions@npm:7.6.17":
   version: 7.6.17
   resolution: "@storybook/addon-actions@npm:7.6.17"
@@ -5078,6 +5069,7 @@ __metadata:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
@@ -5085,7 +5077,7 @@ __metadata:
     "@types/react": "npm:^18.2.48"
     clsx: "npm:^2.1.0"
     eslint: "npm:^8.56.0"
-    ionicons: "npm:^7.2.2"
+    lucide-react: "npm:^0.379.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     typescript: "npm:^5.3.3"
@@ -10636,15 +10628,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ionicons@npm:^7.2.2":
-  version: 7.2.2
-  resolution: "ionicons@npm:7.2.2"
-  dependencies:
-    "@stencil/core": "npm:^4.0.3"
-  checksum: 10c0/9d5810f1b580756c52e06ba846c6518c91588843273a7b68104c7622f4a82b0f560aa7ef66e06e26e01400cfbe37ba8348731a2bab27a0d86d6d334225735bf3
-  languageName: node
-  linkType: hard
-
 "ip-address@npm:^9.0.5":
   version: 9.0.5
   resolution: "ip-address@npm:9.0.5"
@@ -11981,6 +11964,15 @@ __metadata:
   dependencies:
     yallist: "npm:^4.0.0"
   checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
+  languageName: node
+  linkType: hard
+
+"lucide-react@npm:^0.379.0":
+  version: 0.379.0
+  resolution: "lucide-react@npm:0.379.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/b2521db4b2329e51f3b31abf5f6e03caa6cc1c736e8dc27e79fd92c09ed2e95bd7d85ea46a765d264ddbafb525c783bd4689ef512434972fdfcd33fa2bdfb1c6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- Replaces `ionicons` with `lucide-react`
- Reconfigures `@telegraph/icon` to work with `lucide-react`
- Updates components utilizing `@telegraph/icon` to work with breaking changes.
- Fixes tests / Fixes usages in storybook

Notes:
- This work supports [KNO-5961](https://linear.app/knock/issue/KNO-5961/[dashboard]-update-codeeditor-icons-to-lucide-icons) and will require changes to be made in control where we're utilizing `@telegraph/icon`. Builds will fail on this new version in control until updates are made, so zero risk on breakages making it to production.

### Tasks
[KNO-6062](kyle-kno-6062-telegraph-update-icon-component-to-use-lucide-icons)