### PR TITLE
feat: add render modes for light / dark support in storybook

### DIFF
--- a/.storybook/global.css
+++ b/.storybook/global.css
@@ -1,6 +1,6 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
 
-@import "../packages/tokens/dist/css/light.css";
+@import "../packages/tokens/dist/css/default.css";
 @import "../packages/typography/dist/css/default.css";
 @import "../packages/button/dist/css/default.css";
 @import "../packages/icon/dist/css/default.css";
@@ -12,4 +12,6 @@
 
 body {
   font-family: "Inter", sans-serif;
+  background-color: var(--tgph-surface-1);
+  color: var(--tgph-gray-12);
 }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,8 +1,11 @@
-
 export default {
   framework: "@storybook/react-vite",
   stories: ["../packages/**/*.stories.@(js|jsx|mjs|ts|tsx|mdx)"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
+  addons: [
+    "@storybook/addon-links",
+    "@storybook/addon-essentials",
+    "storybook-addon-render-modes",
+  ],
   core: {
     builder: "@storybook/builder-vite", // 👈 The builder enabled here.
   },

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "storybook": "^7.6.17",
+    "storybook-addon-render-modes": "^0.0.11",
     "turbo": "^1.11.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3132,6 +3132,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     storybook: "npm:^7.6.17"
+    storybook-addon-render-modes: "npm:^0.0.11"
     turbo: "npm:^1.11.3"
   languageName: unknown
   linkType: soft
@@ -15176,6 +15177,13 @@ __metadata:
   version: 2.14.3
   resolution: "store2@npm:2.14.3"
   checksum: 10c0/22e1096e6d69590672ca0b7f891d82b060837ef4c3e5df0d4563e6cbed14c52ddf2589fa94b79f4311b6ec41d95d6142e5d01d194539e0175c3fb4090cca8244
+  languageName: node
+  linkType: hard
+
+"storybook-addon-render-modes@npm:^0.0.11":
+  version: 0.0.11
+  resolution: "storybook-addon-render-modes@npm:0.0.11"
+  checksum: 10c0/6ff5a69b789dac0877a2248a402bbf5dd1972db843bfcba194c7a67b1a8b801797bab51e713d6a8827f4ea7fd640a31ff6942a26e88da51bcb9234b2f305a422
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- Updates storybook css import to be `default` so we get theme-ing
- Adds storybook addon to control color scheme to switch between themes

### Tasks 
[KNO-6149](https://linear.app/knock/issue/KNO-6149/[telegraph]-light-dark-mode-support-in-storybook)