### PR TITLE
feat: tooltip group hover functionality

### DIFF
--- a/.changeset/cyan-horses-relate.md
+++ b/.changeset/cyan-horses-relate.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/tooltip": patch
+---
+
+add tooltip group hover functionality

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@radix-ui/react-tooltip": "^1.1.2",
+    "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@telegraph/appearance": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+
+type TooltipGroupContextState = {
+  groupOpen: boolean;
+  setGroupOpen?: (open: boolean) => void;
+};
+
+const TooltipContext = React.createContext<TooltipGroupContextState>({
+  groupOpen: false,
+  setGroupOpen: () => {},
+});
+
+type UseTooltipGroupParams = {
+  open: boolean;
+  delay?: number;
+};
+
+const useTooltipGroup = ({ open, delay = 800 }: UseTooltipGroupParams) => {
+  const context = React.useContext(TooltipContext);
+
+  // If the open prop is set to true, we set the groupOpen state to true
+  // If the open prop is set to false, we set the groupOpen state to false after a delay
+  // to ensure that another tooltip is not opened while this one is closed.
+  React.useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+    if (context.setGroupOpen) {
+      if (open === true) {
+        context.setGroupOpen(true);
+      }
+
+      if (open === false) {
+        timer = setTimeout(() => {
+          if (context.setGroupOpen) {
+            context.setGroupOpen(false);
+          }
+        }, delay);
+      }
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [open, context, delay]);
+
+  return {
+    groupOpen: context.groupOpen,
+  };
+};
+
+type TooltipGroupProviderProps = {
+  children: React.ReactNode;
+};
+
+const TooltipGroupProvider = ({ children }: TooltipGroupProviderProps) => {
+  const [groupOpen, setGroupOpen] = React.useState<boolean>(false);
+
+  return (
+    <TooltipContext.Provider value={{ groupOpen, setGroupOpen }}>
+      {children}
+    </TooltipContext.Provider>
+  );
+};
+
+export { TooltipGroupProvider, useTooltipGroup };

--- a/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
@@ -15,7 +15,7 @@ type UseTooltipGroupParams = {
   delay?: number;
 };
 
