### PR TITLE
feat: update RadioCards to support direction

### DIFF
--- a/.changeset/six-islands-sleep.md
+++ b/.changeset/six-islands-sleep.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/radio": patch
+---
+
+allow direction props to be passed into the radio card component

--- a/packages/radio/src/RadioCards/RadioCards.stories.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.stories.tsx
@@ -6,6 +6,18 @@ import { RadioCards as TelegraphRadioCards } from "./RadioCards";
 
 const meta: Meta<typeof TelegraphRadioCards> = {
   title: "Components/RadioCards",
+  component: TelegraphRadioCards,
+  argTypes: {
+    align: {
+      options: ["horizontal", "vertical"],
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    align: "horizontal",
+  },
 };
 
 export default meta;
@@ -13,13 +25,14 @@ export default meta;
 type StorybookRadioCardsType = StoryObj<typeof TelegraphRadioCards>;
 
 export const RadioCards: StorybookRadioCardsType = {
-  render: () => {
+  render: ({ align }) => {
     //eslint-disable-next-line
     const [value, setValue] = React.useState("1");
     return (
       <TelegraphRadioCards
         value={value}
         onValueChange={(value) => setValue(value)}
+        align={align}
         options={[
           {
             icon: { icon: Lucide.Bell, alt: "Bell" },

--- a/packages/radio/src/RadioCards/RadioCards.stories.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.stories.tsx
@@ -8,15 +8,15 @@ const meta: Meta<typeof TelegraphRadioCards> = {
   title: "Components/RadioCards",
   component: TelegraphRadioCards,
   argTypes: {
-    align: {
-      options: ["horizontal", "vertical"],
+    direction: {
+      options: ["row", "row-reverse", "column", "column-reverse"],
       control: {
         type: "select",
       },
     },
   },
   args: {
-    align: "horizontal",
+    direction: "row",
   },
 };
 
@@ -25,14 +25,14 @@ export default meta;
 type StorybookRadioCardsType = StoryObj<typeof TelegraphRadioCards>;
 
 export const RadioCards: StorybookRadioCardsType = {
-  render: ({ align }) => {
+  render: ({ direction }) => {
     //eslint-disable-next-line
     const [value, setValue] = React.useState("1");
     return (
       <TelegraphRadioCards
         value={value}
         onValueChange={(value) => setValue(value)}
-        align={align}
+        direction={direction}
         options={[
           {
             icon: { icon: Lucide.Bell, alt: "Bell" },

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -114,21 +114,22 @@ type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
 };
 
 const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
+  const isHorizontal = direction === "row" || direction === "row-reverse";
   return (
     <Root direction={direction} {...props}>
       {options.map((option) => (
         <Item value={option.value}>
           <Stack
-            direction={direction === "row" ? "column" : "row"}
-            align={direction === "row" ? "flex-start" : "center"}
+            direction={isHorizontal ? "column" : "row"}
+            align={isHorizontal ? "flex-start" : "center"}
             p="3"
             w="full"
           >
             {option.icon && (
               <Box
-                mb={direction === "row" ? "2" : "0"}
-                mr={direction === "row" ? "0" : "4"}
-                ml={direction === "row" ? "0" : "1"}
+                mb={isHorizontal ? "2" : "0"}
+                mr={isHorizontal ? "0" : "4"}
+                ml={isHorizontal ? "0" : "1"}
               >
                 <ItemIcon {...option.icon} />
               </Box>

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -9,8 +9,7 @@ import React from "react";
 import { baseStyles } from "./RadioCards.css";
 
 type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root> &
-  Omit<TgphComponentProps<typeof Stack>, "tgphRef">;
-type RootRef = React.ElementRef<typeof RadioGroup.Root>;
+  TgphComponentProps<typeof Stack>;
 
 type RadioButtonInternalContext = {
   value?: string;
@@ -20,23 +19,20 @@ const RadioButtonContext = React.createContext<RadioButtonInternalContext>({
   value: "",
 });
 
-const Root = React.forwardRef<RootRef, RootProps>(
-  ({ value, children, onValueChange, ...props }, forwardedRef) => {
-    return (
-      <RadioButtonContext.Provider value={{ value }}>
-        <RadioGroup.Root
-          value={value}
-          onValueChange={onValueChange}
-          asChild
-          {...props}
-          ref={forwardedRef}
-        >
-          <Stack gap="1">{children}</Stack>
-        </RadioGroup.Root>
-      </RadioButtonContext.Provider>
-    );
-  },
-);
+const Root = ({ value, children, onValueChange, ...props }: RootProps) => {
+  return (
+    <RadioButtonContext.Provider value={{ value }}>
+      <RadioGroup.Root
+        value={value}
+        onValueChange={onValueChange}
+        asChild
+        {...props}
+      >
+        <Stack gap="1">{children}</Stack>
+      </RadioGroup.Root>
+    </RadioButtonContext.Provider>
+  );
+};
 
 type ItemProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Item>;
 type ItemRef = React.ElementRef<typeof RadioGroup.Item>;

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -118,7 +118,7 @@ const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
   return (
     <Root direction={direction} {...props}>
       {options.map((option) => (
-        <Item value={option.value}>
+        <Item key={option.value} value={option.value}>
           <Stack
             direction={isHorizontal ? "column" : "row"}
             align={isHorizontal ? "flex-start" : "center"}

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -114,22 +114,22 @@ type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
 };
 
 const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
-  const isHorizontal = direction === "row" || direction === "row-reverse";
+  const isGroupHorizontal = direction === "row" || direction === "row-reverse";
   return (
     <Root direction={direction} {...props}>
       {options.map((option) => (
         <Item key={option.value} value={option.value}>
           <Stack
-            direction={isHorizontal ? "column" : "row"}
-            align={isHorizontal ? "flex-start" : "center"}
+            direction={isGroupHorizontal ? "column" : "row"}
+            align={isGroupHorizontal ? "flex-start" : "center"}
             p="3"
             w="full"
           >
             {option.icon && (
               <Box
-                mb={isHorizontal ? "2" : "0"}
-                mr={isHorizontal ? "0" : "4"}
-                ml={isHorizontal ? "0" : "1"}
+                mb={isGroupHorizontal ? "2" : "0"}
+                mr={isGroupHorizontal ? "0" : "4"}
+                ml={isGroupHorizontal ? "0" : "1"}
               >
                 <ItemIcon {...option.icon} />
               </Box>

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -103,6 +103,7 @@ const ItemIcon = <T extends TgphElement>(props: ItemIconProps<T>) => {
 type DefaultIconProps = React.ComponentProps<typeof Icon>;
 
 type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
+  align?: "horizontal" | "vertical";
   options: Array<
     {
       title?: string;

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -113,7 +113,7 @@ type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
   >;
 };
 
-const Default = ({ options, ...props }: DefaultProps) => {
+const Default = ({ options, align = "horizontal", ...props }: DefaultProps) => {
   return (
     <Root {...props}>
       {options.map((option) => (

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { baseStyles } from "./RadioCards.css";
 
 type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root> &
-  TgphComponentProps<typeof Stack>;
+  Omit<TgphComponentProps<typeof Stack>, "tgphRef">;
 type RootRef = React.ElementRef<typeof RadioGroup.Root>;
 
 type RadioButtonInternalContext = {

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -113,14 +113,23 @@ type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
   >;
 };
 
-const Default = ({ options, ...props }: DefaultProps) => {
+const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
   return (
-    <Root {...props}>
+    <Root direction={direction} {...props}>
       {options.map((option) => (
         <Item value={option.value}>
-          <Stack direction="column" align="flex-start" p="3" w="full">
+          <Stack
+            direction={direction === "row" ? "column" : "row"}
+            align={direction === "row" ? "flex-start" : "center"}
+            p="3"
+            w="full"
+          >
             {option.icon && (
-              <Box mb="2">
+              <Box
+                mb={direction === "row" ? "2" : "0"}
+                mr={direction === "row" ? "0" : "4"}
+                ml={direction === "row" ? "0" : "1"}
+              >
                 <ItemIcon {...option.icon} />
               </Box>
             )}

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -8,7 +8,8 @@ import React from "react";
 
 import { baseStyles } from "./RadioCards.css";
 
-type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root>;
+type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root> &
+  TgphComponentProps<typeof Stack>;
 type RootRef = React.ElementRef<typeof RadioGroup.Root>;
 
 type RadioButtonInternalContext = {
@@ -103,7 +104,6 @@ const ItemIcon = <T extends TgphElement>(props: ItemIconProps<T>) => {
 type DefaultIconProps = React.ComponentProps<typeof Icon>;
 
 type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
-  align?: "horizontal" | "vertical";
   options: Array<
     {
       title?: string;
@@ -113,7 +113,7 @@ type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
   >;
 };
 
-const Default = ({ options, align = "horizontal", ...props }: DefaultProps) => {
+const Default = ({ options, ...props }: DefaultProps) => {
   return (
     <Root {...props}>
       {options.map((option) => (


### PR DESCRIPTION
This PR updates `RadioCards` so that:
- The `RootProps` type reflects the fact that `Stack` props can be passed in. (This allows us to set a `direction` prop on the `RadioCards` component.)
- When the `options` prop is used, the layout of rendered card items will depend upon the `direction` of the root `RadioCards` component.

## Video

https://github.com/user-attachments/assets/8b3bea65-1b57-40b6-8a8c-dc7d469e08b3
