### PR TITLE
feat: add autodocs to storybook components

### DIFF
--- a/packages/button/src/Button/Button.stories.tsx
+++ b/packages/button/src/Button/Button.stories.tsx
@@ -21,6 +21,7 @@ const Icons = { ...Lucide };
 const meta: Meta<typeof TelegraphButton> = {
   title: "Components/Button",
   component: TelegraphButton,
+  tags: ["autodocs"],
   argTypes: {
     color: {
       options: buttonColorMap,

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -8,6 +8,7 @@ import React from "react";
 import { Combobox as TelegraphCombobox } from "../Combobox";
 
 const meta: Meta = {
+  tags: ["autodocs"],
   title: "Components/Combobox",
   component: TelegraphCombobox.Root,
   argTypes: {},

--- a/packages/icon/src/Icon/Icon.stories.tsx
+++ b/packages/icon/src/Icon/Icon.stories.tsx
@@ -7,9 +7,31 @@ import { colorMap, sizeMap } from "./Icon.constants";
 
 const Icons = { ...Lucide };
 
+type StorybookTelegraphIconType = React.ComponentProps<typeof TelegraphIcon>;
+
+const StorybookTelegraphIcon = ({
+  icon,
+  ...props
+}: StorybookTelegraphIconType) => {
+  return (
+    <TelegraphIcon
+      // @ts-expect-error: for illustrative purposes only
+      icon={Icons[icon as keyof typeof Icons]}
+      {...props}
+      alt="test"
+    />
+  );
+};
+
 const meta: Meta<typeof TelegraphIcon> = {
-  title: "Components",
-  component: TelegraphIcon,
+  tags: ["autodocs"],
+  title: "Components/Icon",
+  component: StorybookTelegraphIcon,
+};
+
+export default meta;
+
+export const Default: Story = {
   argTypes: {
     icon: {
       options: Object.keys(Icons),
@@ -39,11 +61,11 @@ const meta: Meta<typeof TelegraphIcon> = {
   args: {
     color: "default",
     size: "3",
+    icon: "Bell",
+    alt: "Bell",
     variant: "primary",
   },
 };
-
-export default meta;
 
 type StorybookIconType = Omit<
   React.ComponentProps<typeof TelegraphIcon>,
@@ -53,15 +75,3 @@ type StorybookIconType = Omit<
 };
 
 type Story = StoryObj<StorybookIconType>;
-
-export const Icon: Story = {
-  render: ({ icon, ...props }) => (
-    <TelegraphIcon
-      // @ts-expect-error: for illustrative purposes only
-      icon={Icons[icon as keyof typeof Icons]}
-      {...props}
-      alt="test"
-    />
-  ),
-  args: { icon: "Bell" },
-};

--- a/packages/input/src/Input/Input.stories.tsx
+++ b/packages/input/src/Input/Input.stories.tsx
@@ -8,6 +8,7 @@ import { COLOR, SIZE } from "./Input.constants";
 const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphInput> = {
+  tags: ["autodocs"],
   title: "Components/Input",
   component: TelegraphInput,
   argTypes: {

--- a/packages/kbd/src/Kbd/Kbd.stories.tsx
+++ b/packages/kbd/src/Kbd/Kbd.stories.tsx
@@ -7,6 +7,7 @@ import { sizeMap } from "./Kbd.constants";
 import { KbdProvider } from "./Kbd.hooks";
 
 const meta: Meta = {
+  tags: ["autodocs"],
   title: "Components/Kbd",
   component: TelegraphKbd,
   argTypes: {

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -7,6 +7,7 @@ import { Stack } from "@telegraph/layout";
 import { Menu as TelegraphMenu } from "./Menu";
 
 const meta: Meta = {
+  tags: ["autodocs"],
   title: "Components/Menu",
   component: TelegraphMenu.Root,
   argTypes: {

--- a/packages/menu/src/MenuItem/MenuItem.stories.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.stories.tsx
@@ -5,6 +5,7 @@ import { Lucide } from "@telegraph/icon";
 import { MenuItem as TelegraphMenuItem } from "./MenuItem";
 
 const meta: Meta = {
+  tags: ["autodocs"],
   title: "Components/Menu/MenuItem",
   component: TelegraphMenuItem,
   argTypes: {

--- a/packages/modal/src/Modal/Modal.stories.tsx
+++ b/packages/modal/src/Modal/Modal.stories.tsx
@@ -8,6 +8,22 @@ import { Modal as TelegraphModal } from "./Modal";
 const meta: Meta<typeof TelegraphModal.Root> = {
   title: "Components/Modal",
   component: TelegraphModal.Root,
+  tags: ["autodocs"],
+  argTypes: {
+    open: {
+      control: {
+        type: "boolean",
+      },
+    },
+    onOpenChange: {
+      control: {
+        type: "function",
+      },
+    },
+  },
+  args: {
+    open: true,
+  },
 };
 
 export default meta;
@@ -18,28 +34,29 @@ export const Modal: Story = {
   render: () => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [open, setOpen] = React.useState(true);
+    const Modal = TelegraphModal;
     return (
       <>
         <Button onClick={() => setOpen(true)}>Open Modal</Button>
-        <TelegraphModal.Root open={open} onOpenChange={setOpen}>
-          <TelegraphModal.Content>
-            <TelegraphModal.Header>
+        <Modal.Root open={open} onOpenChange={setOpen} a11yTitle="Modal title">
+          <Modal.Content>
+            <Modal.Header>
               <Heading as="h2" size="3">
                 Modal title
               </Heading>
-              <TelegraphModal.Close />
-            </TelegraphModal.Header>
-            <TelegraphModal.Body>Modal body</TelegraphModal.Body>
-            <TelegraphModal.Footer>
+              <Modal.Close />
+            </Modal.Header>
+            <Modal.Body>Modal body</Modal.Body>
+            <Modal.Footer>
               <Button variant="outline" size="1">
                 Cancel
               </Button>
               <Button color="accent" size="1">
                 Save
               </Button>
-            </TelegraphModal.Footer>
-          </TelegraphModal.Content>
-        </TelegraphModal.Root>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal.Root>
       </>
     );
   },

--- a/packages/popover/src/Popover/Popover.stories.tsx
+++ b/packages/popover/src/Popover/Popover.stories.tsx
@@ -7,6 +7,7 @@ import { Stack } from "@telegraph/layout";
 import { Popover } from "./Popover";
 
 const meta: Meta = {
+  tags: ["autodocs"],
   title: "Components/Popover",
   component: Popover.Root,
   argTypes: {

--- a/packages/radio/src/RadioCards/RadioCards.stories.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.stories.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import { RadioCards as TelegraphRadioCards } from "./RadioCards";
 
 const meta: Meta<typeof TelegraphRadioCards> = {
+  tags: ["autodocs"],
   title: "Components/RadioCards",
   component: TelegraphRadioCards,
   argTypes: {

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -8,6 +8,7 @@ import { SegmentedControl as TelegraphSegmentedControl } from "./SegmentedContro
 const meta: Meta<typeof TelegraphSegmentedControl> = {
   title: "Components/SegmentedControl",
   component: TelegraphSegmentedControl.Root,
+  tags: ["autodocs"],
 };
 
 type Story = StoryObj<typeof TelegraphSegmentedControl.Root>;

--- a/packages/tag/src/Tag/Tag.stories.tsx
+++ b/packages/tag/src/Tag/Tag.stories.tsx
@@ -7,7 +7,8 @@ import { COLOR, SIZE } from "./Tag.constants";
 const Icons = { ...Lucide };
 
 const meta: Meta<typeof TelegraphTag> = {
-  title: "Components",
+  tags: ["autodocs"],
+  title: "Components/Tag",
   component: TelegraphTag,
   argTypes: {
     size: {

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -9,6 +9,7 @@ import { TooltipGroupProvider } from "./Tooltip.hooks";
 const meta: Meta = {
   title: "Components/Tooltip",
   component: TelegraphTooltip,
+  tags: ["autodocs"],
   argTypes: {
     label: {
       control: {


### PR DESCRIPTION
### Description
- Adds autodocs tag to every `.stories` file in the repo
- Small updates to get the code formatting in `.stories` to work correctly.

### Tasks
[KNO-7237](https://linear.app/knock/issue/KNO-7237/[telegraph]-add-auto-docs-similar-structure-as-text-area-to-all)