### PR TITLE
fix: align prop overlapping + border prop incorrect value

### DIFF
--- a/.changeset/clever-badgers-travel.md
+++ b/.changeset/clever-badgers-travel.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+fix aign prop + border prop

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -74,7 +74,7 @@ const Trigger = ({ asChild = true, tgphRef, children, ...props }: Anchor) => {
 type ContentProps<T extends TgphElement> = React.ComponentProps<
   typeof RadixMenu.Content
 > &
-  TgphComponentProps<typeof Stack<T>> & {
+  Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
     contentStackRef?: React.RefObject<HTMLDivElement>;
   };
 
@@ -83,7 +83,7 @@ const Content = <T extends TgphElement>({
   gap = "1",
   rounded = "4",
   py = "1",
-  border = true,
+  border = "px",
   shadow = "2",
   sideOffset = 4,
   children,


### PR DESCRIPTION
### Description
- Fixes the `align` style-engine prop from overlapping with the `align` radix prop
- Fixes `border` prop to be `px` from breaking change from style-engine

### Tasks
[KNO-6361](https://linear.app/knock/issue/KNO-6361/[telegraph]-fix-overlapping-align-props-in-menu)