### PR TITLE
fix: pass generic to tag root to avoid complex type error + other build type errors

### DIFF
--- a/.changeset/clever-shoes-mix.md
+++ b/.changeset/clever-shoes-mix.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/layout": patch
+"@telegraph/menu": patch
+---
+
+type issues from build

--- a/.changeset/sharp-suits-rest.md
+++ b/.changeset/sharp-suits-rest.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/tag": patch
+---
+
+fix complex type error when using tag component

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -31,7 +31,7 @@ const Stack = <T extends TgphElement>({
   tgphRef,
   ...props
 }: StackProps<T>) => {
-  const stackRef = React.useRef<HTMLDivElement>(null);
+  const stackRef = React.useRef<StackProps<T>["tgphRef"]>(null);
   const composedRef = useComposedRefs(tgphRef, stackRef);
 
   // Filter out the stack props from the rest of the props

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -1,6 +1,10 @@
 import * as RadixMenu from "@radix-ui/react-menu";
 import { Button as TelegraphButton } from "@telegraph/button";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import {
+  RefToTgphRef,
+  type TgphComponentProps,
+  type TgphElement,
+} from "@telegraph/helpers";
 import { Lucide } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
 import React from "react";
@@ -61,12 +65,14 @@ const Content = ({
   );
 };
 
-type ButtonProps = TgphComponentProps<typeof TelegraphButton> &
+type ButtonProps<T extends TgphElement> = TgphComponentProps<
+  typeof TelegraphButton<T>
+> &
   React.ComponentProps<typeof RadixMenu.Item> & {
     selected?: boolean;
   };
 
-const Button = ({
+const Button = <T extends TgphElement>({
   size = "2",
   variant = "ghost",
   mx = "1",
@@ -76,9 +82,11 @@ const Button = ({
   trailingIcon,
   selected,
   ...props
-}: ButtonProps) => {
+}: ButtonProps<T>) => {
   const combinedLeadingIcon = selected
-    ? { icon: Lucide.Check, "aria-hidden": true }
+    ? ({ icon: Lucide.Check, "aria-hidden": true } as TgphComponentProps<
+        typeof TelegraphButton.Icon
+      >)
     : leadingIcon || icon;
 
   return (
@@ -113,7 +121,7 @@ type DividerProps = TgphComponentProps<typeof Box>;
 
 const Divider = ({
   w = "full",
-  borderBottom = "true",
+  borderBottom = "px",
   ...props
 }: DividerProps) => {
   return <Box as="hr" w={w} borderBottom={borderBottom} {...props} />;

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -203,13 +203,13 @@ type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
     onRemove?: () => void;
   } & ( // Optionally allow textToCopy only when onCopy is defined
     | {
-      onCopy: () => void;
-      textToCopy?: string;
-    }
+        onCopy: () => void;
+        textToCopy?: string;
+      }
     | {
-      onCopy?: never;
-      textToCopy?: never;
-    }
+        onCopy?: never;
+        textToCopy?: never;
+      }
   );
 
 const Default = <T extends TgphElement>({

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -198,18 +198,18 @@ const Icon = <T extends TgphElement>({
 };
 
 type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
-  TgphComponentProps<typeof Root> & {
+  TgphComponentProps<typeof Root<T>> & {
     icon?: React.ComponentProps<typeof TelegraphIcon>;
     onRemove?: () => void;
   } & ( // Optionally allow textToCopy only when onCopy is defined
     | {
-        onCopy: () => void;
-        textToCopy?: string;
-      }
+      onCopy: () => void;
+      textToCopy?: string;
+    }
     | {
-        onCopy?: never;
-        textToCopy?: never;
-      }
+      onCopy?: never;
+      textToCopy?: never;
+    }
   );
 
 const Default = <T extends TgphElement>({

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -110,12 +110,12 @@ const CopyButton = ({
     <AnimatePresence mode="wait" initial={false}>
       <Tooltip label="Copy text">
         <TelegraphButton.Root
-          onClick={(event: MouseEvent) => {
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
             // Still run onClick incase the consumer wants to do something else
             onClick?.(event);
             setCopied(true);
             textToCopy && navigator.clipboard.writeText(textToCopy);
-            event.target?.blur();
+            event.currentTarget?.blur();
           }}
           size={context.size}
           color={COLOR.Button[context.variant][context.color]}


### PR DESCRIPTION
### Description
- Was incorrectly not passing a generic to the `<Root/>` component of `<Tag/>` which lead to the `as` prop being undefined and the type too complex to represent. This now passes that generic.
- Fixes other type issues that were happening during build

### Tasks
[KNO-6263](https://linear.app/knock/issue/KNO-6263/[telegraph]-tag-type-too-complex-to-represent)