### PR TITLE
fix: don't throw error if alt text is missing for aria hidden icon

### DIFF
--- a/.changeset/wet-toys-prove.md
+++ b/.changeset/wet-toys-prove.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/button": patch
+"@telegraph/icon": patch
+---
+
+fix: don't throw error if alt text is missing for aria hidden icon

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -24,8 +24,18 @@ describe("Button", () => {
   });
   it("icon button without alt is inaccessible", async () => {
     expect(() =>
+      // @ts-expect-error Testing error case
       render(<Button leadingIcon={{ icon: Lucide.Bell }}>Click me</Button>),
     ).toThrow("@telegraph/icon: alt prop is required");
+  });
+  it("alt text is optional if icon is aria hidden", async () => {
+    const { container } = render(
+      <Button leadingIcon={{ icon: Lucide.Bell, "aria-hidden": true }}>
+        Click me
+      </Button>,
+    );
+
+    expect(await axe(container)).toHaveNoViolations();
   });
   it("icon in text button icon has correct text color", async () => {
     const { container } = render(

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -45,7 +45,7 @@ const Icon = React.forwardRef<IconRef, IconProps>(
       throw new Error(`@telegraph/icon: icon prop is required`);
     }
 
-    if (!alt) {
+    if (!alt && !props["aria-hidden"]) {
       throw new Error(`@telegraph/icon: alt prop is required`);
     }
 


### PR DESCRIPTION
Missing alt text would still throw a runtime error even if aria hidden is set to true. Also adds a test to check that behavior. 