### PR TITLE
feat: better type support with as prop + custom ref

### DIFF
--- a/.changeset/late-drinks-roll.md
+++ b/.changeset/late-drinks-roll.md
@@ -1,0 +1,13 @@
+---
+"@telegraph/typography": patch
+"@telegraph/helpers": patch
+"@telegraph/button": patch
+"@telegraph/layout": patch
+"@telegraph/input": patch
+"@telegraph/modal": patch
+"@telegraph/radio": patch
+"@telegraph/icon": patch
+"@telegraph/tag": patch
+---
+
+better ts support for as prop with custom tgphRef

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -72,10 +72,10 @@ const Root = <T extends TgphElement>({
       const child = children[0] as
         | React.ReactComponentElement<typeof Icon>
         | {
-          props: {
-            icon: undefined;
+            props: {
+              icon: undefined;
+            };
           };
-        };
       if (child?.props?.icon) {
         return "icon-only";
       }
@@ -176,15 +176,15 @@ type DefaultIconProps = React.ComponentProps<typeof Icon>;
 
 type BaseDefaultProps =
   | {
-    leadingIcon?: DefaultIconProps;
-    trailingIcon?: DefaultIconProps;
-    icon?: never;
-  }
+      leadingIcon?: DefaultIconProps;
+      trailingIcon?: DefaultIconProps;
+      icon?: never;
+    }
   | {
-    icon?: DefaultIconProps;
-    leadingIcon?: never;
-    trailingIcon?: never;
-  };
+      icon?: DefaultIconProps;
+      leadingIcon?: never;
+      trailingIcon?: never;
+    };
 type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
   TgphComponentProps<typeof Root> &
   BaseDefaultProps;
@@ -217,6 +217,5 @@ const Button = Default as typeof Default & {
   Icon: typeof Icon;
   Text: typeof Text;
 };
-
 
 export { Button };

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,1 +1,11 @@
-export type { Required, AsProp, PropsWithAs, Optional } from "./types/utility";
+export type {
+  Required,
+  AsProp,
+  PropsWithAs,
+  Optional,
+  PolymorphicProps,
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+  TgphComponentProps,
+  OptionalAsPropConfig,
+} from "./types/utility";

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -1,3 +1,5 @@
+import type React from "react";
+
 // If only T is passed, make all properties required, if K is passed, make only those properties required
 export type Required<T, K = Record<string, unknown>> = K extends keyof T
   ? Omit<T, K> & Required<Pick<T, K>>
@@ -15,6 +17,12 @@ export type AsProp<C extends React.ElementType> = {
   as?: C;
 };
 
+// Allow for internal config of the as prop for use
+// when extending this component
+export type OptionalAsPropConfig<E extends React.ElementType> =
+  | { as?: E; internal_optionalAs: true }
+  | { as: E; internal_optionalAs?: never };
+
 // The `PropsWithAs` type is a utility type that allows you to create a
 // component that can be used as a button, link, or any other element.
 // It takes a generic type `C` that extends `React.ElementType` and a
