### PR TITLE
fix: make menu item stack full width

### DIFF
--- a/.changeset/real-sheep-bathe.md
+++ b/.changeset/real-sheep-bathe.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+fix: make menu item stack full width

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -37,7 +37,7 @@ const MenuItem = <T extends TgphElement>({
       w={w}
       {...props}
     >
-      <Stack gap={gap} align="center">
+      <Stack gap={gap} align="center" w="full">
         <MenuItemLeading
           icon={icon}
           selected={selected}


### PR DESCRIPTION
Should fix the width of custom combobox option labels for the message type picker