### PR TITLE
fix: close combobox without closing parent

### DIFF
--- a/.changeset/sharp-mirrors-watch.md
+++ b/.changeset/sharp-mirrors-watch.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": patch
+---
+
+fix combobox escape key interactions

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -32,6 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dismissable-layer": "^1.1.1",
     "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@telegraph/button": "workspace:^",

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@telegraph/button";
 import type { TgphComponentProps } from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
+import { Modal } from "@telegraph/modal";
 import React from "react";
 
 import { Combobox as TelegraphCombobox } from "../Combobox";
@@ -221,6 +223,65 @@ export const MultiSelectWithClear: Story = {
           </TelegraphCombobox.Content>
         </TelegraphCombobox.Root>
       </Box>
+    );
+  },
+};
+
+export const ComboboxInModal: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = React.useState([firstValue]);
+    // eslint-disable-next-line
+    const [open, setOpen] = React.useState(false);
+    return (
+      <>
+        <Button size="1" variant="outline" onClick={() => setOpen(true)}>
+          Open modal
+        </Button>
+        <Modal.Root
+          a11yTitle="Combobox in modal"
+          open={open}
+          onOpenChange={setOpen}
+        >
+          <Modal.Content>
+            <Modal.Header>
+              <div />
+              <Modal.Close />
+            </Modal.Header>
+            <Modal.Body>
+              <TelegraphCombobox.Root
+                {...args}
+                value={value}
+                onValueChange={setValue}
+                placeholder={"Select a channel"}
+                layout="wrap"
+                closeOnSelect={false}
+                clearable
+              >
+                <TelegraphCombobox.Trigger />
+                <TelegraphCombobox.Content>
+                  <TelegraphCombobox.Search />
+                  <TelegraphCombobox.Options>
+                    {values.map((v) => (
+                      <TelegraphCombobox.Option
+                        value={v.value}
+                        label={v.label}
+                      />
+                    ))}
+                    <TelegraphCombobox.Create
+                      values={values}
+                      onCreate={(createdValue) => {
+                        values.push(createdValue);
+                        setValue((prevValue) => [createdValue, ...prevValue]);
+                      }}
+                    />
+                  </TelegraphCombobox.Options>
+                </TelegraphCombobox.Content>
+              </TelegraphCombobox.Root>
+            </Modal.Body>
+          </Modal.Content>
+        </Modal.Root>
+      </>
     );
   },
 };

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1,3 +1,4 @@
+import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button as TelegraphButton } from "@telegraph/button";
@@ -503,85 +504,92 @@ const Content = <T extends TgphElement>({
   }, [context.open, initialAnimationComplete]);
 
   return (
-    <TelegraphMenu.Content
-      as={motion.div}
-      mt="1"
-      initial={{
-        opacity: 0,
-        scale: 0.8,
-        height: "auto",
-      }}
-      animate={{
-        opacity: 1,
-        scale: 1,
-        // Set height based on the internalContentRef so that
-        // we get smooth animations when the content changes
-        minHeight: height ? `${height}px` : "0",
-      }}
-      exit={{ opacity: 0, scale: 0 }}
-      transition={{ duration: 0.2, type: "spring", bounce: 0 }}
-      onAnimationComplete={() => {
-        // Set height when the initial animation for
-        // displaying the content completes
-        if (!initialAnimationComplete && internalContentRef) {
-          const element = internalContentRef.current as unknown as Element;
-          setHeightFromContent(element);
-        }
-      }}
-      onCloseAutoFocus={(event: Event) => {
-        if (!hasInteractedOutside.current) context.triggerRef?.current?.focus();
-        hasInteractedOutside.current = false;
-
-        event.preventDefault();
-      }}
-      onKeyDown={(event: React.KeyboardEvent) => {
-        // If the first option is focused and the user presses the up
-        // arrow key, focus the search input
-        const options = context.contentRef?.current?.querySelectorAll(
-          "[data-tgph-combobox-option]",
-        );
-
-        if (
-          document.activeElement === options?.[0] &&
-          LAST_KEYS.includes(event.key)
-        ) {
-          context.searchRef?.current?.focus();
-        }
-
-        // Close the combobox if the user presses the escape key
-        if (event.key === "Escape") {
+    // We add radix's dismissable layer here so that we can swallow any escape key
+    // presses to prevent cases like a modal closing when we close the combobox
+    <DismissableLayer
+      onEscapeKeyDown={(event) => {
+        if (context.open) {
+          event.preventDefault();
           context.setOpen(false);
         }
-
-        event.stopPropagation();
       }}
-      bg="surface-1"
-      style={{
-        width: "var(--tgph-comobobox-trigger-width)",
-        ...style,
-        ...{
-          "--tgph-comobobox-content-transform-origin":
-            "var(--radix-popper-transform-origin)",
-          "--tgph-combobox-content-available-width":
-            "var(--radix-popper-available-width)",
-          "--tgph-combobox-content-available-height":
-            "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
-          "--tgph-comobobox-trigger-width": "var(--radix-popper-anchor-width)",
-          "--tgph-combobox-trigger-height": "var(--radix-popper-anchor-height)",
-        },
-      }}
-      {...props}
-      tgphRef={composedRef}
-      data-tgph-combobox-content
-      data-tgph-combobox-content-open={initialAnimationComplete}
-      // Cancel out accessibility attirbutes related to aria menu
-      role={undefined}
-      aria-orientation={undefined}
     >
-      <Stack direction="column" gap="1" tgphRef={internalContentRef}>
-        {children}
-      </Stack>
-    </TelegraphMenu.Content>
+      <TelegraphMenu.Content
+        as={motion.div}
+        mt="1"
+        initial={{
+          opacity: 0,
+          scale: 0.8,
+          height: "auto",
+        }}
+        animate={{
+          opacity: 1,
+          scale: 1,
+          // Set height based on the internalContentRef so that
+          // we get smooth animations when the content changes
+          minHeight: height ? `${height}px` : "0",
+        }}
+        exit={{ opacity: 0, scale: 0 }}
+        transition={{ duration: 0.2, type: "spring", bounce: 0 }}
+        onAnimationComplete={() => {
+          // Set height when the initial animation for
+          // displaying the content completes
+          if (!initialAnimationComplete && internalContentRef) {
+            const element = internalContentRef.current as unknown as Element;
+            setHeightFromContent(element);
+          }
+        }}
+        onCloseAutoFocus={(event: Event) => {
+          if (!hasInteractedOutside.current)
+            context.triggerRef?.current?.focus();
+          hasInteractedOutside.current = false;
+
+          event.preventDefault();
+        }}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          // If the first option is focused and the user presses the up
+          // arrow key, focus the search input
+          const options = context.contentRef?.current?.querySelectorAll(
+            "[data-tgph-combobox-option]",
+          );
+
+          if (
+            document.activeElement === options?.[0] &&
+            LAST_KEYS.includes(event.key)
+          ) {
+            context.searchRef?.current?.focus();
+          }
+        }}
+        bg="surface-1"
+        style={{
+          width: "var(--tgph-comobobox-trigger-width)",
+          ...style,
+          ...{
+            "--tgph-comobobox-content-transform-origin":
+              "var(--radix-popper-transform-origin)",
+            "--tgph-combobox-content-available-width":
+              "var(--radix-popper-available-width)",
+            "--tgph-combobox-content-available-height":
+              "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
+            "--tgph-comobobox-trigger-width":
+              "var(--radix-popper-anchor-width)",
+            "--tgph-combobox-trigger-height":
+              "var(--radix-popper-anchor-height)",
+          },
+        }}
+        {...props}
+        tgphRef={composedRef}
+        data-tgph-combobox-content
+        data-tgph-combobox-content-open={initialAnimationComplete}
+        // Cancel out accessibility attirbutes related to aria menu
+        role={undefined}
+        aria-orientation={undefined}
+      >
+        <Stack direction="column" gap="1" tgphRef={internalContentRef}>
+          {children}
+        </Stack>
+      </TelegraphMenu.Content>
+    </DismissableLayer>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4148,6 +4148,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dismissable-layer@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.0"
+    "@radix-ui/react-use-escape-keydown": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/637f8d55437bd2269d5aa9fa48e869eade31082cd950b5efcc5f0d9ed016b46feb7fcfcc115ba9972dba68c4686b57873d84aca67ece76ab77463e7de995f6da
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-focus-guards@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-focus-guards@npm:1.0.1"
@@ -6609,6 +6632,7 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@radix-ui/react-dismissable-layer": "npm:^1.1.1"
     "@radix-ui/react-use-controllable-state": "npm:^1.1.0"
     "@radix-ui/react-visually-hidden": "npm:^1.1.0"
     "@telegraph/button": "workspace:^"


### PR DESCRIPTION
### Description
- Wraps `<Combobox.Content/>` in radix's `<DismissableLayer/>` so that "Escape" key presses are swallowed by the `<DissmissableLayer/>` as to not bubble up to the `<Combobox/>` parent. This prevents instances when a user is in a `<Modal/>` pressing "Escape" to close the `<Combobox/>` and it instead closes the `<Modal/>`

### Tasks
[KNO-7063](https://linear.app/knock/issue/KNO-7063/[telegraph]-cant-get-out-of-combobox-dropdown-w-keyboard)