### PR TITLE
fix(KNO-7179): radio card keyboard interactions

### DIFF
--- a/.changeset/flat-gifts-compare.md
+++ b/.changeset/flat-gifts-compare.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/radio": patch
+---
+
+Fix radio card keyboard interactions

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -1,6 +1,10 @@
 import * as RadioGroup from "@radix-ui/react-radio-group";
 import { Button } from "@telegraph/button";
-import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
+import {
+  RefToTgphRef,
+  type TgphComponentProps,
+  type TgphElement,
+} from "@telegraph/helpers";
 import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
 import clsx from "clsx";
@@ -28,7 +32,9 @@ const Root = ({ value, children, onValueChange, ...props }: RootProps) => {
         asChild
         {...props}
       >
-        <Stack gap="1">{children}</Stack>
+        <RefToTgphRef>
+          <Stack gap="1">{children}</Stack>
+        </RefToTgphRef>
       </RadioGroup.Root>
     </RadioButtonContext.Provider>
   );
@@ -43,17 +49,19 @@ const Item = React.forwardRef<ItemRef, ItemProps>(
     return (
       <>
         <RadioGroup.Item {...props} ref={forwardedRef} asChild>
-          <Button.Root
-            variant="outline"
-            active={props.value === contextValue}
-            className={clsx(className, baseStyles)}
-            h="full"
-            w="full"
-            px="0"
-            py="0"
-          >
-            {children}
-          </Button.Root>
+          <RefToTgphRef>
+            <Button.Root
+              variant="outline"
+              active={props.value === contextValue}
+              className={clsx(className, baseStyles)}
+              h="full"
+              w="full"
+              px="0"
+              py="0"
+            >
+              {children}
+            </Button.Root>
+          </RefToTgphRef>
         </RadioGroup.Item>
       </>
     );


### PR DESCRIPTION
This PR fixes keyboard control of radio card components, namely the ability to use the left and right arrow keys (or up and down arrow keys) to change which radio item within a group is focused and checked. See [the Keyboard Interaction section of the Radio Group Pattern page in the ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/radio/).

As per [Radix’s _Composition_ docs](https://www.radix-ui.com/primitives/docs/guides/composition#your-component-must-forward-ref), when the `asChild` prop is used, children of `RadioGroup.Root` and `RadioGroup.Item` must accept a ref. Telegraph components use `tgphRef` rather than `ref`, so we simply need to wrap the child components in `<RefToTgphRef>` to apply the forwarded ref to `tgphRef`.

## Tasks

[KNO-7179](https://linear.app/knock/issue/KNO-7179/[telegraph]-radio-cards-do-not-conform-to-expected-keyboard-controls)

