### PR TITLE
fix: add style-engine as dep for layout

### DIFF
--- a/.changeset/dry-shrimps-jog.md
+++ b/.changeset/dry-shrimps-jog.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+add style-engine as dep

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -45,7 +45,6 @@
     "@knocklabs/typescript-config": "^0.0.2",
     "@telegraph/postcss-config": "workspace:^",
     "@telegraph/prettier-config": "workspace:^",
-    "@telegraph/style-engine": "workspace:^",
     "@telegraph/vite-config": "workspace:^",
     "@telegraph/vitest-config": "workspace:^",
     "@types/react": "^18.2.48",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
+    "@telegraph/style-engine": "workspace:^",
     "@telegraph/tokens": "workspace:^",
     "clsx": "^2.1.0"
   },


### PR DESCRIPTION
### Description
Adds `@telegraph/style-engine` as dep to `@telegraph/layout`

### Tasks
[KNO-6358](https://linear.app/knock/issue/KNO-6358/[telegraph]-dependabot-upgrades-for-telegraph-tooltipradio-failing)