-const useTooltipGroup = ({ open, delay = 800 }: UseTooltipGroupParams) => {
+const useTooltipGroup = ({ open, delay = 600 }: UseTooltipGroupParams) => {
   const context = React.useContext(TooltipContext);
 
   // If the open prop is set to true, we set the groupOpen state to true

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -4,6 +4,7 @@ import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 
 import { Tooltip as TelegraphTooltip } from "./Tooltip";
+import { TooltipGroupProvider } from "./Tooltip.hooks";
 
 const meta: Meta = {
   title: "Components/Tooltip",
@@ -51,6 +52,23 @@ export const Default: Story = {
         <TelegraphTooltip {...args}>
           <Button color="blue">Hover me</Button>
         </TelegraphTooltip>
+      </Stack>
+    );
+  },
+};
+
+export const Group: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center" gap="2">
+        <TooltipGroupProvider>
+          <TelegraphTooltip {...args}>
+            <Button color="blue">Hover me</Button>
+          </TelegraphTooltip>
+          <TelegraphTooltip {...args}>
+            <Button color="blue">Hover me</Button>
+          </TelegraphTooltip>
+        </TooltipGroupProvider>
       </Stack>
     );
   },

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -137,7 +137,7 @@ const Tooltip = <T extends TgphElement>({
                           scale: 0.6,
                           ...deriveAnimationBasedOnSide(side),
                         }
-                      : null
+                      : {}
                   }
                   animate={{
                     opacity: 1,

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -28,7 +28,7 @@ type TooltipProps<T extends TgphElement> = React.ComponentPropsWithoutRef<
 
 const Tooltip = <T extends TgphElement>({
   // Radix Tooltip Provider Props
-  delayDuration = 800,
+  delayDuration = 600,
   skipDelayDuration,
   disableHoverableContent,
   // Radix Tooltip Root Props
@@ -62,7 +62,7 @@ const Tooltip = <T extends TgphElement>({
     onChange: onOpenChangeProp,
     defaultProp: defaultOpenProp,
   });
-  const { groupOpen } = useTooltipGroup({ open: !!open });
+  const { groupOpen } = useTooltipGroup({ open: !!open, delay: delayDuration });
 
   const derivedDelayDuration = groupOpen ? 0 : delayDuration;
   const shouldAnimate = !groupOpen;

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import * as RadixTooltip from "@radix-ui/react-tooltip";
+import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import { InvertedAppearance } from "@telegraph/appearance";
 import {
   RefToTgphRef,
@@ -9,6 +10,8 @@ import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
 import { motion } from "framer-motion";
 import React from "react";
+
+import { useTooltipGroup } from "./Tooltip.hooks";
 
 type TooltipBaseProps<T extends TgphElement> = {
   label: string | React.ReactNode;
@@ -25,13 +28,13 @@ type TooltipProps<T extends TgphElement> = React.ComponentPropsWithoutRef<
 
 const Tooltip = <T extends TgphElement>({
   // Radix Tooltip Provider Props
-  delayDuration = 0,
+  delayDuration = 800,
   skipDelayDuration,
   disableHoverableContent,
   // Radix Tooltip Root Props
-  defaultOpen,
-  open,
-  onOpenChange,
+  defaultOpen: defaultOpenProp,
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
   // Radix Tooltip Content Props
   "aria-label": ariaLabel,
   onEscapeKeyDown,
@@ -54,6 +57,16 @@ const Tooltip = <T extends TgphElement>({
   enabled = true,
   children,
 }: TooltipProps<T>) => {
+  const [open, setOpen] = useControllableState({
+    prop: openProp,
+    onChange: onOpenChangeProp,
+    defaultProp: defaultOpenProp,
+  });
+  const { groupOpen } = useTooltipGroup({ open: !!open });
+
+  const derivedDelayDuration = groupOpen ? 0 : delayDuration;
+  const shouldAnimate = !groupOpen;
+
   const deriveAnimationBasedOnSide = (side: TooltipProps<T>["side"]) => {
     const ANIMATION_OFFSET = 5;
     if (side === "top") {
@@ -84,15 +97,11 @@ const Tooltip = <T extends TgphElement>({
   if (enabled) {
     return (
       <RadixTooltip.Provider
-        delayDuration={delayDuration}
+        delayDuration={derivedDelayDuration}
         skipDelayDuration={skipDelayDuration}
         disableHoverableContent={disableHoverableContent}
       >
-        <RadixTooltip.Root
-          defaultOpen={defaultOpen}
-          open={open}
-          onOpenChange={onOpenChange}
-        >
+        <RadixTooltip.Root open={open} onOpenChange={setOpen}>
           <RadixTooltip.Trigger asChild={true}>
             <RefToTgphRef>{children}</RefToTgphRef>
           </RadixTooltip.Trigger>
@@ -121,11 +130,15 @@ const Tooltip = <T extends TgphElement>({
                   as={motion.div}
                   // Add tgph class so that this always works in portals
                   className="tgph"
-                  initial={{
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
-                  }}
+                  initial={
+                    shouldAnimate
+                      ? {
+                          opacity: 0.5,
+                          scale: 0.6,
+                          ...deriveAnimationBasedOnSide(side),
+                        }
+                      : null
+                  }
                   animate={{
                     opacity: 1,
                     scale: 1,

--- a/packages/tooltip/src/Tooltip/index.ts
+++ b/packages/tooltip/src/Tooltip/index.ts
@@ -1,1 +1,2 @@
 export { Tooltip } from "./Tooltip";
+export { TooltipGroupProvider } from "./Tooltip.hooks";

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip } from "./Tooltip";
+export { Tooltip, TooltipGroupProvider } from "./Tooltip";

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,6 +6480,7 @@ __metadata:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@radix-ui/react-tooltip": "npm:^1.1.2"
+    "@radix-ui/react-use-controllable-state": "npm:^1.1.0"
     "@telegraph/appearance": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
### Description
- Adds `TooltipGroupProvider` to `@telegraph/tooltip` so tooltips can be aware of each other and not delay/animate after a previous tooltip was recently hovered. See: https://x.com/BenMcMahen/status/1816239771271750077

### Tasks
[KNO-6639](https://linear.app/knock/issue/KNO-6639/[telegraph]-tooltip-group-delay)