### PR TITLE
feat: refactor button loading state to be more flexible

### DIFF
--- a/.changeset/four-insects-play.md
+++ b/.changeset/four-insects-play.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/button": patch
+---
+
+button loading state refactor


### PR DESCRIPTION
### Description
Previously, the button loading state was only applicable if you were using the default button export. This wasn't ideal as we'd want the loading state reflected no matter how you are using the button. 

So, this update moves the `useDeterminateState` hook into the Root component and also the rendering of the loading icon. It also adds logic for hiding the `leadingIcon` when the button is in a loading state so that the loading state can replace that icon. This is in line with the original spec provided by Krisna, ensuring it works as intended.

### Tasks
[KNO-6662](https://linear.app/knock/issue/KNO-6662/[telegraph]-refactor-button-loading-state-to-be-more-flexible)