### PR TITLE
fix: menu trigger, tooltip enabled

### DIFF
--- a/.changeset/sharp-brooms-swim.md
+++ b/.changeset/sharp-brooms-swim.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/tooltip": patch
+"@telegraph/menu": patch
+---
+
+update menu anchor to menu trigger, enabled prop on tooltip, combobox updated to support new menu

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -296,7 +296,7 @@ const TriggerValue = <T extends TgphElement>({
   );
 };
 
-type TriggerProps = React.ComponentProps<typeof TelegraphMenu.Anchor> & {
+type TriggerProps = React.ComponentProps<typeof TelegraphMenu.Trigger> & {
   placeholder?: string;
   size?: TgphComponentProps<typeof TelegraphButton.Root>["size"];
 };
@@ -318,7 +318,7 @@ const Trigger = ({ size = "1", ...props }: TriggerProps) => {
   }, [context.value, context.placeholder]);
 
   return (
-    <TelegraphMenu.Anchor
+    <TelegraphMenu.Trigger
       {...props}
       asChild
       onClick={(event: React.MouseEvent) => {
@@ -344,36 +344,34 @@ const Trigger = ({ size = "1", ...props }: TriggerProps) => {
       }}
       tgphRef={context.triggerRef}
     >
-      <RefToTgphRef>
-        <TelegraphButton.Root
-          id={context.triggerId}
-          bg="surface-1"
-          variant="outline"
-          w="full"
-          h="full"
-          color={context.errored ? "red" : "gray"}
-          justify="space-between"
-          // Accessibility attributes
-          role="combobox"
-          aria-label={getAriaLabelString()}
-          aria-controls={context.contentId}
-          aria-expanded={context.open}
-          aria-haspopup="listbox"
-          // Custom attributes
-          data-tgph-combobox-trigger
-          data-tgph-comobox-trigger-open={context.open}
-        >
-          <TriggerValue size={size} />
-          <TelegraphButton.Icon
-            as={motion.div}
-            icon={Lucide.ChevronDown}
-            animate={{ rotate: context.open ? "180deg" : "0deg" }}
-            transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-            aria-hidden
-          />
-        </TelegraphButton.Root>
-      </RefToTgphRef>
-    </TelegraphMenu.Anchor>
+      <TelegraphButton.Root
+        id={context.triggerId}
+        bg="surface-1"
+        variant="outline"
+        w="full"
+        h="full"
+        color={context.errored ? "red" : "gray"}
+        justify="space-between"
+        // Accessibility attributes
+        role="combobox"
+        aria-label={getAriaLabelString()}
+        aria-controls={context.contentId}
+        aria-expanded={context.open}
+        aria-haspopup="listbox"
+        // Custom attributes
+        data-tgph-combobox-trigger
+        data-tgph-comobox-trigger-open={context.open}
+      >
+        <TriggerValue size={size} />
+        <TelegraphButton.Icon
+          as={motion.div}
+          icon={Lucide.ChevronDown}
+          animate={{ rotate: context.open ? "180deg" : "0deg" }}
+          transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+          aria-hidden
+        />
+      </TelegraphButton.Root>
+    </TelegraphMenu.Trigger>
   );
 };
 
