### PR TITLE
feat: textarea component

### DIFF
--- a/.changeset/afraid-jeans-occur.md
+++ b/.changeset/afraid-jeans-occur.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/textarea": patch
+---
+
+first iteration of TextArea component

--- a/packages/textarea/.eslintrc.js
+++ b/packages/textarea/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -1,0 +1,17 @@
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/textarea)
+
+# @telegraph/textarea
+> A multi-line user input.
+
+## Installation Instructions
+
+```
+npm install @telegraph/textarea
+```
+
+### Add stylesheet
+```
+@import "@telegraph/textarea"
+```

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -46,9 +46,9 @@
     "@types/react": "^18.2.48",
     "eslint": "^8.56.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.3.3",
-    "vite": "^5.2.12"
+    "react-dom": "^18.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.3.6"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@telegraph/textarea",
+  "version": "0.0.0",
+  "description": "A multi-line user input.",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/textarea",
+  "author": "@knocklabs",
+  "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/css/default.css"
+    },
+    "./default.css": "./dist/css/default.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "prettier": "@telegraph/prettier-config",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch --emptyOutDir false",
+    "build": "yarn clean && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
+    "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@telegraph/layout": "workspace:^",
+    "@telegraph/style-engine": "workspace:^",
+    "clsx": "^2.1.1"
+  },
+  "devDependencies": {
+    "@knocklabs/eslint-config": "^0.0.3",
+    "@knocklabs/typescript-config": "^0.0.2",
+    "@telegraph/helpers": "workspace:^",
+    "@telegraph/postcss-config": "workspace:^",
+    "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/vite-config": "workspace:^",
+    "@types/react": "^18.2.48",
+    "eslint": "^8.56.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.12"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/textarea/postcss.config.mjs
+++ b/packages/textarea/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pkg from "@telegraph/postcss-config";
+
+const { styleEnginePostCssConfig } = pkg;
+
+export default styleEnginePostCssConfig;

--- a/packages/textarea/src/TextArea/TextArea.constants.ts
+++ b/packages/textarea/src/TextArea/TextArea.constants.ts
@@ -1,0 +1,53 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import type { Box } from "@telegraph/layout";
+
+export type Size = "1" | "2" | "3";
+export type Variant = "outline" | "ghost";
+export type State = "default" | "disabled" | "error";
+
+type SizeMap = {
+  [key in Size]: TgphComponentProps<typeof Box>;
+};
+
+type VariantMap = {
+  [key in Variant]: TgphComponentProps<typeof Box>;
+};
+
+type StateMap = {
+  [key in State]: TgphComponentProps<typeof Box>;
+};
+
+export const sizeMap: SizeMap = {
+  "1": {
+    p: "1",
+  },
+  "2": {
+    px: "2",
+    py: "1",
+  },
+  "3": {
+    px: "3",
+    py: "2",
+  },
+};
+
+export const variantMap: VariantMap = {
+  outline: {
+    border: "px",
+  },
+  ghost: {
+    border: "px",
+    borderColor: "transparent",
+  },
+};
+
+export const stateMap: StateMap = {
+  default: {},
+  disabled: {
+    bg: "gray-2",
+    borderColor: "gray-2",
+  },
+  error: {
+    borderColor: "red-6",
+  },
+};

--- a/packages/textarea/src/TextArea/TextArea.css.ts
+++ b/packages/textarea/src/TextArea/TextArea.css.ts
@@ -1,0 +1,80 @@
+import { style, variant } from "@telegraph/style-engine";
+
+export const baseStyles = style({
+  appearance: "none",
+  color: "var(--tgph-gray-12)",
+  fontFamily: "var(--tgph-font-sans)",
+  transition: "border-color 0.15s cubic-bezier(0.4, 0, 0.2, 1)",
+  ":hover": {
+    borderColor: "var(--tgph-gray-7)",
+  },
+  ":focus": {
+    borderColor: "var(--tgph-blue-8)",
+    outline: "none",
+  },
+  "::placeholder": {
+    color: "var(--tgph-gray-10)",
+  },
+});
+
+export const variants = variant({
+  variants: {
+    size: {
+      "1": {
+        fontSize: "var(--tgph-text-1)",
+        lineHeight: "var(--tgph-leading-1)",
+        letterSpacing: "var(--tgph-tracking-1)",
+      },
+      "2": {
+        fontSize: "var(--tgph-text-2)",
+        lineHeight: "var(--tgph-leading-2)",
+        letterSpacing: "var(--tgph-tracking-2)",
+      },
+      "3": {
+        fontSize: "var(--tgph-text-3)",
+        lineHeight: "var(--tgph-leading-3)",
+        letterSpacing: "var(--tgph-tracking-3)",
+      },
+    },
+    state: {
+      default: {},
+      disabled: {
+        cursor: "not-allowed",
+        ":hover": {
+          borderColor: "var(--tgph-gray-2)",
+        },
+        ":focus": {
+          borderColor: "var(--tgph-gray-2)",
+        },
+      },
+      error: {
+        ":hover": {
+          borderColor: "var(--tgph-red-6)",
+        },
+        ":focus": {
+          borderColor: "var(--tgph-red-8)",
+        },
+      },
+    },
+    resize: {
+      both: {
+        resize: "both",
+      },
+      vertical: {
+        resize: "vertical",
+      },
+      horizontal: {
+        resize: "horizontal",
+      },
+      none: {
+        resize: "none",
+      },
+    },
+    variant: {
+      outline: {},
+      ghost: {
+        resize: "none",
+      },
+    },
+  },
+});

--- a/packages/textarea/src/TextArea/TextArea.stories.tsx
+++ b/packages/textarea/src/TextArea/TextArea.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Stack } from "@telegraph/layout";
+
+import { TextArea } from "./TextArea";
+import { sizeMap } from "./TextArea.constants";
+
+const meta = {
+  title: "Components/TextArea",
+  component: TextArea,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TextArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  argTypes: {
+    size: {
+      options: Object.keys(sizeMap),
+      control: {
+        type: "select",
+      },
+    },
+    resize: {
+      options: ["both", "vertical", "horizontal", "none"],
+      control: {
+        type: "select",
+      },
+    },
+    variant: {
+      options: ["outline", "ghost"],
+      control: {
+        type: "select",
+      },
+    },
+    disabled: {
+      control: {
+        type: "boolean",
+      },
+    },
+    errored: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+  args: {
+    size: "2",
+    variant: "outline",
+    value: "",
+    placeholder: "Enter text here...",
+    disabled: false,
+    errored: false,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <Stack direction="column" gap="4">
+      <TextArea size="1" placeholder="Size 1" />
+      <TextArea size="2" placeholder="Size 2" />
+      <TextArea size="3" placeholder="Size 3" />
+    </Stack>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <Stack direction="column" gap="4">
+      <TextArea variant="outline" placeholder="Outline variant" />
+      <TextArea variant="ghost" placeholder="Ghost variant" />
+    </Stack>
+  ),
+};
+
+export const States: Story = {
+  render: () => (
+    <Stack direction="column" gap="4">
+      <TextArea placeholder="Default state" />
+      <TextArea placeholder="Disabled state" disabled />
+      <TextArea placeholder="Error state" errored />
+    </Stack>
+  ),
+};

--- a/packages/textarea/src/TextArea/TextArea.tsx
+++ b/packages/textarea/src/TextArea/TextArea.tsx
@@ -1,0 +1,66 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import { Box } from "@telegraph/layout";
+import { clsx } from "clsx";
+import React from "react";
+
+import {
+  type Size,
+  type State,
+  type Variant,
+  sizeMap,
+  stateMap,
+  variantMap,
+} from "./TextArea.constants";
+import { baseStyles, variants } from "./TextArea.css";
+
+const deriveState = ({ disabled, errored }: TextAreaBaseProps): State => {
+  if (disabled) return "disabled";
+  if (errored) return "error";
+  return "default";
+};
+
+type TextAreaBaseProps = {
+  size?: Size;
+  variant?: Variant;
+  errored?: boolean;
+  disabled?: boolean;
+  resize?: "both" | "vertical" | "horizontal" | "none";
+};
+
+type TextAreaProps = TextAreaBaseProps &
+  TgphComponentProps<typeof Box> &
+  React.ComponentPropsWithoutRef<"textarea">;
+
+const TextArea = ({
+  size = "2",
+  variant = "outline",
+  rounded = "2",
+  resize = "both",
+  disabled,
+  errored,
+  className,
+  ...props
+}: TextAreaProps) => {
+  const derivedState = deriveState({ disabled, errored });
+
+  return (
+    <Box
+      as="textarea"
+      className={clsx(
+        baseStyles,
+        variants({ variant, size, resize, state: derivedState }),
+        className,
+      )}
+      rounded={rounded}
+      disabled={disabled}
+      {...sizeMap[size]}
+      {...variantMap[variant]}
+      {...stateMap[derivedState]}
+      {...props}
+    />
+  );
+};
+
+type TextAreaExportedProps = TgphComponentProps<typeof TextArea>;
+
+export { TextArea, type TextAreaExportedProps as TextAreaProps };

--- a/packages/textarea/src/TextArea/index.ts
+++ b/packages/textarea/src/TextArea/index.ts
@@ -1,0 +1,1 @@
+export { TextArea, type TextAreaProps } from "./TextArea";

--- a/packages/textarea/src/index.ts
+++ b/packages/textarea/src/index.ts
@@ -1,0 +1,1 @@
+export { TextArea, type TextAreaProps } from "./TextArea";

--- a/packages/textarea/tsconfig.json
+++ b/packages/textarea/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/textarea",
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {
+      "vitest.*": ["../../vitest/*"]
+    },
+    "types": ["@testing-library/jest-dom", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/textarea/vite.config.mts
+++ b/packages/textarea/vite.config.mts
@@ -1,0 +1,7 @@
+import {
+  defaultViteConfig,
+  styleEngineViteConfig,
+} from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, styleEngineViteConfig);

--- a/packages/textarea/vitest.config.mts
+++ b/packages/textarea/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "textarea",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7035,6 +7035,30 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@telegraph/textarea@workspace:packages/textarea":
+  version: 0.0.0-use.local
+  resolution: "@telegraph/textarea@workspace:packages/textarea"
+  dependencies:
+    "@knocklabs/eslint-config": "npm:^0.0.3"
+    "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/helpers": "workspace:^"
+    "@telegraph/layout": "workspace:^"
+    "@telegraph/postcss-config": "workspace:^"
+    "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/vite-config": "workspace:^"
+    "@types/react": "npm:^18.2.48"
+    clsx: "npm:^2.1.1"
+    eslint: "npm:^8.56.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.3.3"
+    vite: "npm:^5.2.12"
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@telegraph/tokens@workspace:^, @telegraph/tokens@workspace:packages/tokens":
   version: 0.0.0-use.local
   resolution: "@telegraph/tokens@workspace:packages/tokens"
@@ -15579,7 +15603,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
+"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -17765,6 +17789,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.3.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -17782,6 +17816,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=d69c25"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 
@@ -18291,6 +18335,49 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/3ed576d18c6c008ae92be68f9c79bf7556dae10978a3e8b4c4b42199424755e5c99836e6d4f81fb8b533b957d7f4e351abc60b8a93f4c4b5eb9890b5b6450926
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.2.12":
+  version: 5.4.10
+  resolution: "vite@npm:5.4.10"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/4ef4807d2fd166a920de244dbcec791ba8a903b017a7d8e9f9b4ac40d23f8152c1100610583d08f542b47ca617a0505cfc5f8407377d610599d58296996691ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7045,6 +7045,7 @@ __metadata:
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/style-engine": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^18.2.48"
     clsx: "npm:^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7051,9 +7051,9 @@ __metadata:
     clsx: "npm:^2.1.1"
     eslint: "npm:^8.56.0"
     react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
-    typescript: "npm:^5.3.3"
-    vite: "npm:^5.2.12"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:^5.5.4"
+    vite: "npm:^5.3.6"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -15604,7 +15604,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
+"react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -17790,16 +17790,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -17817,16 +17807,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=d69c25"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 
@@ -18336,49 +18316,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/3ed576d18c6c008ae92be68f9c79bf7556dae10978a3e8b4c4b42199424755e5c99836e6d4f81fb8b533b957d7f4e351abc60b8a93f4c4b5eb9890b5b6450926
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.2.12":
-  version: 5.4.10
-  resolution: "vite@npm:5.4.10"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.43"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/4ef4807d2fd166a920de244dbcec791ba8a903b017a7d8e9f9b4ac40d23f8152c1100610583d08f542b47ca617a0505cfc5f8407377d610599d58296996691ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description 
- Adds `<TextArea/>` component based on the [figma doc](https://www.figma.com/design/br4Lk9C5qw3UVyGsAbONDY/Telegraph-design-system?node-id=893-1686&m=dev)
  - Utilizes `@telegraph/style-engine` and `<Box/>` for styling
  - Exports `<TextArea/>` props via `TextAreaProps` 

### Tasks
[KNO-6105](https://linear.app/knock/issue/KNO-6105/[telegraph]-text-area-component)