### PR TITLE
feat: add tooltip to tag copy button

### DIFF
--- a/.changeset/five-rings-float.md
+++ b/.changeset/five-rings-float.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/tooltip": patch
+---
+
+adds tooltip to copy button + fixes small fixes

--- a/packages/tag/package.json
+++ b/packages/tag/package.json
@@ -38,6 +38,7 @@
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
+    "@telegraph/tooltip": "workspace:^",
     "@telegraph/typography": "workspace:^",
     "clsx": "^2.1.0",
     "framer-motion": "^11.1.9"

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -1,5 +1,4 @@
 import { Button as TelegraphButton } from "@telegraph/button";
-import { useComposedRefs } from "@telegraph/compose-refs";
 import type {
   PolymorphicProps,
   PolymorphicPropsWithTgphRef,
@@ -9,6 +8,7 @@ import type {
 } from "@telegraph/helpers";
 import { Lucide, Icon as TelegraphIcon } from "@telegraph/icon";
 import { Stack } from "@telegraph/layout";
+import { Tooltip } from "@telegraph/tooltip";
 import { Text as TelegraphText } from "@telegraph/typography";
 import { clsx } from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
@@ -93,15 +93,11 @@ const CopyButton = ({
   onClick,
   textToCopy,
   className,
-  tgphRef,
   ...props
 }: CopyButtonProps) => {
   const context = React.useContext(TagContext);
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const composedRef = useComposedRefs(tgphRef, buttonRef);
 
   const [copied, setCopied] = React.useState(false);
-  const [buttonHeight, setButtonHeight] = React.useState(0);
 
   React.useEffect(() => {
     if (copied) {
@@ -110,60 +106,53 @@ const CopyButton = ({
     }
   }, [copied]);
 
-  // Use button height to calculate the offset of the icon animation
-  React.useEffect(() => {
-    if (buttonRef?.current) {
-      const buttonHeight = buttonRef.current.getBoundingClientRect().height;
-      setButtonHeight(buttonHeight - buttonHeight / 4);
-    }
-  }, [buttonRef]);
-
-  // TODO: Add tooltip upon completion of KNO-5405
   return (
     <AnimatePresence mode="wait" initial={false}>
-      <TelegraphButton.Root
-        onClick={(event: MouseEvent) => {
-          // Still run onClick incase the consumer wants to do something else
-          onClick?.(event);
-          setCopied(true);
-          textToCopy && navigator.clipboard.writeText(textToCopy);
-          buttonRef.current?.blur();
-        }}
-        size={context.size}
-        color={COLOR.Button[context.variant][context.color]}
-        variant={context.variant}
-        className={clsx("overflow-hidden", className)}
-        roundedTopRight="3"
-        roundedBottomRight="3"
-        roundedTopLeft="0"
-        roundedBottomLeft="0"
-        tgphRef={composedRef}
-        {...props}
-      >
-        {copied ? (
-          <TelegraphButton.Icon
-            as={motion.span}
-            initial={{ y: buttonHeight }}
-            animate={{ y: 0 }}
-            exit={{ y: buttonHeight }}
-            transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-            icon={Lucide.Check}
-            alt="Copied text"
-            key={"check icon"}
-          />
-        ) : (
-          <TelegraphButton.Icon
-            as={motion.span}
-            initial={{ y: -buttonHeight }}
-            animate={{ y: 0 }}
-            exit={{ y: -buttonHeight }}
-            transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-            icon={Lucide.Copy}
-            alt="Copy text"
-            key={"copy icon"}
-          />
-        )}
-      </TelegraphButton.Root>
+      <Tooltip label="Copy text">
+        <TelegraphButton.Root
+          onClick={(event: MouseEvent) => {
+            // Still run onClick incase the consumer wants to do something else
+            onClick?.(event);
+            setCopied(true);
+            textToCopy && navigator.clipboard.writeText(textToCopy);
+            buttonRef.current?.blur();
+          }}
+          size={context.size}
+          color={COLOR.Button[context.variant][context.color]}
+          variant={context.variant}
+          className={clsx("overflow-hidden", className)}
+          roundedTopRight="3"
+          roundedBottomRight="3"
+          roundedTopLeft="0"
+          roundedBottomLeft="0"
+          mr="8"
+          {...props}
+        >
+          {copied ? (
+            <TelegraphButton.Icon
+              as={motion.span}
+              initial={{ y: "100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "100%" }}
+              transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+              icon={Lucide.Check}
+              alt="Copied text"
+              key={"check icon"}
+            />
+          ) : (
+            <TelegraphButton.Icon
+              as={motion.span}
+              initial={{ y: "-100%" }}
+              animate={{ y: 0 }}
+              exit={{ y: "-100%" }}
+              transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+              icon={Lucide.Copy}
+              alt="Copy text"
+              key={"copy icon"}
+            />
+          )}
+        </TelegraphButton.Root>
+      </Tooltip>
     </AnimatePresence>
   );
 };

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -115,7 +115,7 @@ const CopyButton = ({
             onClick?.(event);
             setCopied(true);
             textToCopy && navigator.clipboard.writeText(textToCopy);
-            buttonRef.current?.blur();
+            event.target?.blur();
           }}
           size={context.size}
           color={COLOR.Button[context.variant][context.color]}
@@ -125,7 +125,6 @@ const CopyButton = ({
           roundedBottomRight="3"
           roundedTopLeft="0"
           roundedBottomLeft="0"
-          mr="8"
           {...props}
         >
           {copied ? (

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -92,62 +92,62 @@ const Tooltip = <T extends TgphElement>({
           <RefToTgphRef>{children}</RefToTgphRef>
         </RadixTooltip.Trigger>
         <RadixTooltip.Portal>
-              <RadixTooltip.Content
-                aria-label={ariaLabel}
-                onEscapeKeyDown={onEscapeKeyDown}
-                onPointerDownOutside={onPointerDownOutside}
-                forceMount={forceMount}
-                side={side}
-                sideOffset={sideOffset}
-                align={align}
-                alignOffset={alignOffset}
-                avoidCollisions={avoidCollisions}
-                collisionBoundary={collisionBoundary}
-                collisionPadding={collisionPadding}
-                arrowPadding={arrowPadding}
-                sticky={sticky}
-                hideWhenDetached={hideWhenDetached}
+          <RadixTooltip.Content
+            aria-label={ariaLabel}
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+            forceMount={forceMount}
+            side={side}
+            sideOffset={sideOffset}
+            align={align}
+            alignOffset={alignOffset}
+            avoidCollisions={avoidCollisions}
+            collisionBoundary={collisionBoundary}
+            collisionPadding={collisionPadding}
+            arrowPadding={arrowPadding}
+            sticky={sticky}
+            hideWhenDetached={hideWhenDetached}
+          >
+            <InvertedAppearance>
+              <Stack
+                as={motion.div}
+                // Add tgph class so that this always works in portals
+                className="tgph"
+                initial={{
+                  opacity: 0.5,
+                  scale: 0.6,
+                  ...deriveAnimationBasedOnSide(side),
+                }}
+                animate={{
+                  opacity: 1,
+                  scale: 1,
+                  x: 0,
+                  y: 0,
+                }}
+                transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+                bg="gray-1"
+                rounded="3"
+                py="2"
+                px="3"
+                align="center"
+                justify="center"
+                style={{
+                  transformOrigin:
+                    "var(--radix-tooltip-content-transform-origin)",
+                }}
+                {...(labelProps ? { labelProps } : {})}
               >
-              <InvertedAppearance>
-                <Stack
-                  as={motion.div}
-                  // Add tgph class so that this always works in portals
-                  className="tgph"
-                  initial={{
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
-                  }}
-                  animate={{
-                    opacity: 1,
-                    scale: 1,
-                    x: 0,
-                    y: 0,
-                  }}
-                  transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-                  bg="gray-1"
-                  rounded="3"
-                  py="2"
-                  px="3"
-                  align="center"
-                  justify="center"
-                  style={{
-                    transformOrigin:
-                      "var(--radix-tooltip-content-transform-origin)",
-                  }}
-                  {...(labelProps ? { labelProps } : {})}
-                >
-                  <RadixTooltip.Arrow fill="var(--tgph-gray-1)" />
-                  {typeof label === "string" ? (
-                    <Text as="span" size="1">
-                      {label}
-                    </Text>
-                  ) : (
-                    label
-                  )}
-                </Stack>
-                    </InvertedAppearance>
-              </RadixTooltip.Content>
+                <RadixTooltip.Arrow fill="var(--tgph-gray-1)" />
+                {typeof label === "string" ? (
+                  <Text as="span" size="1">
+                    {label}
+                  </Text>
+                ) : (
+                  label
+                )}
+              </Stack>
+            </InvertedAppearance>
+          </RadixTooltip.Content>
         </RadixTooltip.Portal>
       </RadixTooltip.Root>
     </RadixTooltip.Provider>

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -92,62 +92,62 @@ const Tooltip = <T extends TgphElement>({
           <RefToTgphRef>{children}</RefToTgphRef>
         </RadixTooltip.Trigger>
         <RadixTooltip.Portal>
-          <InvertedAppearance asChild>
-            <RadixTooltip.Content
-              aria-label={ariaLabel}
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={onPointerDownOutside}
-              forceMount={forceMount}
-              side={side}
-              sideOffset={sideOffset}
-              align={align}
-              alignOffset={alignOffset}
-              avoidCollisions={avoidCollisions}
-              collisionBoundary={collisionBoundary}
-              collisionPadding={collisionPadding}
-              arrowPadding={arrowPadding}
-              sticky={sticky}
-              hideWhenDetached={hideWhenDetached}
-            >
-              <Stack
-                as={motion.div}
-                // Add tgph class so that this always works in portals
-                className="tgph"
-                initial={{
-                  opacity: 0.5,
-                  scale: 0.6,
-                  ...deriveAnimationBasedOnSide(side),
-                }}
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                  x: 0,
-                  y: 0,
-                }}
-                transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-                bg="gray-1"
-                rounded="3"
-                py="2"
-                px="3"
-                align="center"
-                justify="center"
-                style={{
-                  transformOrigin:
-                    "var(--radix-tooltip-content-transform-origin)",
-                }}
-                {...(labelProps ? { labelProps } : {})}
+              <RadixTooltip.Content
+                aria-label={ariaLabel}
+                onEscapeKeyDown={onEscapeKeyDown}
+                onPointerDownOutside={onPointerDownOutside}
+                forceMount={forceMount}
+                side={side}
+                sideOffset={sideOffset}
+                align={align}
+                alignOffset={alignOffset}
+                avoidCollisions={avoidCollisions}
+                collisionBoundary={collisionBoundary}
+                collisionPadding={collisionPadding}
+                arrowPadding={arrowPadding}
+                sticky={sticky}
+                hideWhenDetached={hideWhenDetached}
               >
-                <RadixTooltip.Arrow fill="var(--tgph-gray-1)" />
-                {typeof label === "string" ? (
-                  <Text as="span" size="1">
-                    {label}
-                  </Text>
-                ) : (
-                  label
-                )}
-              </Stack>
-            </RadixTooltip.Content>
-          </InvertedAppearance>
+              <InvertedAppearance>
+                <Stack
+                  as={motion.div}
+                  // Add tgph class so that this always works in portals
+                  className="tgph"
+                  initial={{
+                    opacity: 0.5,
+                    scale: 0.6,
+                    ...deriveAnimationBasedOnSide(side),
+                  }}
+                  animate={{
+                    opacity: 1,
+                    scale: 1,
+                    x: 0,
+                    y: 0,
+                  }}
+                  transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+                  bg="gray-1"
+                  rounded="3"
+                  py="2"
+                  px="3"
+                  align="center"
+                  justify="center"
+                  style={{
+                    transformOrigin:
+                      "var(--radix-tooltip-content-transform-origin)",
+                  }}
+                  {...(labelProps ? { labelProps } : {})}
+                >
+                  <RadixTooltip.Arrow fill="var(--tgph-gray-1)" />
+                  {typeof label === "string" ? (
+                    <Text as="span" size="1">
+                      {label}
+                    </Text>
+                  ) : (
+                    label
+                  )}
+                </Stack>
+                    </InvertedAppearance>
+              </RadixTooltip.Content>
         </RadixTooltip.Portal>
       </RadixTooltip.Root>
     </RadixTooltip.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5672,6 +5672,7 @@ __metadata:
     "@telegraph/icon": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/tailwind-config": "workspace:^"
+    "@telegraph/tooltip": "workspace:^"
     "@telegraph/typography": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@telegraph/vitest-config": "workspace:^"
@@ -5724,7 +5725,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@telegraph/tooltip@workspace:packages/tooltip":
+"@telegraph/tooltip@workspace:^, @telegraph/tooltip@workspace:packages/tooltip":
   version: 0.0.0-use.local
   resolution: "@telegraph/tooltip@workspace:packages/tooltip"
   dependencies:


### PR DESCRIPTION
### Description
- Adds Tooltip for Tag onCopy button
- Refactors some positioning to not use refs

### Tasks 
[KNO-6200](https://linear.app/knock/issue/KNO-6200/[telegraph]-add-tooltip-to-tag-buttons)