@@ -25,3 +33,36 @@ export type AsProp<C extends React.ElementType> = {
 export type PropsWithAs<C extends React.ElementType, P> = AsProp<C> &
   Omit<React.ComponentProps<C>, keyof AsProp<C>> &
   P;
+
+// The `PolymorphicProps` type is a utility type that allows you to create a
+// component that can be used as a button, link, or any other element via
+// the `as` prop. It takes a generic type `E` that extends `React.ElementType`.
+// It returns a type that includes the `as` prop and all the props of the
+// underlying element type `E`.
+export type PolymorphicProps<E extends React.ElementType> = Omit<
+  React.ComponentProps<E>,
+  "as"
+> & {
+  as?: E;
+  children?: React.ReactNode;
+};
+
+// The `PolymorphicPropsWithTgphRef` type is a utility type that allows you to create a
+// component that can be used as a button, link, or any other element via
+// the `as` prop. It takes a generic type `E` that extends `React.ElementType`.
+// It returns a type that includes the `as` prop and all the props of the
+// underlying element type `E`. It also includes a `tgpRef` prop that allows you to
+// pass a ref to the component.
+export type PolymorphicPropsWithTgphRef<
+  E extends React.ElementType,
+  R extends HTMLElement | React.ElementType,
+> = {
+  tgphRef?: React.Ref<R>;
+} & PolymorphicProps<E>;
+
+export type TgphComponentProps<T extends React.ElementType> =
+  React.ComponentProps<T>;
+
+// The `TgphElement` is a wrapper on the React.ElementType type that allows you to
+// pass a component as a prop to another component.
+export type TgphElement = React.ElementType;

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -1,8 +1,12 @@
+import type {
+  PolymorphicPropsWithTgphRef,
+  TgphComponentProps,
+  TgphElement,
+} from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
 import clsx from "clsx";
 // We use "Bell" in place of any icon so we get correct type checking
 import type { Bell } from "lucide-react";
-import React from "react";
 
 import { colorMap, sizeMap } from "./Icon.constants";
 
@@ -14,63 +18,56 @@ type BaseIconProps = {
 } & (
   | {
       alt: string;
-      ["aria-hidden"]?: boolean;
     }
   | {
-      alt?: string;
       ["aria-hidden"]: true;
     }
 );
 
-type IconProps = BaseIconProps & React.HTMLAttributes<HTMLDivElement>;
+type IconProps<T extends TgphElement> = PolymorphicPropsWithTgphRef<
+  T,
+  HTMLSpanElement
+> &
+  TgphComponentProps<typeof Box> &
+  BaseIconProps;
 
-type IconRef = SVGSVGElement;
+const Icon = <T extends TgphElement>({
+  as,
+  size = "2",
+  color = "default",
+  variant = "primary",
+  icon,
+  alt,
+  className,
+  ...props
+}: IconProps<T>) => {
+  const IconComponent = icon;
 
-const Icon = React.forwardRef<IconRef, IconProps>(
-  (
-    {
-      size = "2",
-      color = "default",
-      variant = "primary",
-      icon,
-      alt,
-      className,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    const IconComponent = icon;
+  if (!IconComponent) {
+    throw new Error(`@telegraph/icon: icon prop is required`);
+  }
 
-    if (!IconComponent) {
-      throw new Error(`@telegraph/icon: icon prop is required`);
-    }
+  if (!alt && !props["aria-hidden"]) {
+    throw new Error(`@telegraph/icon: alt prop is required`);
+  }
 
-    if (!alt && !props["aria-hidden"]) {
-      throw new Error(`@telegraph/icon: alt prop is required`);
-    }
-
-    return (
-      <Box
-        className={clsx(
-          size && sizeMap["box"][size],
-          color && colorMap[variant][color],
-          "inline-block",
-          className,
-        )}
-        data-button-icon
-        {...props}
-      >
-        {IconComponent && (
-          <IconComponent
-            aria-label={alt}
-            width="100%"
-            height="100%"
-            ref={forwardedRef}
-          />
-        )}
-      </Box>
-    );
-  },
-);
+  return (
+    <Box
+      as={as || "span"}
+      className={clsx(
+        size && sizeMap["box"][size],
+        color && colorMap[variant][color],
+        "inline-block",
+        className,
+      )}
+      data-button-icon
+      {...props}
+    >
+      {IconComponent && (
+        <IconComponent aria-label={alt} width="100%" height="100%" />
+      )}
+    </Box>
+  );
+};
 
 export { Icon };

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -38,6 +38,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
+    "@telegraph/layout": "workspace:^",
     "clsx": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -19,7 +19,6 @@ type BaseRootProps = {
   errored?: boolean;
 };
 
-
 type RootProps<T extends TgphElement> = Omit<
   PolymorphicPropsWithTgphRef<T, HTMLInputElement>,
   "size"
@@ -37,7 +36,7 @@ const InputContext = React.createContext<Required<InternalProps>>({
 });
 
 const Root = <T extends TgphElement>({
-    as = "input" as T,
+  as = "input" as T,
   size = "2",
   variant = "outline",
   className,
@@ -47,7 +46,7 @@ const Root = <T extends TgphElement>({
   tgphRef,
   ...props
 }: RootProps<T>) => {
-    const Component = as;
+  const Component = as;
   const inputRef = React.useRef<HTMLInputElement>(null);
   const composedRefs = useComposedRefs(tgphRef, inputRef);
 
@@ -98,7 +97,6 @@ const Root = <T extends TgphElement>({
   );
 };
 
-
 type SlotProps = React.ComponentPropsWithoutRef<typeof RadixSlot> & {
   size?: keyof typeof SIZE.Slot;
   position?: "leading" | "trailing";
@@ -132,13 +130,13 @@ const Slot = React.forwardRef<SlotRef, SlotProps>(
   },
 );
 
-
-type DefaultProps<T extends TgphElement> = PolymorphicProps<T> & TgphComponentProps<typeof Root> & {
+type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
+  TgphComponentProps<typeof Root> & {
     LeadingComponent?: React.ReactNode;
     TrailingComponent?: React.ReactNode;
-}
+  };
 
-const Default =<T extends TgphElement> ({
+const Default = <T extends TgphElement>({
   LeadingComponent,
   TrailingComponent,
   ...props

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -30,8 +30,7 @@ const Box = <T extends TgphElement>({
   // Filter out the box props from the rest of the props
   const filteredProps = React.useMemo(() => {
     // Set any defaults here
-    // const mergedProps = { borderColor: true, ...props };
-    const mergedProps = { ...props };
+    const mergedProps = { borderColor: true, ...props };
     return Object.keys(mergedProps).reduce(
       (acc, key) => {
         if (!Object.keys(BOX_PROPS).some((prop) => prop === key)) {

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -1,5 +1,8 @@
 import { useComposedRefs } from "@telegraph/compose-refs";
-import type { PropsWithAs } from "@telegraph/helpers";
+import type {
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+} from "@telegraph/helpers";
 import clsx from "clsx";
 import React from "react";
 
@@ -8,59 +11,57 @@ import { propsToCssVariables } from "../helpers/css-variables";
 import { BOX_PROPS } from "./Box.constants";
 import { BoxPropsTokens } from "./Box.types";
 
-type BoxProps = React.HTMLAttributes<HTMLDivElement> &
-  BoxPropsTokens & {
-    as?: React.ElementType;
-  };
+type BoxProps<T extends TgphElement> = PolymorphicPropsWithTgphRef<
+  T,
+  HTMLElement
+> &
+  BoxPropsTokens;
 
-const Box = React.forwardRef(
-  (
-    { as = "div", className, ...props }: PropsWithAs<"div", BoxProps>,
-    forwardedRef,
-  ) => {
-    const boxRef = React.useRef<HTMLDivElement>(null);
-    const composedRef = useComposedRefs(forwardedRef, boxRef);
+const Box = <T extends TgphElement>({
+  as,
+  className,
+  tgphRef,
+  ...props
+}: BoxProps<T>) => {
+  const Component: TgphElement = as || "div";
+  const boxRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = useComposedRefs(tgphRef, boxRef);
 
-    // Filter out the box props from the rest of the props
-    const filteredProps = React.useMemo(() => {
-      // Set any defaults here
-      const mergedProps = { borderColor: true, ...props };
-      return Object.keys(mergedProps).reduce(
-        (acc, key) => {
-          if (!Object.keys(BOX_PROPS).some((prop) => prop === key)) {
-            acc.rest[key] = mergedProps[key as keyof typeof mergedProps];
-          } else {
-            acc.box[key] = mergedProps[key as keyof typeof mergedProps];
-          }
-          return acc;
-        },
-        { box: {}, rest: {} } as {
-          box: Record<string, string>;
-          rest: Record<string, string>;
-        },
-      );
-    }, [props]);
-
-    React.useLayoutEffect(() => {
-      propsToCssVariables({
-        props: filteredProps.box,
-        ref: boxRef,
-        propsMap: BOX_PROPS,
-      });
-    }, [filteredProps.box]);
-
-    const Component = as;
-
-    return (
-      <Component
-        className={clsx("tgph-box", className)}
-        ref={composedRef}
-        {...filteredProps.rest}
-      />
+  // Filter out the box props from the rest of the props
+  const filteredProps = React.useMemo(() => {
+    // Set any defaults here
+    // const mergedProps = { borderColor: true, ...props };
+    const mergedProps = { ...props };
+    return Object.keys(mergedProps).reduce(
+      (acc, key) => {
+        if (!Object.keys(BOX_PROPS).some((prop) => prop === key)) {
+          acc.rest[key] = mergedProps[key as keyof typeof mergedProps];
+        } else {
+          acc.box[key] = mergedProps[key as keyof typeof mergedProps];
+        }
+        return acc;
+      },
+      { box: {}, rest: {} } as {
+        box: Record<string, string>;
+        rest: Record<string, string>;
+      },
     );
-  },
-) as <T extends React.ElementType>(
-  props: PropsWithAs<T, BoxProps>,
-) => React.ReactElement;
+  }, [props]);
+  React.useLayoutEffect(() => {
+    propsToCssVariables({
+      props: filteredProps.box,
+      ref: boxRef,
+      propsMap: BOX_PROPS,
+    });
+  }, [filteredProps.box]);
+
+  return (
+    <Component
+      className={clsx("tgph-box", className)}
+      ref={composedRef}
+      {...filteredProps.rest}
+    />
+  );
+};
 
 export { Box };

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -1,5 +1,8 @@
 import { useComposedRefs } from "@telegraph/compose-refs";
-import type { PropsWithAs } from "@telegraph/helpers";
+import type {
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+} from "@telegraph/helpers";
 import type t from "@telegraph/tokens";
 import clsx from "clsx";
 import React from "react";
@@ -10,60 +13,64 @@ import { propsToCssVariables } from "../helpers/css-variables";
 
 import { STACK_PROPS } from "./Stack.constants";
 
-type StackProps = React.ComponentProps<typeof Box> & {
-  gap?: Responsive<`${keyof typeof t.tokens.spacing}`>;
-  display?: Responsive<"flex" | "inline-flex">;
-  align?: Responsive<React.CSSProperties["alignItems"]>;
-  direction?: Responsive<React.CSSProperties["flexDirection"]>;
-  justify?: Responsive<React.CSSProperties["justifyContent"]>;
-  wrap?: Responsive<React.CSSProperties["flexWrap"]>;
+type StackProps<T extends TgphElement> = PolymorphicPropsWithTgphRef<
+  T,
+  typeof Box
+> &
+  React.ComponentProps<typeof Box> & {
+    gap?: Responsive<`${keyof typeof t.tokens.spacing}`>;
+    display?: Responsive<"flex" | "inline-flex">;
+    align?: Responsive<React.CSSProperties["alignItems"]>;
+    direction?: Responsive<React.CSSProperties["flexDirection"]>;
+    justify?: Responsive<React.CSSProperties["justifyContent"]>;
+    wrap?: Responsive<React.CSSProperties["flexWrap"]>;
+  };
+
+const Stack = <T extends TgphElement>({
+  className,
+  tgphRef,
+  ...props
+}: StackProps<T>) => {
+  const stackRef = React.useRef<HTMLDivElement>(null);
+  const composedRef = useComposedRefs(tgphRef, stackRef);
+
+  // Filter out the stack props from the rest of the props
+  const filteredProps = React.useMemo(
+    () =>
+      Object.keys(props).reduce(
+        (acc, key) => {
+          if (!Object.keys(STACK_PROPS).some((prop) => prop === key)) {
+            acc.rest[key] = props[key as keyof typeof props];
+          } else {
+            acc.stack[key] = props[key as keyof typeof props];
+          }
+          return acc;
+        },
+        { stack: {}, rest: {} } as {
+          stack: Record<string, Responsive<string>>;
+          rest: Record<string, Responsive<string>>;
+        },
+      ),
+    [props],
+  );
+
+  React.useLayoutEffect(() => {
+    propsToCssVariables({
+      props: filteredProps.stack,
+      ref: stackRef,
+      propsMap: STACK_PROPS,
+    });
+  }, [filteredProps.stack, composedRef]);
+
+  return (
+    <Box
+      className={clsx("tgph-stack", className)}
+      ref={composedRef}
+      {...filteredProps.rest}
+    />
+  );
 };
 
-type StackRef = React.ElementRef<typeof Box>;
 
-const Stack = React.forwardRef<StackRef, StackProps>(
-  ({ className, ...props }, forwardedRef) => {
-    const stackRef = React.useRef<HTMLDivElement>(null);
-    const composedRef = useComposedRefs(forwardedRef, stackRef);
-
-    // Filter out the stack props from the rest of the props
-    const filteredProps = React.useMemo(
-      () =>
-        Object.keys(props).reduce(
-          (acc, key) => {
-            if (!Object.keys(STACK_PROPS).some((prop) => prop === key)) {
-              acc.rest[key] = props[key as keyof typeof props];
-            } else {
-              acc.stack[key] = props[key as keyof typeof props];
-            }
-            return acc;
-          },
-          { stack: {}, rest: {} } as {
-            stack: Record<string, Responsive<string>>;
-            rest: Record<string, Responsive<string>>;
-          },
-        ),
-      [props],
-    );
-
-    React.useLayoutEffect(() => {
-      propsToCssVariables({
-        props: filteredProps.stack,
-        ref: stackRef,
-        propsMap: STACK_PROPS,
-      });
-    }, [filteredProps.stack, composedRef]);
-
-    return (
-      <Box
-        className={clsx("tgph-stack", className)}
-        ref={composedRef}
-        {...filteredProps.rest}
-      />
-    );
-  },
-) as <T extends React.ElementType>(
-  props: PropsWithAs<T, StackProps>,
-) => React.ReactElement;
 
 export { Stack };

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -71,6 +71,4 @@ const Stack = <T extends TgphElement>({
   );
 };
 
-
-
 export { Stack };

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -1,6 +1,11 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button } from "@telegraph/button";
+import type {
+  PolymorphicProps,
+  TgphComponentProps,
+  TgphElement,
+} from "@telegraph/helpers";
 import { Lucide } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
 import clsx from "clsx";
@@ -11,83 +16,75 @@ type RootProps = Omit<
   React.ComponentPropsWithoutRef<typeof Dialog.Root>,
   "modal"
 > &
-  React.ComponentPropsWithoutRef<typeof Stack> & {
+  TgphComponentProps<typeof Stack> & {
     a11yTitle: string;
     a11yDescription?: string;
   };
 
-type RootRef = HTMLDivElement;
-
-const Root = React.forwardRef<RootRef, RootProps>(
-  (
-    {
-      defaultOpen,
-      open,
-      onOpenChange,
-      a11yTitle,
-      a11yDescription,
-      className,
-      children,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    return (
-      <Dialog.Root
-        open={open}
-        onOpenChange={onOpenChange}
-        defaultOpen={defaultOpen}
-      >
-        <VisuallyHidden.Root>
-          <Dialog.Title>{a11yTitle}</Dialog.Title>
-          {a11yDescription && (
-            <Dialog.Description>{a11yDescription}</Dialog.Description>
-          )}
-        </VisuallyHidden.Root>
-        <AnimatePresence>
-          {open && (
-            <>
-              <Dialog.Overlay asChild>
-                <Box
-                  as={motion.div}
-                  onClick={() => onOpenChange?.(false)}
-                  initial={{ backdropFilter: "blur(0px)", opacity: 0 }}
-                  animate={{ backdropFilter: "blur(4px)", opacity: 1 }}
-                  exit={{ backdropFilter: "blur(0px)", opacity: 0 }}
-                  transition={{ duration: 0.3, bounce: 0, type: "spring" }}
-                  className="fixed inset-0 bg-alpha-black-4 z-overlay"
-                />
-              </Dialog.Overlay>
-              <Stack
-                className={clsx(
-                  "fixed z-modal top-0 left-1/2 -translate-x-1/2",
-                  "max-h-[calc(100vh-var(--tgph-spacing-32))] shadow-1",
-                  className,
-                )}
-                direction="column"
+const Root = ({
+  defaultOpen,
+  open,
+  onOpenChange,
+  a11yTitle,
+  a11yDescription,
+  className,
+  children,
+  ...props
+}: RootProps) => {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      defaultOpen={defaultOpen}
+    >
+      <VisuallyHidden.Root>
+        <Dialog.Title>{a11yTitle}</Dialog.Title>
+        {a11yDescription && (
+          <Dialog.Description>{a11yDescription}</Dialog.Description>
+        )}
+      </VisuallyHidden.Root>
+      <AnimatePresence>
+        {open && (
+          <>
+            <Dialog.Overlay asChild>
+              <Box
                 as={motion.div}
-                my="16"
-                initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-                animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
-                exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-                transition={{ duration: 0.2, bounce: 0, type: "spring" }}
-                maxW={props.maxW ?? "140"}
-                w={props.w ?? "full"}
-                bg="surface-1"
-                border
-                rounded="4"
-                {...props}
-                ref={forwardedRef}
-              >
-                {children}
-              </Stack>
-            </>
-          )}
-        </AnimatePresence>
-      </Dialog.Root>
-    );
-  },
-);
+                onClick={() => onOpenChange?.(false)}
+                initial={{ backdropFilter: "blur(0px)", opacity: 0 }}
+                animate={{ backdropFilter: "blur(4px)", opacity: 1 }}
+                exit={{ backdropFilter: "blur(0px)", opacity: 0 }}
+                transition={{ duration: 0.3, bounce: 0, type: "spring" }}
+                className="fixed inset-0 bg-alpha-black-4 z-overlay"
+              />
+            </Dialog.Overlay>
+            <Stack
+              className={clsx(
+                "fixed z-modal top-0 left-1/2 -translate-x-1/2",
+                "max-h-[calc(100vh-var(--tgph-spacing-32))] shadow-1",
+                className,
+              )}
+              direction="column"
+              as={motion.div}
+              my="16"
+              initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+              animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
+              exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+              transition={{ duration: 0.2, bounce: 0, type: "spring" }}
+              maxW={props.maxW ?? "140"}
+              w={props.w ?? "full"}
+              bg="surface-1"
+              border
+              rounded="4"
+              {...props}
+            >
+              {children}
+            </Stack>
+          </>
+        )}
+      </AnimatePresence>
+    </Dialog.Root>
+  );
+};
 
 type ContentProps = React.ComponentPropsWithoutRef<typeof Dialog.Content>;
 type ContentRef = React.ElementRef<typeof Dialog.Content>;
@@ -102,86 +99,80 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
   },
 );
 
-type CloseProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Dialog.Close>,
-  "color"
-> &
-  React.ComponentPropsWithoutRef<typeof Button>;
-type CloseRef = React.ElementRef<typeof Button>;
-
-const Close = React.forwardRef<CloseRef, CloseProps>(
-  ({ size = "1", variant = "ghost", ...props }, forwardedRef) => {
-    return (
-      <Dialog.Close asChild>
-        <Button
-          icon={{ icon: Lucide.X, alt: "Close Modal" }}
-          variant={variant}
-          size={size}
-          {...props}
-          ref={forwardedRef}
-        />
-      </Dialog.Close>
-    );
-  },
-);
-
-type BodyProps = React.ComponentPropsWithoutRef<typeof Stack>;
-type BodyRef = React.ElementRef<typeof Stack>;
-
-const Body: React.FC<BodyProps> = React.forwardRef<BodyRef, BodyProps>(
-  ({ children, ...props }, forwardedRef) => {
-    return (
-      <Stack direction="column" px="6" py="4" {...props} ref={forwardedRef}>
-        {children}
-      </Stack>
-    );
-  },
-);
-
-type HeaderProps = React.ComponentPropsWithoutRef<typeof Stack>;
-type HeaderRef = React.ElementRef<typeof Stack>;
-
-const Header: React.FC<HeaderProps> = React.forwardRef<HeaderRef, HeaderProps>(
-  ({ children, ...props }, forwardedRef) => {
-    return (
-      <Stack
-        direction="row"
-        justify="space-between"
-        align="center"
-        px="6"
-        py="4"
-        borderBottom
+type CloseProps<T extends TgphElement> = TgphComponentProps<typeof Button<T>> &
+  Omit<React.ComponentPropsWithoutRef<typeof Dialog.Close>, "color">;
+const Close = <T extends TgphElement>({
+  size = "1",
+  variant = "ghost",
+  ...props
+}: CloseProps<T>) => {
+  return (
+    <Dialog.Close asChild>
+      <Button
+        icon={{ icon: Lucide.X, alt: "Close Modal" }}
+        variant={variant}
+        size={size}
         {...props}
-        ref={forwardedRef}
-      >
-        {children}
-      </Stack>
-    );
-  },
-);
+      />
+    </Dialog.Close>
+  );
+};
 
-type FooterProps = React.ComponentPropsWithoutRef<typeof Stack>;
-type FooterRef = React.ElementRef<typeof Stack>;
+type BodyProps<T extends TgphElement> = PolymorphicProps<T> &
+  TgphComponentProps<typeof Stack<T>>;
 
-const Footer: React.FC<FooterProps> = React.forwardRef<FooterRef, FooterProps>(
-  ({ children, ...props }, forwardedRef) => {
-    return (
-      <Stack
-        direction="row"
-        align="center"
-        justify="end"
-        gap="2"
-        px="6"
-        py="4"
-        borderTop
-        {...props}
-        ref={forwardedRef}
-      >
-        {children}
-      </Stack>
-    );
-  },
-);
+const Body = <T extends TgphElement>({ children, ...props }: BodyProps<T>) => {
+  return (
+    <Stack direction="column" px="6" py="4" {...props}>
+      {children}
+    </Stack>
+  );
+};
+
+type HeaderProps<T extends TgphElement> = PolymorphicProps<T> &
+  TgphComponentProps<typeof Stack<T>>;
+
+const Header = <T extends TgphElement>({
+  children,
+  ...props
+}: HeaderProps<T>) => {
+  return (
+    <Stack
+      direction="row"
+      justify="space-between"
+      align="center"
+      px="6"
+      py="4"
+      borderBottom
+      {...props}
+    >
+      {children}
+    </Stack>
+  );
+};
+
+type FooterProps<T extends TgphElement> = PolymorphicProps<T> &
+  TgphComponentProps<typeof Stack<T>>;
+
+const Footer = <T extends TgphElement>({
+  children,
+  ...props
+}: FooterProps<T>) => {
+  return (
+    <Stack
+      direction="row"
+      align="center"
+      justify="end"
+      gap="2"
+      px="6"
+      py="4"
+      borderTop
+      {...props}
+    >
+      {children}
+    </Stack>
+  );
+};
 
 const Modal = {} as {
   Root: typeof Root;

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -4,8 +4,14 @@ import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
 import React from "react";
 
+import type {
+  TgphComponentProps,
+  TgphElement,
+} from "@telegraph/helpers";
+
 type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root>;
 type RootRef = React.ElementRef<typeof RadioGroup.Root>;
+
 
 type RadioButtonInternalContext = {
   value?: string;
@@ -55,41 +61,29 @@ const Item = React.forwardRef<ItemRef, ItemProps>(
   },
 );
 
-type ItemTitleProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Button.Text>,
-  "as"
->;
-type ItemTitleRef = React.ElementRef<typeof Button.Text>;
 
-const ItemTitle = React.forwardRef<ItemTitleRef, ItemTitleProps>(
-  ({ size = "2", ...props }, forwardedRef) => {
+type ItemTitleProps<T extends TgphElement> = TgphComponentProps<typeof Button.Text<T>>
+
+const ItemTitle =
+  <T extends TgphElement>({ size = "2", ...props }: ItemTitleProps<T>) => {
     return (
-      <Button.Text as={"span"} size={size} {...props} ref={forwardedRef} />
+      <Button.Text as={"span"} size={size} {...props}/>
     );
-  },
-);
+  }
 
-type ItemDescriptionProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Button.Text>,
-  "as"
->;
-type ItemDescriptionRef = React.ElementRef<typeof Button.Text>;
 
-const ItemDescription = React.forwardRef<
-  ItemDescriptionRef,
-  ItemDescriptionProps
->(({ size = "0", ...props }, forwardedRef) => {
-  return <Button.Text as={"span"} size={size} {...props} ref={forwardedRef} />;
-});
+type ItemDescriptionProps<T extends TgphElement> = TgphComponentProps<typeof Button.Text<T>>
+const ItemDescription = <T extends TgphElement>({ size = "0", ...props }: ItemDescriptionProps<T> ) => {
+  return <Button.Text as={"span"} size={size} {...props} />;
+};
 
-type ItemIconProps = React.ComponentPropsWithoutRef<typeof Button.Icon>;
-type ItemIconRef = React.ElementRef<typeof Button.Icon>;
 
-const ItemIcon = React.forwardRef<ItemIconRef, ItemIconProps>(
-  (props, forwardedRef) => {
-    return <Button.Icon {...props} ref={forwardedRef} />;
-  },
-);
+type ItemIconProps<T extends TgphElement> = TgphComponentProps<typeof Button.Icon<T>>
+
+const ItemIcon =
+  <T extends TgphElement>(props: ItemIconProps<T> ) => {
+    return <Button.Icon {...props} />;
+  }
 
 type DefaultIconProps = React.ComponentProps<typeof Icon>;
 

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -1,17 +1,12 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { Button } from "@telegraph/button";
+import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
 import React from "react";
 
-import type {
-  TgphComponentProps,
-  TgphElement,
-} from "@telegraph/helpers";
-
 type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root>;
 type RootRef = React.ElementRef<typeof RadioGroup.Root>;
-
 
 type RadioButtonInternalContext = {
   value?: string;
@@ -61,29 +56,34 @@ const Item = React.forwardRef<ItemRef, ItemProps>(
   },
 );
 
+type ItemTitleProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button.Text<T>
+>;
 
-type ItemTitleProps<T extends TgphElement> = TgphComponentProps<typeof Button.Text<T>>
-
-const ItemTitle =
-  <T extends TgphElement>({ size = "2", ...props }: ItemTitleProps<T>) => {
-    return (
-      <Button.Text as={"span"} size={size} {...props}/>
-    );
-  }
-
-
-type ItemDescriptionProps<T extends TgphElement> = TgphComponentProps<typeof Button.Text<T>>
-const ItemDescription = <T extends TgphElement>({ size = "0", ...props }: ItemDescriptionProps<T> ) => {
+const ItemTitle = <T extends TgphElement>({
+  size = "2",
+  ...props
+}: ItemTitleProps<T>) => {
   return <Button.Text as={"span"} size={size} {...props} />;
 };
 
+type ItemDescriptionProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button.Text<T>
+>;
+const ItemDescription = <T extends TgphElement>({
+  size = "0",
+  ...props
+}: ItemDescriptionProps<T>) => {
+  return <Button.Text as={"span"} size={size} {...props} />;
+};
 
-type ItemIconProps<T extends TgphElement> = TgphComponentProps<typeof Button.Icon<T>>
+type ItemIconProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button.Icon<T>
+>;
 
-const ItemIcon =
-  <T extends TgphElement>(props: ItemIconProps<T> ) => {
-    return <Button.Icon {...props} />;
-  }
+const ItemIcon = <T extends TgphElement>(props: ItemIconProps<T>) => {
+  return <Button.Icon {...props} />;
+};
 
 type DefaultIconProps = React.ComponentProps<typeof Icon>;
 

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -1,6 +1,13 @@
 import { Button as TelegraphButton } from "@telegraph/button";
-import type { Optional, Required } from "@telegraph/helpers";
+import type {
+  PolymorphicProps,
+  PolymorphicPropsWithTgphRef,
+  Required,
+  TgphComponentProps,
+  TgphElement,
+} from "@telegraph/helpers";
 import { Lucide, Icon as TelegraphIcon } from "@telegraph/icon";
+import { Box } from "@telegraph/layout";
 import { Text as TelegraphText } from "@telegraph/typography";
 import { clsx } from "clsx";
 import React from "react";
@@ -13,9 +20,12 @@ type RootBaseProps = {
   variant?: keyof typeof COLOR.Root;
 };
 
-type RootProps = React.HTMLAttributes<RootRef> & RootBaseProps;
-
-type RootRef = HTMLSpanElement;
+type RootProps<T extends TgphElement> = PolymorphicPropsWithTgphRef<
+  T,
+  HTMLSpanElement
+> &
+  TgphComponentProps<typeof Box> &
+  RootBaseProps;
 
 const TagContext = React.createContext<Required<RootBaseProps>>({
   size: "1",
@@ -23,125 +33,132 @@ const TagContext = React.createContext<Required<RootBaseProps>>({
   variant: "soft",
 });
 
-const Root = React.forwardRef<RootRef, RootProps>(
-  (
-    { size = "1", color = "default", variant = "soft", className, ...props },
-    forwardedRef,
-  ) => {
-    return (
-      <TagContext.Provider value={{ size, color, variant }}>
-        <span
-          className={clsx(
-            "inline-flex items-center rounded-3 pl-2",
-            SIZE.Root[size],
-            COLOR.Root[variant][color],
-            className,
-          )}
-          {...props}
-          ref={forwardedRef}
-          data-tag
-        />
-      </TagContext.Provider>
-    );
-  },
-);
-
-type TextProps = Optional<React.ComponentProps<typeof TelegraphText>, "as">;
-
-type TextRef = React.ElementRef<typeof TelegraphText>;
-
-const Text = React.forwardRef<TextRef, TextProps>(
-  ({ as = "span", className, ...props }, forwardedRef) => {
-    const context = React.useContext(TagContext);
-    return (
-      <TelegraphText
+const Root = <T extends TgphElement>({
+  as = "span" as T,
+  size = "1",
+  color = "default",
+  variant = "soft",
+  className,
+  ...props
+}: RootProps<T>) => {
+  return (
+    <TagContext.Provider value={{ size, color, variant }}>
+      <Box
         as={as}
-        size={context.size}
-        color={COLOR.Text[context.variant][context.color]}
-        className={clsx("rounded-tl-0 rounded-bl-0 mr-2", className)}
+        className={clsx(
+          "inline-flex items-center rounded-3 pl-2",
+          SIZE.Root[size],
+          COLOR.Root[variant][color],
+          className,
+        )}
         {...props}
-        ref={forwardedRef}
+        data-tag
       />
-    );
-  },
-);
-
-type ButtonProps = React.ComponentProps<typeof TelegraphButton.Root>;
-type ButtonRef = React.ElementRef<typeof TelegraphButton.Root>;
-
-const Button = React.forwardRef<ButtonRef, ButtonProps>(
-  ({ className, ...props }, forwardedRef) => {
-    const context = React.useContext(TagContext);
-    return (
-      <TelegraphButton
-        size={context.size}
-        color={COLOR.Button[context.variant][context.color]}
-        variant={context.variant}
-        icon={{ icon: Lucide.X, alt: "close" }}
-        className={clsx("rounded-tl-0 rounded-bl-0", className)}
-        {...props}
-        ref={forwardedRef}
-      />
-    );
-  },
-);
-
-type IconProps = React.ComponentProps<typeof TelegraphIcon>;
-type IconRef = React.ElementRef<typeof TelegraphIcon>;
-
-const Icon = React.forwardRef<IconRef, IconProps>(
-  ({ className, ...props }, forwardedRef) => {
-    const context = React.useContext(TagContext);
-    return (
-      <TelegraphIcon
-        size={context.size}
-        color={COLOR.Icon[context.variant][context.color]}
-        className={clsx("rounded-tl-0 rounded-bl-0 mr-1", className)}
-        {...props}
-        ref={forwardedRef}
-      />
-    );
-  },
-);
-
-type DefaultProps = React.ComponentProps<typeof Root> & {
-  icon?: React.ComponentProps<typeof TelegraphIcon>;
-  onCopy?: () => void;
-  onRemove?: () => void;
+    </TagContext.Provider>
+  );
 };
-type DefaultRef = React.ElementRef<typeof Root>;
 
-const Default = React.forwardRef<DefaultRef, DefaultProps>(
-  (
-    {
-      color = "default",
-      size = "1",
-      variant = "soft",
-      icon,
-      onRemove,
-      onCopy,
-      children,
-      ...props
-    },
-    ref,
-  ) => {
-    return (
-      <Root color={color} size={size} variant={variant} {...props} ref={ref}>
-        {icon && <Icon {...icon} />}
-        <Text as="span">{children}</Text>
-        {onRemove && (
-          <Button onClick={onRemove} icon={{ icon: Lucide.X, alt: "Remove" }} />
-        )}
-        {onCopy && (
-          <Button
-            onClick={onCopy}
-            icon={{ icon: Lucide.Copy, alt: "Copy text" }}
-          />
-        )}
-      </Root>
-    );
-  },
-);
+type TextProps<T extends TgphElement> = Omit<
+  TgphComponentProps<typeof TelegraphText<T>>,
+  "as"
+> & {
+  as?: T;
+};
+
+const Text = <T extends TgphElement>({
+  as = "span" as T,
+  className,
+  ...props
+}: TextProps<T>) => {
+  const context = React.useContext(TagContext);
+  return (
+    <TelegraphText
+      as={as}
+      size={context.size}
+      color={COLOR.Text[context.variant][context.color]}
+      className={clsx("rounded-tl-0 rounded-bl-0 mr-2", className)}
+      {...props}
+    />
+  );
+};
+type ButtonProps<T extends TgphElement> = TgphComponentProps<
+  typeof TelegraphButton<T>
+>;
+
+const Button = <T extends TgphElement>({
+  className,
+  ...props
+}: ButtonProps<T>) => {
+  const context = React.useContext(TagContext);
+  return (
+    <TelegraphButton
+      size={context.size}
+      color={COLOR.Button[context.variant][context.color]}
+      variant={context.variant}
+      icon={{ icon: Lucide.X, alt: "close" }}
+      className={clsx("rounded-tl-0 rounded-bl-0", className)}
+      {...props}
+    />
+  );
+};
+type IconProps<T extends TgphElement> = TgphComponentProps<
+  typeof TelegraphIcon<T>
+>;
+
+const Icon = <T extends TgphElement>({
+  icon,
+  alt,
+  "aria-hidden": ariaHidden,
+  className,
+  ...props
+}: IconProps<T>) => {
+  const context = React.useContext(TagContext);
+  const a11yProps = !alt ? { "aria-hidden": ariaHidden } : { alt };
+  return (
+    <TelegraphIcon
+      icon={icon}
+      size={context.size}
+      color={COLOR.Icon[context.variant][context.color]}
+      className={clsx("rounded-tl-0 rounded-bl-0 mr-1", className)}
+      {...a11yProps}
+      {...props}
+    />
+  );
+};
+
+type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
+  TgphComponentProps<typeof Root> & {
+    icon?: React.ComponentProps<typeof TelegraphIcon>;
+    onCopy?: () => void;
+    onRemove?: () => void;
+  };
+
+const Default = <T extends TgphElement>({
+  color = "default",
+  size = "1",
+  variant = "soft",
+  icon,
+  onRemove,
+  onCopy,
+  children,
+  ...props
+}: DefaultProps<T>) => {
+  return (
+    <Root color={color} size={size} variant={variant} {...props}>
+      {icon && <Icon {...icon} />}
+      <Text as="span">{children}</Text>
+      {onRemove && (
+        <Button onClick={onRemove} icon={{ icon: Lucide.X, alt: "Remove" }} />
+      )}
+      {onCopy && (
+        <Button
+          onClick={onCopy}
+          icon={{ icon: Lucide.Copy, alt: "Copy text" }}
+        />
+      )}
+    </Root>
+  );
+};
 
 Object.assign(Default, {
   Root,
@@ -156,5 +173,6 @@ const Tag = Default as typeof Default & {
   Text: typeof Text;
   Icon: typeof Icon;
 };
+
 
 export { Tag };

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -174,5 +174,4 @@ const Tag = Default as typeof Default & {
   Icon: typeof Icon;
 };
 
-
 export { Tag };

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -55,6 +55,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
+    "@telegraph/helpers": "workspace:^",
     "clsx": "^2.1.0"
   }
 }

--- a/packages/typography/src/Code/Code.tsx
+++ b/packages/typography/src/Code/Code.tsx
@@ -1,9 +1,13 @@
+import {
+  OptionalAsPropConfig,
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+} from "@telegraph/helpers";
 import clsx from "clsx";
-import React from "react";
 
 import { CODE_PROPS } from "./Code.constants";
 
-type CodeProps = React.HTMLAttributes<CodeRef> & {
+type BaseCodeProps = {
   as: "span" | "div" | "pre" | "code";
   size?: keyof typeof CODE_PROPS.size;
   weight?: keyof typeof CODE_PROPS.weight;
@@ -11,39 +15,41 @@ type CodeProps = React.HTMLAttributes<CodeRef> & {
   color?: keyof typeof CODE_PROPS.variant.soft;
 };
 
-type CodeRef = HTMLParagraphElement &
-  HTMLSpanElement &
-  HTMLDivElement &
-  HTMLPreElement;
+type CodeProps<T extends TgphElement> = Omit<
+  PolymorphicPropsWithTgphRef<T, HTMLElement>,
+  keyof BaseCodeProps
+> &
+  BaseCodeProps &
+  OptionalAsPropConfig<T>;
 
-const Code = React.forwardRef<CodeRef, CodeProps>(
-  (
-    {
-      as: Component,
-      size = "2",
-      weight = "regular",
-      variant = "soft",
-      color = "default",
-      className,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    if (!Component) throw new Error("as prop is required");
-    return (
-      <Component
-        className={clsx(
-          "m-0 box-border font-mono px-1 rounded-1",
-          color && CODE_PROPS.variant[variant][color],
-          size && CODE_PROPS.size[size],
-          weight && CODE_PROPS.weight[weight],
-          className,
-        )}
-        ref={forwardedRef}
-        {...props}
-      />
-    );
-  },
-);
+const Code = <T extends TgphElement>({
+  as,
+  size = "2",
+  weight = "regular",
+  variant = "soft",
+  color = "default",
+  className,
+  tgphRef,
+  // Remove this from props to avoid passing to DOM element
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  internal_optionalAs: _internal_optionalAs,
+  ...props
+}: CodeProps<T>) => {
+  if (!as) throw new Error("as prop is required");
+  const Component: TgphElement = as;
+  return (
+    <Component
+      className={clsx(
+        "m-0 box-border font-mono px-1 rounded-1",
+        color && CODE_PROPS.variant[variant][color],
+        size && CODE_PROPS.size[size],
+        weight && CODE_PROPS.weight[weight],
+        className,
+      )}
+      ref={tgphRef}
+      {...props}
+    />
+  );
+};
 
 export { Code };

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -1,45 +1,52 @@
+import {
+  OptionalAsPropConfig,
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+} from "@telegraph/helpers";
 import clsx from "clsx";
-import React from "react";
 
 import { alignMap, colorMap, sizeMap } from "../helpers/prop-mappings";
 
-type HeadingProps = React.HTMLAttributes<HeadingRef> & {
+type BaseHeadingProps = {
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   align?: keyof typeof alignMap;
   size?: keyof typeof sizeMap;
   color?: keyof typeof colorMap;
 };
+type HeadingProps<T extends TgphElement> = Omit<
+  PolymorphicPropsWithTgphRef<T, HTMLElement>,
+  keyof BaseHeadingProps
+> &
+  BaseHeadingProps &
+  OptionalAsPropConfig<T>;
 
-type HeadingRef = HTMLHeadingElement;
-
-const Heading = React.forwardRef<HeadingRef, HeadingProps>(
-  (
-    {
-      as: Component,
-      color = "default",
-      size = "2",
-      align,
-      className,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    if (!Component) throw new Error("as prop is required");
-
-    return (
-      <Component
-        className={clsx(
-          "m-0 box-border font-semi-bold",
-          align && alignMap[align],
-          color && colorMap[color],
-          size && sizeMap[size],
-          className,
-        )}
-        ref={forwardedRef}
-        {...props}
-      />
-    );
-  },
-);
+const Heading = <T extends TgphElement>({
+  as,
+  color = "default",
+  size = "2",
+  align,
+  className,
+  tgphRef,
+  // Remove this from props to avoid passing to DOM element
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  internal_optionalAs: _internal_optionalAs,
+  ...props
+}: HeadingProps<T>) => {
+  if (!as) throw new Error("as prop is required");
+  const Component: TgphElement = as;
+  return (
+    <Component
+      className={clsx(
+        "m-0 box-border font-semi-bold",
+        align && alignMap[align],
+        color && colorMap[color],
+        size && sizeMap[size],
+        className,
+      )}
+      ref={tgphRef}
+      {...props}
+    />
+  );
+};
 
 export { Heading };

--- a/packages/typography/src/Text/Text.tsx
+++ b/packages/typography/src/Text/Text.tsx
@@ -39,7 +39,7 @@ const Text = <T extends TgphElement>({
   ...props
 }: TextProps<T>) => {
   if (!as) throw new Error("as prop is required");
-  const Component: TgphElement = as
+  const Component: TgphElement = as;
   return (
     <Component
       className={clsx(

--- a/packages/typography/src/Text/Text.tsx
+++ b/packages/typography/src/Text/Text.tsx
@@ -1,5 +1,9 @@
+import {
+  OptionalAsPropConfig,
+  PolymorphicPropsWithTgphRef,
+  TgphElement,
+} from "@telegraph/helpers";
 import clsx from "clsx";
-import React from "react";
 
 import {
   alignMap,
@@ -8,59 +12,48 @@ import {
   weightMap,
 } from "../helpers/prop-mappings";
 
-type TextProps = React.HTMLAttributes<TextRef> & {
-  as:
-    | "p"
-    | "span"
-    | "div"
-    | "label"
-    | "em"
-    | "strong"
-    | "b"
-    | "i"
-    | "pre"
-    | "code";
+type BaseTextProps = {
   align?: keyof typeof alignMap;
   size?: keyof typeof sizeMap;
   color?: keyof typeof colorMap;
   weight?: keyof typeof weightMap;
 };
 
-type TextRef = HTMLParagraphElement &
-  HTMLSpanElement &
-  HTMLDivElement &
-  HTMLLabelElement &
-  HTMLPreElement;
+type TextProps<T extends TgphElement> = Omit<
+  PolymorphicPropsWithTgphRef<T, HTMLElement>,
+  keyof BaseTextProps
+> &
+  BaseTextProps &
+  OptionalAsPropConfig<T>;
 
-const Text = React.forwardRef<TextRef, TextProps>(
-  (
-    {
-      as: Component,
-      color = "default",
-      size = "2",
-      weight = "regular",
-      align,
-      className,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    if (!Component) throw new Error("as prop is required");
-    return (
-      <Component
-        className={clsx(
-          "m-0 box-border",
-          align && alignMap[align],
-          color && colorMap[color],
-          size && sizeMap[size],
-          weight && weightMap[weight],
-          className,
-        )}
-        ref={forwardedRef}
-        {...props}
-      />
-    );
-  },
-);
+const Text = <T extends TgphElement>({
+  as,
+  color = "default",
+  size = "2",
+  weight = "regular",
+  align,
+  className,
+  tgphRef,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  internal_optionalAs: _internal_optionalAs,
+  ...props
+}: TextProps<T>) => {
+  if (!as) throw new Error("as prop is required");
+  const Component: TgphElement = as
+  return (
+    <Component
+      className={clsx(
+        "m-0 box-border",
+        align && alignMap[align],
+        color && colorMap[color],
+        size && sizeMap[size],
+        weight && weightMap[weight],
+        className,
+      )}
+      ref={tgphRef}
+      {...props}
+    />
+  );
+};
 
 export { Text };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5398,6 +5398,7 @@ __metadata:
     "@radix-ui/react-slot": "npm:^1.0.2"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
+    "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"
@@ -5618,6 +5619,7 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"


### PR DESCRIPTION
### Description
- Adds type utilities `PolymorphicProps`, `PolymorphicPropsWithTgphRef`, `TgphComponentProps`, and `TgphElement` to manage `as` and custom `ref` across telegraph
- Removes `forwardRef` when interacting with Telegraph components and replaces with `as` / `tgphRef` combo..

Allows for the ability to use `as` prop across any Telegraph component and get type safe props, for example: `<Text as={motion.span}/>` would get `motion` props like `animate`, `transition`, etc. 

### Tasks
[KNO-6183](https://linear.app/knock/issue/KNO-6183/[telegraph]-refactor-forwardref-to-use-custom-ref-prop)