### PR TITLE
feat: package scaffolding with moonrepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ yarn-error.log*
 
 # Storybook
 /storybook-static
+
+# moon
+.moon/cache
+.moon/docker

--- a/.moon/workspace.yml
+++ b/.moon/workspace.yml
@@ -1,0 +1,32 @@
+# https://moonrepo.dev/docs/config/workspace
+$schema: 'https://moonrepo.dev/schemas/workspace.json'
+
+# Require a specific version of moon while running commands, otherwise fail.
+# versionConstraint: '>=1.0.0'
+
+# Extend and inherit an external configuration file. Must be a valid HTTPS URL or file system path.
+# extends: './shared/workspace.yml'
+
+# REQUIRED: A map of all projects found within the workspace, or a list or file system globs.
+# When using a map, each entry requires a unique project ID as the map key, and a file system
+# path to the project folder as the map value. File paths are relative from the workspace root,
+# and cannot reference projects located outside the workspace boundary.
+projects:
+  - 'packages/*'
+
+# Configures the version control system to utilize within the workspace. A VCS
+# is required for determining touched (added, modified, etc) files, calculating file hashes,
+# computing affected files, and much more.
+vcs:
+  # The client to use when managing the repository.
+  # Accepts "git". Defaults to "git".
+  manager: 'git'
+
+  # The default branch (master/main/trunk) in the repository for comparing the
+  # local branch against. For git, this is is typically "master" or "main",
+  # and must include the remote prefix (before /).
+  defaultBranch: 'main'
+
+generator:
+  templates:
+    - './templates'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node": "18.x"
   },
   "scripts": {
+    "generate:package": "moon generate package",
     "dev:packages": "turbo dev --filter=\"./packages/*\" --concurrency=100",
     "build:packages": "turbo build --filter=\"./packages/*\" --filter=\"!config\"",
     "build:config": "turbo build --filter=\"./packages/*-config\"",
@@ -43,6 +44,7 @@
     "@commitlint/cli": "^18.6.0",
     "@commitlint/config-conventional": "^18.6.0",
     "@manypkg/cli": "^0.21.2",
+    "@moonrepo/cli": "^1.25.2",
     "@storybook/addon-essentials": "^7.6.17",
     "@storybook/addon-interactions": "^7.6.17",
     "@storybook/addon-links": "^7.6.17",

--- a/templates/package/.eslintrc.js
+++ b/templates/package/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/templates/package/README.md
+++ b/templates/package/README.md
@@ -1,0 +1,18 @@
+
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/{{package_name}})
+
+# @telegraph/{{package_name}}
+> {{package_description}}
+
+## Installation Instructions
+
+```
+npm install @telegraph/{{package_name}}
+```
+
+### Add stylesheet
+```
+@import "@telegraph/{{package_name}}"
+```

--- a/templates/package/package.json
+++ b/templates/package/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@telegraph/{{package_name}}",
+  "version": "0.0.0",
+  "description": "{{package_description}}",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/{{package_name}}",
+  "author": "@knocklabs",
+  "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/css/default.css"
+    },
+    "./default.css": "./dist/css/default.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "prettier": "@telegraph/prettier-config",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch --emptyOutDir false",
+    "build": "yarn clean && vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "coverage": "vitest run --coverage",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
+    "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
+    "preview": "vite preview"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@knocklabs/eslint-config": "^0.0.3",
+    "@knocklabs/typescript-config": "^0.0.2",
+    "@telegraph/postcss-config": "workspace:^",
+    "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/tailwind-config": "workspace:^",
+    "@telegraph/vite-config": "workspace:^",
+    "@telegraph/vitest-config": "workspace:^",
+    "@types/react": "^18.2.48",
+    "eslint": "^8.56.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.12",
+    "vitest": "^1.2.2"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/templates/package/postcss.config.mjs
+++ b/templates/package/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pkg from "@telegraph/postcss-config";
+
+const { postCssConfig } = pkg;
+
+export default postCssConfig;

--- a/templates/package/src/default.css
+++ b/templates/package/src/default.css
@@ -1,0 +1,4 @@
+/* Including just "@tailwind utilities;" will build only the classnames within the package */
+@tailwind utilities;
+
+@config "../tailwind.config.mts";

--- a/templates/package/tailwind.config.mts
+++ b/templates/package/tailwind.config.mts
@@ -1,0 +1,7 @@
+import tailwindConfig from "@telegraph/tailwind-config";
+
+export default {
+  content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
+  extend: {},
+  presets: [tailwindConfig],
+};

--- a/templates/package/template.yml
+++ b/templates/package/template.yml
@@ -1,0 +1,11 @@
+title: 'package'
+description: Scaffolds the initial structure of a new package
+variables:
+  package_name:
+    type: 'string'
+    required: true
+    prompt: "Package name: @telegraph/"
+  package_description:
+    type: 'string'
+    required: false
+    prompt: "A short description of the package"

