### PR TITLE
feat: various tooltip improvements and fixes

### DIFF
--- a/.changeset/dry-peas-travel.md
+++ b/.changeset/dry-peas-travel.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/appearance": patch
+"@telegraph/tooltip": patch
+"@telegraph/button": patch
+---
+
+support disabled state in tooltip + tooltip appearance override

--- a/packages/appearance/src/index.ts
+++ b/packages/appearance/src/index.ts
@@ -1,1 +1,6 @@
-export { useAppearance, Appearance, InvertedAppearance } from "./useAppearance";
+export {
+  useAppearance,
+  Appearance,
+  InvertedAppearance,
+  OverrideAppearance,
+} from "./useAppearance";

--- a/packages/appearance/src/useAppearance.tsx
+++ b/packages/appearance/src/useAppearance.tsx
@@ -112,6 +112,22 @@ const Appearance = ({
   return <Component {...derivedAppearanceProps} {...props} />;
 };
 
+// Helper component used to explicitly set the appearance of a component
+// used in places like the Tooltip component.
+const OverrideAppearance = ({
+  appearance,
+  asChild,
+  ...props
+}: AppearanceProps) => {
+  const { lightAppearanceProps, darkAppearanceProps } = useAppearance();
+
+  const derivedAppearanceProps =
+    appearance === "light" ? lightAppearanceProps : darkAppearanceProps;
+
+  const Component = asChild ? Slot : "div";
+  return <Component {...derivedAppearanceProps} {...props} />;
+};
+
 // Helper component to apply the inverted appearance
 const InvertedAppearance = ({
   appearance,
@@ -123,4 +139,4 @@ const InvertedAppearance = ({
   );
 };
 
-export { useAppearance, Appearance, InvertedAppearance };
+export { useAppearance, Appearance, InvertedAppearance, OverrideAppearance };

--- a/packages/button/src/Button/Button.css.ts
+++ b/packages/button/src/Button/Button.css.ts
@@ -31,7 +31,14 @@ export const baseStyles = style({
   textDecoration: "none",
   ":disabled": {
     cursor: "not-allowed",
-    pointerEvents: "none",
+  },
+  selectors: {
+    "&[data-tgph-button-state=disabled]:hover": {
+      // Revert background color on hover for disabled buttons.
+      // This ensures the button doesn't change background
+      // color when hovered over in a disabled state.
+      backgroundColor: "revert",
+    },
   },
 });
 

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -97,4 +97,12 @@ describe("Button", () => {
     expect(text).toHaveClass("text-gray-9");
     expect(icon).toHaveClass("text-gray-8");
   });
+  it("if a button set to an anchor is disabled, it turns into a button", () => {
+    const { container } = render(
+      <Button as="a" disabled>
+        Button
+      </Button>,
+    );
+    expect(container.firstChild?.nodeName).toBe("BUTTON");
+  });
 });

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -102,6 +102,12 @@ const Root = <T extends TgphElement>({
     minDurationMs: 1200,
   });
 
+  // If the button is in a disabled state, we don't want any clicks to fire.
+  // To do this reliably, we convert the element back to a button if it is
+  // disabled. We do this so we can use the native button element's disabled
+  // state to prevent clicks.
+  const derivedAs = disabled ? "button" : as;
+
   const layout = React.useMemo<InternalProps["layout"]>(() => {
     const childrenArray = React.Children.toArray(children);
     if (childrenArray?.length === 1 && React.isValidElement(childrenArray[0])) {
@@ -124,7 +130,7 @@ const Root = <T extends TgphElement>({
       value={{ variant, size, color, state, layout, active }}
     >
       <Stack
-        as={as || "button"}
+        as={derivedAs || "button"}
         className={clsx(
           baseStyles,
           variant === "solid" && solidVariant({ color }),

--- a/packages/tooltip/src/Tooltip/Tooltip.constants.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.constants.ts
@@ -1,0 +1,22 @@
+import type { OverrideAppearance } from "@telegraph/appearance";
+import type { Required, TgphComponentProps } from "@telegraph/helpers";
+import type { Stack } from "@telegraph/layout";
+
+type Appearance = Required<
+  TgphComponentProps<typeof OverrideAppearance>
+>["appearance"];
+
+// Set any appearance specifics props for the content.
+// For example, a light appearance tooltip should stand out
+// from the background of the page.
+export const TooltipContentProps: Record<
+  Appearance,
+  TgphComponentProps<typeof Stack>
+> = {
+  light: {
+    border: "px",
+    shadow: "2",
+  },
+
+  dark: {},
+};

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -27,6 +27,12 @@ const meta: Meta = {
         type: "select",
       },
     },
+    appearance: {
+      options: ["light", "dark"],
+      control: {
+        type: "select",
+      },
+    },
     enabled: {
       control: {
         type: "boolean",
@@ -38,6 +44,7 @@ const meta: Meta = {
     side: "bottom",
     align: "center",
     enabled: true,
+    appearance: "dark",
   },
 };
 
@@ -67,6 +74,46 @@ export const Group: Story = {
           </TelegraphTooltip>
           <TelegraphTooltip {...args}>
             <Button color="blue">Hover me</Button>
+          </TelegraphTooltip>
+        </TooltipGroupProvider>
+      </Stack>
+    );
+  },
+};
+
+export const DisabledButtonTrigger: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center" gap="2">
+        <TooltipGroupProvider>
+          <TelegraphTooltip {...args}>
+            <Button
+              color="blue"
+              onClick={() => console.log("clicked")}
+              disabled
+            >
+              Hover me
+            </Button>
+          </TelegraphTooltip>
+        </TooltipGroupProvider>
+      </Stack>
+    );
+  },
+};
+export const DisabledAnchorTrigger: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center" gap="2">
+        <TooltipGroupProvider>
+          <TelegraphTooltip {...args}>
+            <Button
+              as="a"
+              color="blue"
+              onClick={() => console.log("clicked")}
+              disabled
+            >
+              Hover me
+            </Button>
           </TelegraphTooltip>
         </TooltipGroupProvider>
       </Stack>


### PR DESCRIPTION
## Description
### Tooltip appearance
- Allows an `appearance` prop to be set on a tooltip with the default set to `dark`. This helps to support cases where we want to override the theme of the tooltip like in the `DateTimePopover`
- Adds an `OverrideAppearance` helper component to `@telegraph/appearance` to support this work. 
- Adds the `appearance` prop to storybook to test this behavior.

### Disabled state handling for button + tooltip
- Previously, we relied on `pointer-events: none` when `disabled` was set to block all `<Button/>` click events. This worked great for that, but not so great when we wanted things like hover events to trigger tooltips. This PR fixes this issue by removing the `pointer-events: auto` style and instead relies on the native button disabled state. For example, when passing `as={Link}` _or_ `as="a"` along with `disabled={true}`, we now override the `as` prop and replace it with `button`. This works splendidly because it still prevents clicks BUT still allows hover events for our tooltips.
- The tooltip now detects if there the children within it are disabled, and if so changes the delay to 0. This helps to better support the pattern throughout control of letting the user know why a button is disabled. 
- Adds disabled button + tooltip examples to storybook to test this behavior. Also, adds a test in `Button` to ensure that a disabled `as="a"` gets transformed into a button.

### Misc
- Lowers the default delay duration for tooltips to 400ms as the previous time set (600ms) felt too slow.

## Tasks
- [KNO-7085](https://linear.app/knock/issue/KNO-7085/[telegraph]-adjust-tooltip-delay-duration-timing) 
- [KNO-6986 ](https://linear.app/knock/issue/KNO-6986/[telegraph]-button-used-as-link-disabled-state-broken)
- [KNO-7008 ](https://linear.app/knock/issue/KNO-7008/[telegraph]-improve-tooltip-disabled-state-interaction)
- [KNO-7116](https://linear.app/knock/issue/KNO-7116/[telegraph]-allow-theme-to-be-passed-to-tooltip)