### PR TITLE
feat: icon alt prop optional when aria-hidden is present

### DIFF
--- a/.changeset/seven-clouds-applaud.md
+++ b/.changeset/seven-clouds-applaud.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/icon": patch
+---
+
+When aria-hidden prop is preset on `<Icon/>`, alt prop is optional

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -8,11 +8,19 @@ import { colorMap, sizeMap } from "./Icon.constants";
 
 type BaseIconProps = {
   icon: typeof Bell;
-  alt: string;
   size?: keyof (typeof sizeMap)["box"];
   variant?: keyof typeof colorMap;
   color?: keyof (typeof colorMap)["primary"];
-};
+} & (
+  | {
+      alt: string;
+      ["aria-hidden"]?: boolean;
+    }
+  | {
+      alt?: string;
+      ["aria-hidden"]: true;
+    }
+);
 
 type IconProps = BaseIconProps & React.HTMLAttributes<HTMLDivElement>;
 


### PR DESCRIPTION
### Description
- If an icon is only used for decoration the `alt` prop should not be required. So, if passing `aria-hidden` to the Icon, the `alt` prop becomes optional as this is the correct prop to pass to adhere to a11y standards.

### Tasks
[KNO-6152](https://linear.app/knock/issue/KNO-6152/[telegraph]-icon-optional-alt-when-passing-aria-hidden)