### PR TITLE
fix: ref warning from RefToTgphRef

### DIFF
--- a/.changeset/quiet-impalas-clean.md
+++ b/.changeset/quiet-impalas-clean.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/helpers": patch
+---
+
+refactor component in order to avoid function component ref error

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -28,9 +28,6 @@
     "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@radix-ui/react-slot": "^1.1.0"
-  },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.3",
     "@knocklabs/typescript-config": "^0.0.2",

--- a/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
+++ b/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
@@ -5,15 +5,111 @@
 // a new component that accepts a `ref` prop and forwards it to the `tgphRef`
 // prop.
 //
-import { Slot } from "@radix-ui/react-slot";
 import React from "react";
+
+const FORWARD_REF_SYMBOL = Symbol.for("react.forward_ref");
+
+type ApplyRefPropsProps = {
+  children: React.ReactNode;
+};
+
+type Child = React.ReactElement & {
+  $$typeof: symbol;
+  type: { $$typeof: symbol };
+};
+
+// Merge props the same way that radix slot does
+// https://github.com/radix-ui/primitives/blob/main/packages/react/slot/src/Slot.tsx
+const mergeProps = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  slotProps: Record<string, any>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  childProps: Record<string, any>,
+) => {
+  // all child props should override
+  const overrideProps = { ...childProps };
+
+  for (const propName in childProps) {
+    const slotPropValue = slotProps[propName];
+    const childPropValue = childProps[propName];
+
+    const isHandler = /^on[A-Z]/.test(propName);
+    if (isHandler) {
+      // if the handler exists on both, we compose them
+      if (slotPropValue && childPropValue) {
+        overrideProps[propName] = (...args: unknown[]) => {
+          childPropValue(...args);
+          slotPropValue(...args);
+        };
+      }
+      // but if it exists only on the slot, we use only this one
+      else if (slotPropValue) {
+        overrideProps[propName] = slotPropValue;
+      }
+    }
+    // if it's `style`, we merge them
+    else if (propName === "style") {
+      overrideProps[propName] = { ...slotPropValue, ...childPropValue };
+    } else if (propName === "className") {
+      overrideProps[propName] = [slotPropValue, childPropValue]
+        .filter(Boolean)
+        .join(" ");
+    }
+  }
+
+  return { ...slotProps, ...overrideProps };
+};
+
+const applyRefProps = (
+  { children, ...props }: ApplyRefPropsProps,
+  ref: React.Ref<unknown>,
+) => {
+  if (!children) return null;
+  const childrenArray = React.Children.toArray(children);
+  return childrenArray.map((child) => {
+    if (React.isValidElement(child)) {
+      const validChild = child as Child;
+      const $$typeof = validChild.$$typeof;
+      const $$typeofType = validChild.type.$$typeof;
+      const childProps = validChild.props;
+      const tgphRef = childProps.tgphRef;
+
+      // If we detect that the child is a forwardRef, we to pass the `ref` prop
+      // to it so that components that exist outside of our library can still
+      // receive the ref. We do it this way in order to avoid this warning:
+      // "Function components cannot be given refs. Attempts to access this ref will fail.
+      // Did you mean to use React.forwardRef()"
+      if (
+        $$typeof === FORWARD_REF_SYMBOL ||
+        $$typeofType === FORWARD_REF_SYMBOL
+      ) {
+        return React.cloneElement(validChild, {
+          ...mergeProps(props, childProps),
+          tgphRef: tgphRef || ref,
+          ref: tgphRef || ref,
+        });
+      }
+
+      // Otherwise, we can just pass the `tgphRef` prop to the child.
+      return React.cloneElement(validChild, {
+        ...mergeProps(props, childProps),
+        tgphRef: tgphRef || ref,
+      });
+    }
+
+    // If the child is not a valid element, we can just return it.
+    return child;
+  });
+};
 
 // We can't generate the type of the ref because it's a forwardRef so any
 // works for this use case
 //
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const RefToTgphRef = React.forwardRef<any, any>((props, ref) => {
-  return <Slot {...props} ref={ref} tgphRef={ref} />;
-});
+const RefToTgphRef = React.forwardRef<any, any>(
+  ({ children: childrenProp, ...props }, ref) => {
+    return applyRefProps({ children: childrenProp, ...props }, ref);
+  },
+);
 
 export { RefToTgphRef };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6556,7 +6556,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-slot": "npm:^1.1.0"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^18.2.48"


### PR DESCRIPTION
### Description
When in dev mode in control, the console became littered with the warning `Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()`. This was happening because we were always passing the `ref` from `React.fowardRef` into the underlying component via radix `<Slot/>`. This PR refactors the `RefToTgphRef` component to detect if the children contain `React.forwardRef` and ONLY pass `ref` under that circumstance. This totally eliminates the warning while still maintaining the ability to pass `ref` to components outside of the telegraph ecosystem. Doing this refactor will also allow us to more granularly control how refs are passed when we eventually need to support React v19.

### Tasks
[KNO-6839](https://linear.app/knock/issue/KNO-6839/[telegraph]-fix-ref-warning-stemming-from-reftotgphref)