### PR TITLE
feat(kno-6761): Add size 0 to Kbd component

### DIFF
--- a/packages/kbd/src/Kbd/Kbd.constants.ts
+++ b/packages/kbd/src/Kbd/Kbd.constants.ts
@@ -4,6 +4,19 @@ import type { Stack } from "@telegraph/layout";
 import type { Text } from "@telegraph/typography";
 
 export const sizeMap = {
+  "0": {
+    stack: {
+      minW: "4",
+      h: "4",
+    },
+    text: {
+      size: "0",
+      px: "1",
+    },
+    icon: {
+      size: "0",
+    },
+  },
   "1": {
     stack: {
       minW: "5",


### PR DESCRIPTION
### What changed?

This PR updates the `Kbd` component to support a `size` prop of `0`.

## Tasks

[KNO-6761](https://linear.app/knock/issue/KNO-6761/[telegraph]-add-size-0-kbd)

## Video

https://github.com/user-attachments/assets/a6b50db4-3cb4-468a-a59e-3d56f3d67a8b
