### PR TITLE
chore: remove tooltip arrow

### DIFF
--- a/.changeset/old-ways-know.md
+++ b/.changeset/old-ways-know.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/tooltip": patch
+---
+
+remove arrow from the tooltip

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -140,7 +140,6 @@ const Tooltip = <T extends TgphElement>({
                 }}
                 {...(labelProps ? { labelProps } : {})}
               >
-                <RadixTooltip.Arrow fill="var(--tgph-gray-1)" />
                 {typeof label === "string" ? (
                   <Text as="span" size="1">
                     {label}


### PR DESCRIPTION
### Description
Removes the arrow from the tooltip 😀

[Discussion](https://knocklabs.slack.com/archives/C01Q4R82QAU/p1719410520105899)

### Tasks 
[KNO-6288](https://linear.app/knock/issue/KNO-6288/[telegraph]-remove-arrow-from-tooltip)