### PR TITLE
fix: box props not inherited through stack component

### DIFF
--- a/.changeset/red-baboons-warn.md
+++ b/.changeset/red-baboons-warn.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+fix box props not being inherited through stack component in typescript

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -10,7 +10,7 @@ import { propsToCssVariables } from "../helpers/css-variables";
 
 import { STACK_PROPS } from "./Stack.constants";
 
-type StackProps = React.ComponentPropsWithoutRef<typeof Box> & {
+type StackProps = React.ComponentProps<typeof Box> & {
   gap?: Responsive<`${keyof typeof t.tokens.spacing}`>;
   display?: Responsive<"flex" | "inline-flex">;
   align?: Responsive<React.CSSProperties["alignItems"]>;


### PR DESCRIPTION
### Description
- Fixes the props from `<Box/>` not being properly inherited into the `<Stack/>` component. `React.ComponentPropsWithoutRef` seems like it might be bugged, you can see Radix uses their own custom type for this [here](https://github.com/radix-ui/primitives/blob/af1e3b41cb5c49d7b8c073d2aec34d5074c6dd17/packages/react/primitive/src/Primitive.tsx#L28), so `React.ComponentProps` seems to work fine for this for now. 

### Tasks 
[KNO-6155](https://linear.app/knock/issue/KNO-6155/[telegraph]-stack-not-properly-inheriting-box-props-in-typescript)