### PR TITLE
fix: modal sizing when full width

### DIFF
--- a/.changeset/mean-kangaroos-beg.md
+++ b/.changeset/mean-kangaroos-beg.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/modal": patch
+---
+
+Allow for full width modal without bleeding to the edges

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -59,24 +59,28 @@ const Root = ({
               <Stack
                 className={clsx(
                   "fixed z-modal top-0 left-1/2 -translate-x-1/2",
-                  "max-h-[calc(100vh-var(--tgph-spacing-32))] shadow-1",
-                  className,
+                  "w-full",
+                  "max-h-[calc(100vh-var(--tgph-spacing-32))] max-w-[calc(100vw-var(--tgph-spacing-8))]",
                 )}
-                direction="column"
-                as={motion.div}
-                my="16"
-                initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-                animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
-                exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
-                transition={{ duration: 0.2, bounce: 0, type: "spring" }}
-                maxW={props.maxW ?? "140"}
-                w={props.w ?? "full"}
-                bg="surface-1"
-                border
-                rounded="4"
-                {...props}
               >
-                {children}
+                <Stack
+                  className={clsx("shadow-1", className)}
+                  direction="column"
+                  as={motion.div}
+                  my="16"
+                  initial={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+                  animate={{ scale: 1, opacity: 1, y: 0, x: "-50%" }}
+                  exit={{ scale: 0.8, opacity: 0, y: -20, x: "-50%" }}
+                  transition={{ duration: 0.2, bounce: 0, type: "spring" }}
+                  maxW={props.maxW ?? "140"}
+                  w={props.w ?? "full"}
+                  bg="surface-1"
+                  border
+                  rounded="4"
+                  {...props}
+                >
+                  {children}
+                </Stack>
               </Stack>
             </Dialog.Overlay>
           </>


### PR DESCRIPTION
### Description
- Adds container to modal content that gives guardrails on width / height when using `maxW="full"` `w="full"` props on `Modal.Root`

### Tasks
[KNO-6268](https://linear.app/knock/issue/KNO-6268/[telegraph]-modal-max-width-stretching-to-screen)