--- a/templates/package/tsconfig.json
+++ b/templates/package/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/{{package_name}}",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/templates/package/vite.config.mts
+++ b/templates/package/vite.config.mts
@@ -1,0 +1,4 @@
+import { defaultViteConfig, scopedCssViteConfig } from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, scopedCssViteConfig);

--- a/templates/package/vitest.config.mts
+++ b/templates/package/vitest.config.mts
@@ -1,0 +1,2 @@
+import { vitestConfig } from "@telegraph/vitest-config";
+export default vitestConfig;

--- a/templates/package/vitest.d.ts
+++ b/templates/package/vitest.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="@telegraph/vitest-config/dist/vitest-axe.d.ts" />
+// NOTE: This file should not be editied
+// This generates the correct types for vite `expect` to interacte with "vitest-axe"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3115,6 +3115,7 @@ __metadata:
     "@commitlint/cli": "npm:^18.6.0"
     "@commitlint/config-conventional": "npm:^18.6.0"
     "@manypkg/cli": "npm:^0.21.2"
+    "@moonrepo/cli": "npm:^1.25.2"
     "@storybook/addon-essentials": "npm:^7.6.17"
     "@storybook/addon-interactions": "npm:^7.6.17"
     "@storybook/addon-links": "npm:^7.6.17"
@@ -3288,6 +3289,88 @@ __metadata:
   version: 0.14.2
   resolution: "@microsoft/tsdoc@npm:0.14.2"
   checksum: 10c0/c018857ad439144559ce34a397a29ace7cf5b24b999b8e3c1b88d878338088b3a453eaac4435beaf2c7eae13c4c0aac81e42f96f0f1d48e8d4eeb438eb3bb82f
+  languageName: node
+  linkType: hard
+
+"@moonrepo/cli@npm:^1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/cli@npm:1.25.2"
+  dependencies:
+    "@moonrepo/core-linux-arm64-gnu": "npm:1.25.2"
+    "@moonrepo/core-linux-arm64-musl": "npm:1.25.2"
+    "@moonrepo/core-linux-x64-gnu": "npm:1.25.2"
+    "@moonrepo/core-linux-x64-musl": "npm:1.25.2"
+    "@moonrepo/core-macos-arm64": "npm:1.25.2"
+    "@moonrepo/core-macos-x64": "npm:1.25.2"
+    "@moonrepo/core-windows-x64-msvc": "npm:1.25.2"
+    detect-libc: "npm:^2.0.3"
+  dependenciesMeta:
+    "@moonrepo/core-linux-arm64-gnu":
+      optional: true
+    "@moonrepo/core-linux-arm64-musl":
+      optional: true
+    "@moonrepo/core-linux-x64-gnu":
+      optional: true
+    "@moonrepo/core-linux-x64-musl":
+      optional: true
+    "@moonrepo/core-macos-arm64":
+      optional: true
+    "@moonrepo/core-macos-x64":
+      optional: true
+    "@moonrepo/core-windows-x64-msvc":
+      optional: true
+  bin:
+    moon: moon.js
+  checksum: 10c0/88c1531c4d6287e9d53b8f55ac6449f6cfc349bff91dbc9d443e2b0beedb69f5fdd825cf3403cbe03d205dd04f982efe986af93a48045dce50752ff3caa6846c
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-linux-arm64-gnu@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-linux-arm64-gnu@npm:1.25.2"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-linux-arm64-musl@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-linux-arm64-musl@npm:1.25.2"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-linux-x64-gnu@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-linux-x64-gnu@npm:1.25.2"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-linux-x64-musl@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-linux-x64-musl@npm:1.25.2"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-macos-arm64@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-macos-arm64@npm:1.25.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-macos-x64@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-macos-x64@npm:1.25.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@moonrepo/core-windows-x64-msvc@npm:1.25.2":
+  version: 1.25.2
+  resolution: "@moonrepo/core-windows-x64-msvc@npm:1.25.2"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -8424,6 +8507,13 @@ __metadata:
   bin:
     detect-libc: ./bin/detect-libc.js
   checksum: 10c0/4da0deae9f69e13bc37a0902d78bf7169480004b1fed3c19722d56cff578d16f0e11633b7fbf5fb6249181236c72e90024cbd68f0b9558ae06e281f47326d50d
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "detect-libc@npm:2.0.3"
+  checksum: 10c0/88095bda8f90220c95f162bf92cad70bd0e424913e655c20578600e35b91edc261af27531cf160a331e185c0ced93944bc7e09939143225f56312d7fd800fdb7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- Adds the ability to scaffold a new project via cli command `yarn generate:package`
- Uses [moonrepo](https://moonrepo.dev/docs/guides/codegen#generating-code-from-a-template) for code generation
- Adds `package` template

### Tasks
[KNO-6151](https://linear.app/knock/issue/KNO-6151/[telegraph]-add-scaffolding-commands-for-packages)