### PR TITLE
fix: update radio card color styles and spacing

### DIFF
--- a/.changeset/few-lizards-double.md
+++ b/.changeset/few-lizards-double.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/radio": patch
+---
+
+fix: update radio card color styles and spacing"

--- a/packages/radio/src/RadioCards/RadioCards.styles.css
+++ b/packages/radio/src/RadioCards/RadioCards.styles.css
@@ -1,0 +1,13 @@
+.tgph-radio-card-description,
+.tgph-radio-card-icon {
+  transition: color 0.2s ease-in-out;
+}
+
+/* Style hovered or active radio card elements */
+.tgph-radio-card-root:hover .tgph-radio-card-description,
+.tgph-radio-card-root[data-tgph-button-active="true"]
+  .tgph-radio-card-description,
+.tgph-radio-card-root:hover .tgph-radio-card-icon,
+.tgph-radio-card-root[data-tgph-button-active="true"] .tgph-radio-card-icon {
+  color: var(--tgph-gray-12) !important;
+}

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -27,7 +27,7 @@ const Root = React.forwardRef<RootRef, RootProps>(
           {...props}
           ref={forwardedRef}
         >
-          <Stack gap="2">{children}</Stack>
+          <Stack gap="1">{children}</Stack>
         </RadioGroup.Root>
       </RadioButtonContext.Provider>
     );
@@ -46,7 +46,7 @@ const Item = React.forwardRef<ItemRef, ItemProps>(
           <Button.Root
             variant="outline"
             active={props.value === contextValue}
-            className="data-[tgph-button-active=true]:!shadow-blue-8 data-[tgph-button-active=true]:!shadow-[inset_0_0_0_2px] !p-0 !h-full !w-full"
+            className="tgph-radio-card-root data-[tgph-button-active=true]:!shadow-blue-8 data-[tgph-button-active=true]:!shadow-[inset_0_0_0_2px] !p-0 !h-full !w-full"
           >
             {children}
           </Button.Root>
@@ -74,7 +74,15 @@ const ItemDescription = <T extends TgphElement>({
   size = "0",
   ...props
 }: ItemDescriptionProps<T>) => {
-  return <Button.Text as={"span"} size={size} {...props} />;
+  return (
+    <Button.Text
+      className="tgph-radio-card-description"
+      as={"span"}
+      size={size}
+      color="gray"
+      {...props}
+    />
+  );
 };
 
 type ItemIconProps<T extends TgphElement> = TgphComponentProps<
@@ -82,7 +90,9 @@ type ItemIconProps<T extends TgphElement> = TgphComponentProps<
 >;
 
 const ItemIcon = <T extends TgphElement>(props: ItemIconProps<T>) => {
-  return <Button.Icon {...props} />;
+  return (
+    <Button.Icon className="tgph-radio-card-icon" color="gray" {...props} />
+  );
 };
 
 type DefaultIconProps = React.ComponentProps<typeof Icon>;

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -3,6 +3,7 @@ import { Button } from "@telegraph/button";
 import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
+import clsx from "clsx";
 import React from "react";
 
 type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root>;
@@ -72,11 +73,12 @@ type ItemDescriptionProps<T extends TgphElement> = TgphComponentProps<
 >;
 const ItemDescription = <T extends TgphElement>({
   size = "0",
+  className,
   ...props
 }: ItemDescriptionProps<T>) => {
   return (
     <Button.Text
-      className="tgph-radio-card-description"
+      className={clsx("tgph-radio-card-description", className)}
       as={"span"}
       size={size}
       color="gray"
@@ -91,7 +93,11 @@ type ItemIconProps<T extends TgphElement> = TgphComponentProps<
 
 const ItemIcon = <T extends TgphElement>(props: ItemIconProps<T>) => {
   return (
-    <Button.Icon className="tgph-radio-card-icon" color="gray" {...props} />
+    <Button.Icon
+      color="gray"
+      {...props}
+      className={clsx("tgph-radio-card-icon", props.className)}
+    />
   );
 };
 

--- a/packages/radio/src/default.css
+++ b/packages/radio/src/default.css
@@ -1,4 +1,18 @@
 /* Including just "@tailwind utilities;" will build only the classnames within the package */
 @tailwind utilities;
 
+.tgph-radio-card-description,
+.tgph-radio-card-icon {
+  transition: color 0.2s ease-in-out;
+}
+
+/* Style hovered or active radio card elements */
+.tgph-radio-card-root:hover .tgph-radio-card-description,
+.tgph-radio-card-root[data-tgph-button-active="true"]
+  .tgph-radio-card-description,
+.tgph-radio-card-root:hover .tgph-radio-card-icon,
+.tgph-radio-card-root[data-tgph-button-active="true"] .tgph-radio-card-icon {
+  color: var(--tgph-gray-12) !important;
+}
+
 @config "../tailwind.config.mts";

--- a/packages/radio/src/default.css
+++ b/packages/radio/src/default.css
@@ -1,18 +1,6 @@
+@import "./RadioCards/RadioCards.styles.css";
+
 /* Including just "@tailwind utilities;" will build only the classnames within the package */
 @tailwind utilities;
-
-.tgph-radio-card-description,
-.tgph-radio-card-icon {
-  transition: color 0.2s ease-in-out;
-}
-
-/* Style hovered or active radio card elements */
-.tgph-radio-card-root:hover .tgph-radio-card-description,
-.tgph-radio-card-root[data-tgph-button-active="true"]
-  .tgph-radio-card-description,
-.tgph-radio-card-root:hover .tgph-radio-card-icon,
-.tgph-radio-card-root[data-tgph-button-active="true"] .tgph-radio-card-icon {
-  color: var(--tgph-gray-12) !important;
-}
 
 @config "../tailwind.config.mts";


### PR DESCRIPTION
Updates the text/icon colors for the unselected, hover, and active states. Also updates the spacing between cards. 

<img width="705" alt="Screenshot 2024-08-06 at 10 47 00 AM" src="https://github.com/user-attachments/assets/a3b068e8-ea16-453b-a25b-8ad41de1e1a5">

Looks like the built css is correct too:

![Screenshot 2024-08-06 at 10 50 02 AM](https://github.com/user-attachments/assets/1e539fee-99b8-4841-810a-c851fc3a43ce)

