### PR TITLE
fix: modal not allowing for internal scrolling

### DIFF
--- a/.changeset/empty-snakes-vanish.md
+++ b/.changeset/empty-snakes-vanish.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/modal": patch
+---
+
+fix modal not being able to scroll

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -46,7 +46,7 @@ const Root = ({
       <AnimatePresence>
         {open && (
           <>
-            <Dialog.Overlay asChild>
+            <Dialog.Overlay>
               <Box
                 as={motion.div}
                 onClick={() => onOpenChange?.(false)}
@@ -56,7 +56,6 @@ const Root = ({
                 transition={{ duration: 0.3, bounce: 0, type: "spring" }}
                 className="fixed inset-0 bg-alpha-black-4 z-overlay"
               />
-            </Dialog.Overlay>
             <Stack
               className={clsx(
                 "fixed z-modal top-0 left-1/2 -translate-x-1/2",
@@ -79,6 +78,7 @@ const Root = ({
             >
               {children}
             </Stack>
+            </Dialog.Overlay>
           </>
         )}
       </AnimatePresence>

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -56,28 +56,28 @@ const Root = ({
                 transition={{ duration: 0.3, bounce: 0, type: "spring" }}
                 className="fixed inset-0 bg-alpha-black-4 z-overlay"
               />
-            <Stack
-              className={clsx(
-                "fixed z-modal top-0 left-1/2 -translate-x-1/2",
-                "max-h-[calc(100vh-var(--tgph-spacing-32))] shadow-1",
-                className,
-              )}
-              direction="column"
-              as={motion.div}
-              my="16"
-              initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-              animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
-              exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-              transition={{ duration: 0.2, bounce: 0, type: "spring" }}
-              maxW={props.maxW ?? "140"}
-              w={props.w ?? "full"}
-              bg="surface-1"
-              border
-              rounded="4"
-              {...props}
-            >
-              {children}
-            </Stack>
+              <Stack
+                className={clsx(
+                  "fixed z-modal top-0 left-1/2 -translate-x-1/2",
+                  "max-h-[calc(100vh-var(--tgph-spacing-32))] shadow-1",
+                  className,
+                )}
+                direction="column"
+                as={motion.div}
+                my="16"
+                initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+                animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
+                exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+                transition={{ duration: 0.2, bounce: 0, type: "spring" }}
+                maxW={props.maxW ?? "140"}
+                w={props.w ?? "full"}
+                bg="surface-1"
+                border
+                rounded="4"
+                {...props}
+              >
+                {children}
+              </Stack>
             </Dialog.Overlay>
           </>
         )}


### PR DESCRIPTION
### Description
The Radix docs seemed to incorrectly layout the example dialog in a way that doesn't allow for scrolling inside of it. Wrapping the Overlay around the content seems to fix that issue, see; https://github.com/radix-ui/primitives/pull/2250#issuecomment-1777464051

### Tasks 
[KNO-6257](https://linear.app/knock/issue/KNO-6257/[dashboard]-unable-to-scroll-in-editor-pop-out)