### PR TITLE
fix: only render children when Tooltip is disabled

### DIFF
--- a/.changeset/rude-lions-fly.md
+++ b/.changeset/rude-lions-fly.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/tooltip": patch
+---
+
+fix: only render children when Tooltip is disabled

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -183,7 +183,7 @@ const Tooltip = <T extends TgphElement>({
     );
   }
 
-  return <span>{children}</span>;
+  return <>{children}</>;
 };
 
 export { Tooltip };


### PR DESCRIPTION
Removes the extra span from the disabled tooltip. Seems to be causing minor layout changes when the tooltip was enabled/disabled with the following markup:

```
<Stack>
  <Button />
  <Tooltip enabled={isEnabled} label={...}>
    <Button />
  </Tooltip>
</Stack>
```
When disabled, the span was adding 2px around the right button. Cannot track down why that is (there's no border, etc. - the span shouldn't be affecting anything), but I think not adding the extra span is cleaner regardless.
![CleanShot 2024-10-16 at 05 25 49](https://github.com/user-attachments/assets/a401ecbf-bbbe-4fb1-9070-f25b7d7af8eb)
