### PR TITLE
fix: add border shorthand to box

### DIFF
--- a/.changeset/unlucky-ligers-cheat.md
+++ b/.changeset/unlucky-ligers-cheat.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+add border shorthand to box

--- a/packages/layout/src/Box/Box.css.ts
+++ b/packages/layout/src/Box/Box.css.ts
@@ -50,6 +50,7 @@ const boxProperties = defineStyleProps({
   },
   shorthands: {
     bg: ["backgroundColor"],
+    border: ["borderWidth"],
     borderBottom: ["borderBottomWidth"],
     borderLeft: ["borderLeftWidth"],
     borderRight: ["borderRightWidth"],

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -19,12 +19,12 @@ const Box = <T extends TgphElement>({
   tgphRef,
   borderColor = "gray-4",
   borderStyle = "solid",
-  borderWidth = "0",
+  border = "0",
   ...props
 }: BoxProps<T>) => {
   const Component = (as || "div") as TgphElement;
   const { styleClassName, componentProps } = useStyleProps({
-    props: { ...props, borderColor, borderStyle, borderWidth },
+    props: { ...props, borderColor, borderStyle, border },
     stylePropsFn,
   });
   return (


### PR DESCRIPTION
### Description
Adds missing border shorthand to box and fixes defaults in Box.tsx

### Tasks 
[KNO-6454](kyle-kno-6454-telegraph-add-border-prop-to-box)