@@ -573,9 +571,10 @@ const Option = <T extends TgphElement>({
     ? contextValue.some((v) => v.value === value)
     : contextValue.value === value;
 
-  const handleSelection = (event: React.KeyboardEvent) => {
+  const handleSelection = (event: Event | React.KeyboardEvent) => {
     // Don't do anything if the key isn't a selection key
-    if (event.key && !SELECT_KEYS.includes(event.key)) return;
+    const keyboardEvent = event as React.KeyboardEvent;
+    if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) return;
 
     // Don't bubble up the event
     event.stopPropagation();

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@radix-ui/react-menu": "^2.0.6",
+    "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -1,14 +1,32 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@telegraph/button";
 import type { TgphComponentProps } from "@telegraph/helpers";
 import { Lucide } from "@telegraph/icon";
+import { Stack } from "@telegraph/layout";
 
 import { Menu as TelegraphMenu } from "./Menu";
 
 const meta: Meta = {
   title: "Components/Menu",
   component: TelegraphMenu.Root,
-  argTypes: {},
-  args: {},
+  argTypes: {
+    align: {
+      options: ["start", "center", "end"],
+      control: {
+        type: "select",
+      },
+    },
+    side: {
+      options: ["top", "bottom", "left", "right"],
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    align: "center",
+    side: "bottom",
+  },
 };
 
 export default meta;
@@ -18,34 +36,41 @@ type Story = StoryObj<TgphComponentProps<typeof TelegraphMenu.Root>>;
 export const Default: Story = {
   render: ({ ...args }) => {
     return (
-      <TelegraphMenu.Root {...args}>
-        <TelegraphMenu.Anchor />
-        <TelegraphMenu.Content m="20">
-          <TelegraphMenu.Button
-            leadingIcon={{ icon: Lucide.Cog, "aria-hidden": true }}
-          >
-            Manage workflow
-          </TelegraphMenu.Button>
-          <TelegraphMenu.Button
-            leadingIcon={{ icon: Lucide.Pencil, "aria-hidden": true }}
-          >
-            Edit workflow steps
-          </TelegraphMenu.Button>
-          <TelegraphMenu.Divider />
-          <TelegraphMenu.Button
-            color="red"
-            leadingIcon={{ icon: Lucide.Archive, "aria-hidden": true }}
-          >
-            Archive workflow
-          </TelegraphMenu.Button>
-          <TelegraphMenu.Button
-            leadingIcon={{ icon: Lucide.CornerUpLeft, "aria-hidden": true }}
-            disabled={true}
-          >
-            Reset all uncomitted changes
-          </TelegraphMenu.Button>
-        </TelegraphMenu.Content>
-      </TelegraphMenu.Root>
+      <Stack m="20" align="center" justify="center">
+        <TelegraphMenu.Root {...args}>
+          <TelegraphMenu.Trigger>
+            <Button
+              variant="outline"
+              leadingIcon={{ icon: Lucide.Ellipsis, "aria-hidden": true }}
+            />
+          </TelegraphMenu.Trigger>
+          <TelegraphMenu.Content {...args}>
+            <TelegraphMenu.Button
+              leadingIcon={{ icon: Lucide.Cog, "aria-hidden": true }}
+            >
+              Manage workflow
+            </TelegraphMenu.Button>
+            <TelegraphMenu.Button
+              leadingIcon={{ icon: Lucide.Pencil, "aria-hidden": true }}
+            >
+              Edit workflow steps
+            </TelegraphMenu.Button>
+            <TelegraphMenu.Divider />
+            <TelegraphMenu.Button
+              color="red"
+              leadingIcon={{ icon: Lucide.Archive, "aria-hidden": true }}
+            >
+              Archive workflow
+            </TelegraphMenu.Button>
+            <TelegraphMenu.Button
+              leadingIcon={{ icon: Lucide.CornerUpLeft, "aria-hidden": true }}
+              disabled={true}
+            >
+              Reset all uncomitted changes
+            </TelegraphMenu.Button>
+          </TelegraphMenu.Content>
+        </TelegraphMenu.Root>
+      </Stack>
     );
   },
 };

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -27,11 +27,17 @@ const meta: Meta = {
         type: "select",
       },
     },
+    enabled: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   args: {
     label: "Tooltip",
     side: "bottom",
     align: "center",
+    enabled: true,
   },
 };
 

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import React from "react";
 type TooltipBaseProps<T extends TgphElement> = {
   label: string | React.ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
+  enabled?: boolean;
 };
 
 type TooltipProps<T extends TgphElement> = React.ComponentPropsWithoutRef<
@@ -49,6 +50,8 @@ const Tooltip = <T extends TgphElement>({
   // Label Props
   label,
   labelProps,
+  // Telegraph Props
+  enabled = true,
   children,
 }: TooltipProps<T>) => {
   const deriveAnimationBasedOnSide = (side: TooltipProps<T>["side"]) => {
@@ -77,83 +80,88 @@ const Tooltip = <T extends TgphElement>({
       };
     }
   };
-  return (
-    <RadixTooltip.Provider
-      delayDuration={delayDuration}
-      skipDelayDuration={skipDelayDuration}
-      disableHoverableContent={disableHoverableContent}
-    >
-      <RadixTooltip.Root
-        defaultOpen={defaultOpen}
-        open={open}
-        onOpenChange={onOpenChange}
+
+  if (enabled) {
+    return (
+      <RadixTooltip.Provider
+        delayDuration={delayDuration}
+        skipDelayDuration={skipDelayDuration}
+        disableHoverableContent={disableHoverableContent}
       >
-        <RadixTooltip.Trigger asChild={true}>
-          <RefToTgphRef>{children}</RefToTgphRef>
-        </RadixTooltip.Trigger>
-        <RadixTooltip.Portal>
-          <RadixTooltip.Content
-            aria-label={ariaLabel}
-            onEscapeKeyDown={onEscapeKeyDown}
-            onPointerDownOutside={onPointerDownOutside}
-            forceMount={forceMount}
-            side={side}
-            sideOffset={sideOffset}
-            align={align}
-            alignOffset={alignOffset}
-            avoidCollisions={avoidCollisions}
-            collisionBoundary={collisionBoundary}
-            collisionPadding={collisionPadding}
-            arrowPadding={arrowPadding}
-            sticky={sticky}
-            hideWhenDetached={hideWhenDetached}
-            style={{
-              zIndex: `var(--tgph-zIndex-tooltip)`,
-            }}
-          >
-            <InvertedAppearance>
-              <Stack
-                as={motion.div}
-                // Add tgph class so that this always works in portals
-                className="tgph"
-                initial={{
-                  opacity: 0.5,
-                  scale: 0.6,
-                  ...deriveAnimationBasedOnSide(side),
-                }}
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                  x: 0,
-                  y: 0,
-                }}
-                transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-                bg="gray-1"
-                rounded="3"
-                py="2"
-                px="3"
-                align="center"
-                justify="center"
-                style={{
-                  transformOrigin:
-                    "var(--radix-tooltip-content-transform-origin)",
-                }}
-                {...(labelProps ? { labelProps } : {})}
-              >
-                {typeof label === "string" ? (
-                  <Text as="span" size="1">
-                    {label}
-                  </Text>
-                ) : (
-                  label
-                )}
-              </Stack>
-            </InvertedAppearance>
-          </RadixTooltip.Content>
-        </RadixTooltip.Portal>
-      </RadixTooltip.Root>
-    </RadixTooltip.Provider>
-  );
+        <RadixTooltip.Root
+          defaultOpen={defaultOpen}
+          open={open}
+          onOpenChange={onOpenChange}
+        >
+          <RadixTooltip.Trigger asChild={true}>
+            <RefToTgphRef>{children}</RefToTgphRef>
+          </RadixTooltip.Trigger>
+          <RadixTooltip.Portal>
+            <RadixTooltip.Content
+              aria-label={ariaLabel}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={onPointerDownOutside}
+              forceMount={forceMount}
+              side={side}
+              sideOffset={sideOffset}
+              align={align}
+              alignOffset={alignOffset}
+              avoidCollisions={avoidCollisions}
+              collisionBoundary={collisionBoundary}
+              collisionPadding={collisionPadding}
+              arrowPadding={arrowPadding}
+              sticky={sticky}
+              hideWhenDetached={hideWhenDetached}
+              style={{
+                zIndex: `var(--tgph-zIndex-tooltip)`,
+              }}
+            >
+              <InvertedAppearance>
+                <Stack
+                  as={motion.div}
+                  // Add tgph class so that this always works in portals
+                  className="tgph"
+                  initial={{
+                    opacity: 0.5,
+                    scale: 0.6,
+                    ...deriveAnimationBasedOnSide(side),
+                  }}
+                  animate={{
+                    opacity: 1,
+                    scale: 1,
+                    x: 0,
+                    y: 0,
+                  }}
+                  transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+                  bg="gray-1"
+                  rounded="3"
+                  py="2"
+                  px="3"
+                  align="center"
+                  justify="center"
+                  style={{
+                    transformOrigin:
+                      "var(--radix-tooltip-content-transform-origin)",
+                  }}
+                  {...(labelProps ? { labelProps } : {})}
+                >
+                  {typeof label === "string" ? (
+                    <Text as="span" size="1">
+                      {label}
+                    </Text>
+                  ) : (
+                    label
+                  )}
+                </Stack>
+              </InvertedAppearance>
+            </RadixTooltip.Content>
+          </RadixTooltip.Portal>
+        </RadixTooltip.Root>
+      </RadixTooltip.Provider>
+    );
+  }
+
+  return children;
 };
 
 export { Tooltip };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5724,6 +5724,7 @@ __metadata:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@radix-ui/react-menu": "npm:^2.0.6"
+    "@radix-ui/react-use-controllable-state": "npm:^1.1.0"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"


### PR DESCRIPTION
### Description
- Change `Menu.Anchor` to `Menu.Trigger` for consistency
- Make `Menu` state controllable
- Add `enabled` prop to tooltip for hiding/showing the tooltip 
- Update `Combobox` to use `Menu.Trigger`

### Tasks
[KNO-6304](https://linear.app/knock/issue/KNO-6304/[telegraph]-menu-and-tooltip-fixes)