### PR TITLE
feat: useDeterminateState + button integration

### DIFF
--- a/.changeset/tame-planes-double.md
+++ b/.changeset/tame-planes-double.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/button": patch
+---
+
+useDeterminateState + button integration

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,9 +1,10 @@
-import type {
-  PolymorphicProps,
-  PolymorphicPropsWithTgphRef,
-  Required,
-  TgphComponentProps,
-  TgphElement,
+import {
+  type PolymorphicProps,
+  type PolymorphicPropsWithTgphRef,
+  type Required,
+  type TgphComponentProps,
+  type TgphElement,
+  useDeterminateState,
 } from "@telegraph/helpers";
 import { Lucide, Icon as TelegraphIcon } from "@telegraph/icon";
 import { Stack } from "@telegraph/layout";
@@ -238,9 +239,15 @@ const Default = <T extends TgphElement>({
   trailingIcon,
   icon,
   children,
-  state = "default",
+  state: stateProp = "default",
   ...props
 }: DefaultProps<T>) => {
+  const state = useDeterminateState<DefaultProps<T>["state"]>({
+    value: stateProp,
+    determinateValue: "loading",
+    minDurationMs: 1200,
+  });
+
   const combinedLeadingIcon = leadingIcon || icon;
   return (
     <Root state={state} {...props}>

--- a/packages/helpers/src/hooks/useDeterminateState.ts
+++ b/packages/helpers/src/hooks/useDeterminateState.ts
@@ -1,0 +1,66 @@
+/*
+ * useDeterminateState
+ *
+ * A hook that returns a state transitioning to a determinate value after a minimum duration.
+ * For example, you could use this hook with a button that transitions into a "loading" state,
+ * ensuring it remains in the "loading" state for at least 1000ms. This provides clear feedback
+ * to the user that the action is being processed.
+ *
+ */
+import React from "react";
+
+type UseDeterminateStateParams<T> = {
+  value: T;
+  determinateValue: T;
+  minDurationMs?: number;
+};
+
+const useDeterminateState = <T>({
+  value,
+  determinateValue,
+  minDurationMs = 1000,
+}: UseDeterminateStateParams<T>): T => {
+  const [state, setState] = React.useState<T>(value);
+  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
+  const startTimeRef = React.useRef<number | null>(null);
+
+  const clearExistingTimeout = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+  };
+
+  const handleTransition = React.useCallback(() => {
+    if (value === determinateValue) {
+      clearExistingTimeout();
+      setState(determinateValue);
+      startTimeRef.current = Date.now();
+    } else if (startTimeRef.current !== null) {
+      const elapsedTime = Date.now() - startTimeRef.current;
+      const remainingTime = minDurationMs - elapsedTime;
+
+      if (remainingTime > 0) {
+        clearExistingTimeout();
+        timeoutRef.current = setTimeout(() => {
+          setState(value);
+          startTimeRef.current = null;
+        }, remainingTime);
+      } else {
+        setState(value);
+        startTimeRef.current = null;
+      }
+    } else {
+      setState(value);
+    }
+  }, [value, determinateValue, minDurationMs]);
+
+  React.useEffect(() => {
+    handleTransition();
+    return clearExistingTimeout;
+  }, [value, handleTransition]);
+
+  return state;
+};
+
+export { useDeterminateState };

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -11,3 +11,5 @@ export type {
 } from "./types/utility";
 
 export { RefToTgphRef } from "./components/RefToTgphRef";
+
+export { useDeterminateState } from "./hooks/useDeterminateState";


### PR DESCRIPTION
### Description
Adds `useDeterminateState` hook, allowing a state value to hold a certain value for a minimum amount of time. For example, this hook is integrated into our button component so that if the `state` prop is set to `loading`, it will remain `loading` for at least 1 second, even if `state` transitions to another value. This ensures that the button cleanly transitions to a `loading` state and remains visible long enough for the user to perceive it, even if the action takes a shorter amount of time than the `minDurationMs`.

### Tasks
[KNO-6656](https://linear.app/knock/issue/KNO-6656/[telegraph]-usedeterminatestate-hook-button-integration)