### PR TITLE
feat: add spacing token for card wdith

### DIFF
--- a/packages/tokens/src/tokens/spacing.ts
+++ b/packages/tokens/src/tokens/spacing.ts
@@ -31,6 +31,7 @@ export const spacing = {
   80: "20rem",
   96: "24rem",
   140: "35rem", // Default modal width
+  160: "40rem", // Default card width
   full: "100%",
   auto: "auto",
 };


### PR DESCRIPTION
### Description
- Adds spacing unit `160` (`40rem` / `640px`) to use as the default width for cards

### Tasks
[KNO-6153](https://linear.app/knock/issue/KNO-6153/[telegraph]-640px-spacing-constant)