### PR TITLE
feat: kbd component

### DIFF
--- a/.changeset/plenty-keys-own.md
+++ b/.changeset/plenty-keys-own.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/appearance": patch
+"@telegraph/typography": patch
+"@telegraph/kbd": patch
+---
+
+new kbd component

--- a/packages/appearance/src/useAppearance.tsx
+++ b/packages/appearance/src/useAppearance.tsx
@@ -3,13 +3,11 @@ import React from "react";
 
 type Appearance = "light" | "dark";
 
-type UseAppearanceParams =
-  | {
-      appearanceOverride?: Appearance;
-    }
-  | undefined;
+type UseAppearanceParams = {
+  appearanceOverride?: Appearance;
+};
 
-const useAppearance = (params: UseAppearanceParams) => {
+const useAppearance = (params: UseAppearanceParams = {}) => {
   const [appearance, setAppearance] = React.useState<Appearance>(
     params?.appearanceOverride || "light",
   );

--- a/packages/kbd/.eslintrc.js
+++ b/packages/kbd/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/packages/kbd/README.md
+++ b/packages/kbd/README.md
@@ -1,0 +1,17 @@
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/kbd)
+
+# @telegraph/kbd
+> Styled element for keyboard input or hotkey.
+
+## Installation Instructions
+
+```
+npm install @telegraph/kbd
+```
+
+### Add stylesheet
+```
+@import "@telegraph/kbd"
+```

--- a/packages/kbd/package.json
+++ b/packages/kbd/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@telegraph/kbd",
+  "version": "0.0.0",
+  "description": "Styled element for keyboard input or hotkey.",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/kbd",
+  "author": "@knocklabs",
+  "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/css/default.css"
+    },
+    "./default.css": "./dist/css/default.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "prettier": "@telegraph/prettier-config",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch --emptyOutDir false",
+    "build": "yarn clean && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
+    "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@telegraph/helpers": "workspace:^",
+    "@telegraph/layout": "workspace:^",
+    "@telegraph/typography": "workspace:^"
+  },
+  "devDependencies": {
+    "@knocklabs/eslint-config": "^0.0.3",
+    "@knocklabs/typescript-config": "^0.0.2",
+    "@telegraph/postcss-config": "workspace:^",
+    "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/vite-config": "workspace:^",
+    "@types/react": "^18.2.48",
+    "eslint": "^8.56.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.3.0"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/kbd/postcss.config.mjs
+++ b/packages/kbd/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pkg from "@telegraph/postcss-config";
+
+const { styleEnginePostCssConfig } = pkg;
+
+export default styleEnginePostCssConfig;

--- a/packages/kbd/src/Kbd/Kbd.constants.ts
+++ b/packages/kbd/src/Kbd/Kbd.constants.ts
@@ -1,3 +1,7 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import type { Stack } from "@telegraph/layout";
+import type { Text } from "@telegraph/typography";
+
 export const sizeMap = {
   "1": {
     stack: {
@@ -26,89 +30,70 @@ export const sizeMap = {
   },
 } as const;
 
-export const colorMap = {
+type StackColor = {
+  borderColor: TgphComponentProps<typeof Stack>["borderColor"];
+  bg: TgphComponentProps<typeof Stack>["bg"];
+  bgPressed: TgphComponentProps<typeof Stack>["bg"];
+};
+
+type TextColor = {
+  color: TgphComponentProps<typeof Text>["color"];
+};
+
+export type Appearance = "light" | "dark";
+export type Contrast = "default" | "contrast";
+export type ColorMap = {
+  [key in Appearance]: {
+    [key in Contrast]: {
+      stack: StackColor;
+      text: TextColor;
+    };
+  };
+};
+
+export const colorMap: ColorMap = {
   light: {
     default: {
-      default: {
-        stack: {
-          borderColor: "gray-3",
-          bg: "surface-1",
-        },
-        text: {
-          color: "default",
-        },
+      stack: {
+        borderColor: "gray-3",
+        bg: "surface-1",
+        bgPressed: "gray-4",
       },
-      pressed: {
-        stack: {
-          borderColor: "gray-3",
-          bg: "gray-4",
-        },
-        text: {
-          color: "default",
-        },
+      text: {
+        color: "default",
       },
-      contrast: {
-        default: {
-          stack: {
-            borderColor: "gray-3",
-            bg: "transparent",
-          },
-          text: {
-            color: "white",
-          },
-        },
-        pressed: {
-          stack: {
-            borderColor: "gray-3",
-            bg: "alpha-black-2",
-          },
-          text: {
-            color: "default",
-          },
-        },
+    },
+    contrast: {
+      stack: {
+        borderColor: "gray-3",
+        bg: "transparent",
+        bgPressed: "alpha-black-2",
+      },
+      text: {
+        color: "white",
       },
     },
   },
   dark: {
     default: {
-      default: {
-        stack: {
-          borderColor: "gray-3",
-          bg: "surface-1",
-        },
-        text: {
-          color: "default",
-        },
+      stack: {
+        borderColor: "gray-3",
+        bg: "surface-1",
+        bgPressed: "gray-4",
       },
-      pressed: {
-        stack: {
-          borderColor: "gray-3",
-          bg: "gray-4",
-        },
-        text: {
-          color: "default",
-        },
+      text: {
+        color: "default",
       },
     },
     contrast: {
-      default: {
-        stack: {
-          borderColor: "black",
-          bg: "transparent",
-        },
-        text: {
-          color: "black",
-        },
+      stack: {
+        borderColor: "black",
+        bg: "transparent",
+        bgPressed: "alpha-black-2",
       },
-      pressed: {
-        stack: {
-          borderColor: "gray-3",
-          bg: "alpha-black-2",
-        },
-        text: {
-          color: "default",
-        },
+      text: {
+        color: "black",
       },
     },
   },
-} as const;
+};

--- a/packages/kbd/src/Kbd/Kbd.constants.ts
+++ b/packages/kbd/src/Kbd/Kbd.constants.ts
@@ -1,0 +1,114 @@
+export const sizeMap = {
+  "1": {
+    stack: {
+      w: "5",
+      h: "5",
+    },
+    text: {
+      size: "0",
+    },
+  },
+  "2": {
+    stack: {
+      w: "6",
+      h: "6",
+    },
+    text: { size: "1" },
+  },
+  "3": {
+    stack: {
+      w: "8",
+      h: "8",
+    },
+    text: {
+      size: "2",
+    },
+  },
+} as const;
+
+export const colorMap = {
+  light: {
+    default: {
+      default: {
+        stack: {
+          borderColor: "gray-3",
+          bg: "surface-1",
+        },
+        text: {
+          color: "default",
+        },
+      },
+      pressed: {
+        stack: {
+          borderColor: "gray-3",
+          bg: "gray-4",
+        },
+        text: {
+          color: "default",
+        },
+      },
+      contrast: {
+        default: {
+          stack: {
+            borderColor: "gray-3",
+            bg: "transparent",
+          },
+          text: {
+            color: "white",
+          },
+        },
+        pressed: {
+          stack: {
+            borderColor: "gray-3",
+            bg: "alpha-black-2",
+          },
+          text: {
+            color: "default",
+          },
+        },
+      },
+    },
+  },
+  dark: {
+    default: {
+      default: {
+        stack: {
+          borderColor: "gray-3",
+          bg: "surface-1",
+        },
+        text: {
+          color: "default",
+        },
+      },
+      pressed: {
+        stack: {
+          borderColor: "gray-3",
+          bg: "gray-4",
+        },
+        text: {
+          color: "default",
+        },
+      },
+    },
+    contrast: {
+      default: {
+        stack: {
+          borderColor: "black",
+          bg: "transparent",
+        },
+        text: {
+          color: "black",
+        },
+      },
+      pressed: {
+        stack: {
+          borderColor: "gray-3",
+          bg: "alpha-black-2",
+        },
+        text: {
+          color: "default",
+        },
+      },
+    },
+  },
+} as const;

--- a/packages/kbd/src/Kbd/Kbd.hooks.tsx
+++ b/packages/kbd/src/Kbd/Kbd.hooks.tsx
@@ -1,0 +1,120 @@
+import React from "react";
+
+type PressedContextState = {
+  currentlyPressedKeys: Array<string> | null;
+};
+
+const PressedContext = React.createContext<PressedContextState>({
+  currentlyPressedKeys: null,
+});
+
+type UsePressedParams = {
+  key: KeyboardEvent["key"];
+};
+
+const usePressed = ({ key }: UsePressedParams) => {
+  const context = React.useContext(PressedContext);
+  const [pressed, setPressed] = React.useState(false);
+
+  const handleKeyDown = React.useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === key) {
+        setPressed(true);
+      }
+    },
+    [key],
+  );
+
+  const handleKeyUp = React.useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === key) {
+        setPressed(false);
+      }
+    },
+    [key],
+  );
+
+  React.useEffect(() => {
+    // If currentPressedKey is equal to null then this hook
+    // is not contained within a KbdProvider. If it is any
+    // other value, i.e. string | undefined, then it is contained
+    // within a KBD Provider
+    if (context?.currentlyPressedKeys !== null) {
+      if (context?.currentlyPressedKeys.includes(key)) {
+        return setPressed(true);
+      }
+      return setPressed(false);
+    }
+
+    // If context does not exist, add event listeners
+    // to set the pressed prop based on the keydown and keyup events
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [context?.currentlyPressedKeys, key, handleKeyDown, handleKeyUp]);
+
+  return { pressed };
+};
+
+type KbdProviderProps = {
+  children: React.ReactNode;
+};
+
+const KbdProvider = ({ children }: KbdProviderProps) => {
+  const [currentlyPressedKeys, setCurrentlyPressedKeys] = React.useState<
+    PressedContextState["currentlyPressedKeys"]
+  >([]);
+
+  // Brodcast the the keys currently being pressed, passing
+  // as an array so we can check for multiple keys being pressed
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const keys = [];
+      if (event.key) {
+        keys.push(event.key);
+      }
+
+      if (event.metaKey) {
+        keys.push("Meta");
+      }
+
+      if (event.shiftKey) {
+        keys.push("Shift");
+      }
+
+      if (event.altKey) {
+        keys.push("Alt");
+      }
+
+      if (event.ctrlKey) {
+        keys.push("Control");
+      }
+
+      setCurrentlyPressedKeys(keys);
+    };
+
+    const handleKeyUp = () => {
+      setCurrentlyPressedKeys([]);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, []);
+
+  return (
+    <PressedContext.Provider value={{ currentlyPressedKeys }}>
+      {children}
+    </PressedContext.Provider>
+  );
+};
+
+export { KbdProvider, usePressed };

--- a/packages/kbd/src/Kbd/Kbd.hooks.tsx
+++ b/packages/kbd/src/Kbd/Kbd.hooks.tsx
@@ -69,7 +69,7 @@ const KbdProvider = ({ children }: KbdProviderProps) => {
     PressedContextState["currentlyPressedKeys"]
   >([]);
 
-  // Brodcast the the keys currently being pressed, passing
+  // Broadcast the the keys currently being pressed, passing
   // as an array so we can check for multiple keys being pressed
   React.useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/packages/kbd/src/Kbd/Kbd.stories.tsx
+++ b/packages/kbd/src/Kbd/Kbd.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import type { TgphComponentProps } from "@telegraph/helpers";
+import { Box } from "@telegraph/layout";
+
+import { Kbd as TelegraphKbd } from "./Kbd";
+import { sizeMap } from "./Kbd.constants";
+
+const meta: Meta = {
+  title: "Components/Kbd",
+  component: TelegraphKbd,
+  argTypes: {
+    size: {
+      options: Object.keys(sizeMap),
+      control: {
+        type: "select",
+      },
+    },
+    contrast: {
+      control: {
+        type: "boolean",
+      },
+    },
+    label: {
+      control: {
+        type: "text",
+      },
+    },
+    eventKey: {
+      control: {
+        type: "text",
+      },
+    }
+  },
+  args: {
+    size: "1",
+    contrast: false,
+    label: "K",
+    eventKey: "k",
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<TgphComponentProps<typeof TelegraphKbd>>;
+
+export const Default: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Box bg={args.contrast ? "accent-9" : "surface-2"} p="20">
+        <TelegraphKbd {...args} />
+      </Box>
+    );
+  },
+};

--- a/packages/kbd/src/Kbd/Kbd.stories.tsx
+++ b/packages/kbd/src/Kbd/Kbd.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import type { TgphComponentProps } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Stack } from "@telegraph/layout";
 
 import { Kbd as TelegraphKbd } from "./Kbd";
 import { sizeMap } from "./Kbd.constants";
+import { KbdProvider } from "./Kbd.hooks";
 
 const meta: Meta = {
   title: "Components/Kbd",
@@ -29,7 +30,7 @@ const meta: Meta = {
       control: {
         type: "text",
       },
-    }
+    },
   },
   args: {
     size: "1",
@@ -46,9 +47,12 @@ type Story = StoryObj<TgphComponentProps<typeof TelegraphKbd>>;
 export const Default: Story = {
   render: ({ ...args }) => {
     return (
-      <Box bg={args.contrast ? "accent-9" : "surface-2"} p="20">
-        <TelegraphKbd {...args} />
-      </Box>
+      <KbdProvider>
+        <Stack bg={args.contrast ? "accent-9" : "surface-2"} p="20" gap="1">
+          <TelegraphKbd eventKey="Meta" label="⌘" />
+          <TelegraphKbd {...args} />
+        </Stack>
+      </KbdProvider>
     );
   },
 };

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -19,9 +19,9 @@ const Kbd = ({
   ...props
 }: KbdProps) => {
   const { appearance } = useAppearance();
+  const { pressed } = usePressed({ key: props.eventKey || label });
 
   const contrast = contrastProp ? "contrast" : "default";
-  const { pressed } = usePressed({ key: props.eventKey || label });
 
   return (
     <Stack

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -1,69 +1,54 @@
 import { useAppearance } from "@telegraph/appearance";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
-import { useEffect, useState } from "react";
 
 import { colorMap, sizeMap } from "./Kbd.constants";
+import { usePressed } from "./Kbd.hooks";
 
 type KbdProps = {
   size?: keyof typeof sizeMap;
   contrast?: boolean;
   label: string;
-  eventKey?: string;
+  eventKey?: KeyboardEvent["key"];
 };
 
-const Kbd = (props: KbdProps) => {
-  const { size = "1", contrast = false, label } = props;
+const Kbd = ({
+  size = "1",
+  contrast: contrastProp = false,
+  label,
+  ...props
+}: KbdProps) => {
   const { appearance } = useAppearance();
-  const [pressedState, setPressedState] = useState(false);
 
-  const key = props.eventKey || label;
-
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      console.log(event.key, key);
-      if (event.key === key) {
-        setPressedState(true);
-      }
-    };
-
-    const handleKeyUp = (event: KeyboardEvent) => {
-      if (event.key === key) {
-        setPressedState(false);
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    window.addEventListener("keyup", handleKeyUp);
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-      window.removeEventListener("keyup", handleKeyUp);
-    };
-  }, [key]);
+  const contrast = contrastProp ? "contrast" : "default";
+  const { pressed } = usePressed({ key: props.eventKey || label });
 
   return (
     <Stack
-      {...colorMap[appearance][contrast ? "contrast" : "default"][
-        pressedState ? "pressed" : "default"
-      ].stack}
       {...sizeMap[size].stack}
+      bg={
+        pressed
+          ? colorMap[appearance][contrast].stack.bgPressed
+          : colorMap[appearance][contrast].stack.bg
+      }
+      shadow={pressed ? "inner" : "0"}
+      borderColor={colorMap[appearance][contrast].stack.borderColor}
       border="px"
       rounded="1"
       align="center"
       justify="center"
+      style={{
+        transition: "background-color 0.2s ease-in-out",
+      }}
     >
       <Text
         as="span"
-        {...colorMap[appearance][contrast ? "contrast" : "default"][
-          pressedState ? "pressed" : "default"
-        ].text}
         {...sizeMap[size].text}
+        color={colorMap[appearance][contrast].text.color}
       >
         {label}
       </Text>
     </Stack>
   );
 };
-
 export { Kbd };

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -10,12 +10,13 @@ type KbdProps = {
   contrast?: boolean;
   label: string;
   eventKey?: KeyboardEvent["key"];
-};
+} & React.ComponentProps<typeof Stack>;
 
 const Kbd = ({
   size = "1",
   contrast: contrastProp = false,
   label,
+  style,
   ...props
 }: KbdProps) => {
   const { appearance } = useAppearance();
@@ -39,7 +40,9 @@ const Kbd = ({
       justify="center"
       style={{
         transition: "background-color 0.2s ease-in-out",
+        ...style,
       }}
+      {...props}
     >
       <Text
         as="span"

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -1,0 +1,69 @@
+import { useAppearance } from "@telegraph/appearance";
+import { Stack } from "@telegraph/layout";
+import { Text } from "@telegraph/typography";
+import { useEffect, useState } from "react";
+
+import { colorMap, sizeMap } from "./Kbd.constants";
+
+type KbdProps = {
+  size?: keyof typeof sizeMap;
+  contrast?: boolean;
+  label: string;
+  eventKey?: string;
+};
+
+const Kbd = (props: KbdProps) => {
+  const { size = "1", contrast = false, label } = props;
+  const { appearance } = useAppearance();
+  const [pressedState, setPressedState] = useState(false);
+
+  const key = props.eventKey || label;
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      console.log(event.key, key);
+      if (event.key === key) {
+        setPressedState(true);
+      }
+    };
+
+    const handleKeyUp = (event: KeyboardEvent) => {
+      if (event.key === key) {
+        setPressedState(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keyup", handleKeyUp);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [key]);
+
+  return (
+    <Stack
+      {...colorMap[appearance][contrast ? "contrast" : "default"][
+        pressedState ? "pressed" : "default"
+      ].stack}
+      {...sizeMap[size].stack}
+      border="px"
+      rounded="1"
+      align="center"
+      justify="center"
+    >
+      <Text
+        as="span"
+        {...colorMap[appearance][contrast ? "contrast" : "default"][
+          pressedState ? "pressed" : "default"
+        ].text}
+        {...sizeMap[size].text}
+      >
+        {label}
+      </Text>
+    </Stack>
+  );
+};
+
+export { Kbd };

--- a/packages/kbd/src/Kbd/index.ts
+++ b/packages/kbd/src/Kbd/index.ts
@@ -1,0 +1,2 @@
+export { Kbd } from "./Kbd";
+export { KbdProvider } from "./Kbd.hooks";

--- a/packages/kbd/src/index.ts
+++ b/packages/kbd/src/index.ts
@@ -1,0 +1,1 @@
+export { Kbd, KbdProvider } from "./Kbd";

--- a/packages/kbd/tsconfig.json
+++ b/packages/kbd/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/kbd",
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {
+      "vitest.*": ["../../vitest/*"]
+    },
+    "types": ["@testing-library/jest-dom", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/kbd/vite.config.mts
+++ b/packages/kbd/vite.config.mts
@@ -1,0 +1,7 @@
+import {
+  defaultViteConfig,
+  styleEngineViteConfig,
+} from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, styleEngineViteConfig);

--- a/packages/typography/src/helpers/prop-mappings.ts
+++ b/packages/typography/src/helpers/prop-mappings.ts
@@ -27,6 +27,7 @@ export const colorMap = {
   purple: "text-purple-11",
   accent: "text-accent-11",
   white: "text-white",
+  black: "text-black",
   disabled: "text-gray-9",
 } as const;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6151,6 +6151,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@telegraph/kbd@workspace:packages/kbd":
+  version: 0.0.0-use.local
+  resolution: "@telegraph/kbd@workspace:packages/kbd"
+  dependencies:
+    "@knocklabs/eslint-config": "npm:^0.0.3"
+    "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/helpers": "workspace:^"
+    "@telegraph/layout": "workspace:^"
+    "@telegraph/postcss-config": "workspace:^"
+    "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/typography": "workspace:^"
+    "@telegraph/vite-config": "workspace:^"
+    "@types/react": "npm:^18.2.48"
+    eslint: "npm:^8.56.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.3.3"
+    vite: "npm:^5.3.0"
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@telegraph/layout@workspace:^, @telegraph/layout@workspace:packages/layout":
   version: 0.0.0-use.local
   resolution: "@telegraph/layout@workspace:packages/layout"


### PR DESCRIPTION
### Description
Co-authored with @meryldakin 

- Adds `Kbd` component to display keyboard keys with a pressed state
- Adds `KbdProvider` so that a user can wrap parts of their app in order to limit the amount of event listeners, i.e. no `KbdProvider` means and event listener for each use of `Kbd` vs using `KbdProvider` means 1 event listener for all `Kbd` components. 
- Fixes issue with `useAppearance` props

### Tasks
[KNO-6208](https://linear.app/knock/issue/KNO-6208/[telegraph]-kbd-component-pressed-state)