### PR TITLE
feat: select component

### DIFF
--- a/.changeset/mean-roses-type.md
+++ b/.changeset/mean-roses-type.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/select": patch
+---
+
+new select component + combobox fixes

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -1,4 +1,4 @@
-export type DefinedOption = { value: string; label?: string };
+export type DefinedOption = { value: string; label?: string | React.ReactNode };
 export type Option = DefinedOption | undefined;
 export const isMultiSelect = (
   value: Option | Array<Option>,

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -156,6 +156,14 @@ describe("Combobox", () => {
       await user.click(clearButton!);
       expect(trigger?.textContent).toBe("");
     });
+    it("should not be able to open when disabled", async () => {
+      const user = userEvent.setup();
+      const { container } = render(<ComboboxSingleSelect disabled />);
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+      await user.click(trigger!);
+      await waitFor(() => trigger?.getAttribute("aria-expanded") === "false");
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+    });
   });
   describe("Multi Select", () => {
     it("combobox is accessible", async () => {

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -56,6 +56,7 @@ type RootProps<O extends Option | Array<Option>> = {
   modal?: boolean;
   closeOnSelect?: boolean;
   clearable?: boolean;
+  disabled?: boolean;
   children?: React.ReactNode;
 };
 
@@ -81,12 +82,14 @@ const ComboboxContext = React.createContext<
   setOpen: () => {},
   onOpenToggle: () => {},
   clearable: false,
+  disabled: false,
 });
 
 const Root = <O extends Option | Array<Option>>({
   modal = true,
   closeOnSelect = true,
   clearable = false,
+  disabled = false,
   open: openProp,
   onOpenChange: onOpenChangeProp,
   defaultOpen: defaultOpenProp,
@@ -138,6 +141,7 @@ const Root = <O extends Option | Array<Option>>({
         onOpenToggle,
         closeOnSelect,
         clearable,
+        disabled,
         searchQuery,
         setSearchQuery,
         triggerRef,
@@ -401,6 +405,7 @@ const Trigger = ({ size = "2", ...props }: TriggerProps) => {
         // Custom attributes
         data-tgph-combobox-trigger
         data-tgph-comobox-trigger-open={context.open}
+        disabled={context.disabled}
       >
         <TriggerValue />
         <Stack align="center" gap="1">

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -40,18 +40,14 @@ type MultiSelect = {
   onValueChange?: (value: Array<Option>) => void;
 };
 
-type RootProps = (
-  | {
-      value?: MultiSelect["value"];
-      onValueChange?: MultiSelect["onValueChange"];
-      layout?: "truncate" | "wrap";
-    }
-  | {
-      value?: SingleSelect["value"];
-      onValueChange?: SingleSelect["onValueChange"];
-      layout?: never;
-    }
-) & {
+type LayoutValue<O extends Option | Array<Option>> = O extends Option
+  ? never
+  : "truncate" | "wrap";
+
+type RootProps<O extends Option | Array<Option>> = {
+  value?: O;
+  onValueChange?: (value: O) => void;
+  layout?: LayoutValue<O>;
   open?: boolean;
   defaultOpen?: boolean;
   errored?: boolean;
@@ -64,7 +60,7 @@ type RootProps = (
 };
 
 const ComboboxContext = React.createContext<
-  Omit<RootProps, "children"> & {
+  Omit<RootProps<Option | Array<Option>>, "children"> & {
     contentId: string;
     triggerId: string;
     open: boolean;
@@ -77,6 +73,7 @@ const ComboboxContext = React.createContext<
     contentRef?: React.RefObject<HTMLDivElement>;
   }
 >({
+  value: undefined,
   onValueChange: () => {},
   contentId: "",
   triggerId: "",
@@ -86,7 +83,7 @@ const ComboboxContext = React.createContext<
   clearable: false,
 });
 
-const Root = ({
+const Root = <O extends Option | Array<Option>>({
   modal = true,
   closeOnSelect = true,
   clearable = false,
@@ -99,7 +96,7 @@ const Root = ({
   placeholder,
   layout,
   ...props
-}: RootProps) => {
+}: RootProps<O>) => {
   const contentId = React.useId();
   const triggerId = React.useId();
   const triggerRef = React.useRef(null);
@@ -131,7 +128,10 @@ const Root = ({
         contentId,
         triggerId,
         value,
-        onValueChange,
+        // Need to cast this to avoid type errors
+        // because the type of onValueChange is not
+        // consistent with the value type
+        onValueChange: onValueChange as (value: Option | Array<Option>) => void,
         placeholder,
         open,
         setOpen,
@@ -158,8 +158,8 @@ const Root = ({
 };
 
 type TriggerTagProps = {
-  value: string;
-  label?: string;
+  value: DefinedOption["value"];
+  label?: DefinedOption["label"];
 };
 
 const TriggerTag = ({ label, value, ...props }: TriggerTagProps) => {
@@ -618,8 +618,8 @@ const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
 type OptionProps<T extends TgphElement> = TgphComponentProps<
   typeof TelegraphMenu.Button<T>
 > & {
-  value: string;
-  label?: string;
+  value: DefinedOption["value"];
+  label?: DefinedOption["label"];
   selected?: boolean | null;
 };
 

--- a/packages/select/.eslintrc.js
+++ b/packages/select/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -1,0 +1,17 @@
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/select)
+
+# @telegraph/select
+> A simple select component built on top of @telegraph/combobox
+
+## Installation Instructions
+
+```
+npm install @telegraph/select
+```
+
+### Add stylesheet
+```
+@import "@telegraph/select"
+```

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -44,9 +44,9 @@
     "@types/react": "^18.2.48",
     "eslint": "^8.56.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "typescript": "^5.3.3",
-    "vite": "^5.2.12"
+    "react-dom": "^18.3.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.3.6"
   },
   "peerDependencies": {
     "react": "^18.2.0",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -12,10 +12,8 @@
     ".": {
       "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts",
-      "default": "./dist/css/default.css"
-    },
-    "./default.css": "./dist/css/default.css"
+      "types": "./dist/types/index.d.ts"
+    }
   },
   "files": [
     "dist",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@telegraph/select",
+  "version": "0.0.0",
+  "description": "A simple select component built on top of @telegraph/combobox",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/select",
+  "author": "@knocklabs",
+  "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/css/default.css"
+    },
+    "./default.css": "./dist/css/default.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "prettier": "@telegraph/prettier-config",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch --emptyOutDir false",
+    "build": "yarn clean && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
+    "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@telegraph/combobox": "workspace:*",
+    "@telegraph/helpers": "workspace:*"
+  },
+  "devDependencies": {
+    "@knocklabs/eslint-config": "^0.0.3",
+    "@knocklabs/typescript-config": "^0.0.2",
+    "@telegraph/postcss-config": "workspace:^",
+    "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/vite-config": "workspace:^",
+    "@types/react": "^18.2.48",
+    "eslint": "^8.56.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.2.12"
+  },
+  "peerDependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/select/postcss.config.mjs
+++ b/packages/select/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pkg from "@telegraph/postcss-config";
+
+const { styleEnginePostCssConfig } = pkg;
+
+export default styleEnginePostCssConfig;

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { Select } from "./Select";
+
+const meta: Meta<typeof Select.Root> = {
+  title: "Components/Select",
+  component: Select.Root,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Select.Root>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {
+  argTypes: {
+    size: {
+      options: ["0", "1", "2", "3"],
+      control: {
+        type: "select",
+      },
+    },
+  },
+  args: {
+    size: "2",
+  },
+  render: ({ ...props }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = React.useState<string | undefined>(undefined);
+    return (
+      <Select.Root
+        placeholder="Select an option"
+        value={value}
+        onValueChange={setValue}
+        {...props}
+      >
+        <Select.Option value="1">Option 1</Select.Option>
+        <Select.Option value="2">Option 2</Select.Option>
+      </Select.Root>
+    );
+  },
+};

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -3,15 +3,10 @@ import React from "react";
 
 import { Select } from "./Select";
 
-const meta: Meta<typeof Select.Root> = {
+const meta = {
   title: "Components/Select",
   component: Select.Root,
   tags: ["autodocs"],
-} satisfies Meta<typeof Select.Root>;
-
-export default meta;
-
-export const Default: StoryObj<typeof meta> = {
   argTypes: {
     size: {
       options: ["0", "1", "2", "3"],
@@ -23,7 +18,14 @@ export const Default: StoryObj<typeof meta> = {
   args: {
     size: "2",
   },
-  render: ({ ...props }) => {
+} satisfies Meta<typeof Select.Root>;
+
+type Story = StoryObj<typeof meta>;
+
+export default meta;
+
+export const SingleSelect: Story = {
+  render: ({ size }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [value, setValue] = React.useState<string | undefined>(undefined);
     return (
@@ -31,10 +33,31 @@ export const Default: StoryObj<typeof meta> = {
         placeholder="Select an option"
         value={value}
         onValueChange={setValue}
-        {...props}
+        size={size}
       >
         <Select.Option value="1">Option 1</Select.Option>
         <Select.Option value="2">Option 2</Select.Option>
+      </Select.Root>
+    );
+  },
+};
+
+export const MultiSelect: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = React.useState<Array<string>>([]);
+    return (
+      <Select.Root
+        placeholder="Select an option"
+        value={value}
+        onValueChange={setValue}
+        size={args.size}
+        multiple
+      >
+        <Select.Option value="1">Option 1</Select.Option>
+        <Select.Option value="2">Option 2</Select.Option>
+        <Select.Option value="3">Option 3</Select.Option>
+        <Select.Option value="4">Option 4</Select.Option>
       </Select.Root>
     );
   },

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -14,9 +14,15 @@ const meta = {
         type: "select",
       },
     },
+    disabled: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   args: {
     size: "2",
+    disabled: false,
   },
 } satisfies Meta<typeof Select.Root>;
 
@@ -25,7 +31,7 @@ type Story = StoryObj<typeof meta>;
 export default meta;
 
 export const SingleSelect: Story = {
-  render: ({ size }) => {
+  render: (args) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [value, setValue] = React.useState<string | undefined>(undefined);
     return (
@@ -33,7 +39,8 @@ export const SingleSelect: Story = {
         placeholder="Select an option"
         value={value}
         onValueChange={setValue}
-        size={size}
+        size={args.size}
+        disabled={args.disabled}
       >
         <Select.Option value="1">Option 1</Select.Option>
         <Select.Option value="2">Option 2</Select.Option>
@@ -53,6 +60,7 @@ export const MultiSelect: Story = {
         onValueChange={setValue}
         size={args.size}
         multiple
+        disabled={args.disabled}
       >
         <Select.Option value="1">Option 1</Select.Option>
         <Select.Option value="2">Option 2</Select.Option>

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -1,0 +1,81 @@
+import { Combobox } from "@telegraph/combobox";
+import { TgphComponentProps } from "@telegraph/helpers";
+import React from "react";
+
+type Option = TgphComponentProps<typeof Combobox.Option>;
+
+type RootProps = Omit<
+  TgphComponentProps<typeof Combobox.Root>,
+  "value" | "onValueChange" | "layout"
+> & {
+  value?: Option["value"];
+  onValueChange?: (value: Option["value"]) => void;
+  size?: TgphComponentProps<typeof Combobox.Trigger>["size"];
+  triggerProps?: TgphComponentProps<typeof Combobox.Trigger>;
+  contentProps?: TgphComponentProps<typeof Combobox.Content>;
+  optionsProps?: TgphComponentProps<typeof Combobox.Options>;
+};
+
+const Root = ({
+  size = "1",
+  value,
+  onValueChange,
+  triggerProps,
+  contentProps,
+  optionsProps,
+  children,
+  ...props
+}: RootProps) => {
+  const [options, setOptions] = React.useState<Array<Option>>([]);
+
+  // Get all of the options passed into Select so that we can display
+  // the label of the selected option in the trigger.
+  React.useEffect(() => {
+    if (!children) return;
+    const options = React.Children.toArray(children)
+      // Filter down to the components that are Option components
+      .filter((child) => {
+        return React.isValidElement(child) && child.props.value;
+      })
+      // Map the Option components to an array of objects that have a value and label
+      // so that we can display the label of the selected option in the trigger.
+      .map((child) => {
+        const childOption = child as React.ReactElement<OptionProps>;
+        return {
+          value: childOption.props.value,
+          // If the Option component has a label, use it. Otherwise, use the value
+          // so that we can display something.
+          label: childOption.props?.children || childOption.props.value,
+        };
+      });
+
+    setOptions(options);
+  }, [children]);
+
+  const label = options.find((option) => option.value === value)?.label;
+
+  return (
+    <Combobox.Root
+      value={value ? { value, label } : undefined}
+      onValueChange={(value) => onValueChange?.(value.value)}
+      {...props}
+    >
+      <Combobox.Trigger size={size} {...triggerProps} />
+      <Combobox.Content {...contentProps}>
+        <Combobox.Options {...optionsProps}>{children}</Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+
+type OptionProps = TgphComponentProps<typeof Combobox.Option>;
+
+const Option = ({ value, children, ...props }: OptionProps) => {
+  return <Combobox.Option value={value} label={children} {...props} />;
+};
+
+const Select = { Root, Option };
+type SelectProps = RootProps;
+
+export { Select };
+export type { SelectProps, OptionProps, Option };

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -108,7 +108,7 @@ const Root = ({
   );
 };
 
-type OptionProps = TgphComponentProps<typeof Combobox.Option>;
+type OptionProps = Omit<TgphComponentProps<typeof Combobox.Option>, "label">;
 
 const Option = ({ value, children, ...props }: OptionProps) => {
   return <Combobox.Option value={value} label={children} {...props} />;

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -24,7 +24,7 @@ type RootProps = Omit<
         layout?: TgphComponentProps<typeof Combobox.Root>["layout"];
       }
     | {
-        multiple?: false | undefined;
+        multiple?: false;
         value?: SingleValue;
         onValueChange?: (value: SingleValue) => void;
         layout?: never;
@@ -42,12 +42,9 @@ const Root = ({
   children,
   ...props
 }: RootProps) => {
-  const [options, setOptions] = React.useState<Array<Option>>([]);
-
   // Get all of the options passed into Select so that we can display
   // the label of the selected option in the trigger.
-  React.useEffect(() => {
-    if (!children) return;
+  const options = React.useMemo(() => {
     const options = React.Children.toArray(children)
       // Filter down to the components that are Option components
       .filter((child) => {
@@ -65,7 +62,7 @@ const Root = ({
         };
       });
 
-    setOptions(options);
+    return options;
   }, [children]);
 
   const derivedValue = React.useMemo(() => {

--- a/packages/select/src/Select/index.ts
+++ b/packages/select/src/Select/index.ts
@@ -1,0 +1,2 @@
+export { Select } from "./Select";
+export type { SelectProps, OptionProps, Option } from "./Select";

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,0 +1,2 @@
+export { Select } from "./Select";
+export type { SelectProps, OptionProps, Option } from "./Select";

--- a/packages/select/tsconfig.json
+++ b/packages/select/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/select",
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {
+      "vitest.*": ["../../vitest/*"]
+    },
+    "types": ["@testing-library/jest-dom", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/select/vite.config.mts
+++ b/packages/select/vite.config.mts
@@ -1,0 +1,7 @@
+import {
+  defaultViteConfig,
+  styleEngineViteConfig,
+} from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, styleEngineViteConfig);

--- a/packages/select/vitest.config.mts
+++ b/packages/select/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "select",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7002,9 +7002,9 @@ __metadata:
     "@types/react": "npm:^18.2.48"
     eslint: "npm:^8.56.0"
     react: "npm:^18.2.0"
-    react-dom: "npm:^18.2.0"
-    typescript: "npm:^5.3.3"
-    vite: "npm:^5.2.12"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:^5.5.4"
+    vite: "npm:^5.3.6"
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -15651,7 +15651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
+"react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -17837,16 +17837,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.3.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
-  languageName: node
-  linkType: hard
-
 "typescript@npm:^5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -17864,16 +17854,6 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=d69c25"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 
@@ -18383,49 +18363,6 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/3ed576d18c6c008ae92be68f9c79bf7556dae10978a3e8b4c4b42199424755e5c99836e6d4f81fb8b533b957d7f4e351abc60b8a93f4c4b5eb9890b5b6450926
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.2.12":
-  version: 5.4.10
-  resolution: "vite@npm:5.4.10"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.43"
-    rollup: "npm:^4.20.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    sass-embedded: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    sass-embedded:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/4ef4807d2fd166a920de244dbcec791ba8a903b017a7d8e9f9b4ac40d23f8152c1100610583d08f542b47ca617a0505cfc5f8407377d610599d58296996691ed
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,7 +6626,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@telegraph/combobox@workspace:packages/combobox":
+"@telegraph/combobox@workspace:*, @telegraph/combobox@workspace:packages/combobox":
   version: 0.0.0-use.local
   resolution: "@telegraph/combobox@workspace:packages/combobox"
   dependencies:
@@ -6682,7 +6682,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@telegraph/helpers@workspace:^, @telegraph/helpers@workspace:packages/helpers":
+"@telegraph/helpers@workspace:*, @telegraph/helpers@workspace:^, @telegraph/helpers@workspace:packages/helpers":
   version: 0.0.0-use.local
   resolution: "@telegraph/helpers@workspace:packages/helpers"
   dependencies:
@@ -6985,6 +6985,29 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.3.1
+  languageName: unknown
+  linkType: soft
+
+"@telegraph/select@workspace:packages/select":
+  version: 0.0.0-use.local
+  resolution: "@telegraph/select@workspace:packages/select"
+  dependencies:
+    "@knocklabs/eslint-config": "npm:^0.0.3"
+    "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/combobox": "workspace:*"
+    "@telegraph/helpers": "workspace:*"
+    "@telegraph/postcss-config": "workspace:^"
+    "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/vite-config": "workspace:^"
+    "@types/react": "npm:^18.2.48"
+    eslint: "npm:^8.56.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    typescript: "npm:^5.3.3"
+    vite: "npm:^5.2.12"
+  peerDependencies:
+    react: ^18.2.0
+    react-dom: ^18.2.0
   languageName: unknown
   linkType: soft
 
@@ -15628,7 +15651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
+"react-dom@npm:^18.2.0, react-dom@npm:^18.3.1":
   version: 18.3.1
   resolution: "react-dom@npm:18.3.1"
   dependencies:
@@ -17814,6 +17837,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^5.3.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^5.5.4":
   version: 5.5.4
   resolution: "typescript@npm:5.5.4"
@@ -17831,6 +17864,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^5.3.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=d69c25"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 
@@ -18340,6 +18383,49 @@ __metadata:
   bin:
     vite: bin/vite.js
   checksum: 10c0/3ed576d18c6c008ae92be68f9c79bf7556dae10978a3e8b4c4b42199424755e5c99836e6d4f81fb8b533b957d7f4e351abc60b8a93f4c4b5eb9890b5b6450926
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.2.12":
+  version: 5.4.10
+  resolution: "vite@npm:5.4.10"
+  dependencies:
+    esbuild: "npm:^0.21.3"
+    fsevents: "npm:~2.3.3"
+    postcss: "npm:^8.4.43"
+    rollup: "npm:^4.20.0"
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/4ef4807d2fd166a920de244dbcec791ba8a903b017a7d8e9f9b4ac40d23f8152c1100610583d08f542b47ca617a0505cfc5f8407377d610599d58296996691ed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
- Adds `<Select/>` component. A simpler version of `<Combobox/>` that more closely matches the browser `<select/>` element.
- Support the `multiple` prop like the browser `<select/>`
- Fixes [KNO-6849](https://linear.app/knock/issue/KNO-6849/[telegraph]-allow-combobox-labels-to-be-react-nodes) so that we can pass react nodes to the label.
- Fixes [KNO-6934](https://linear.app/knock/issue/KNO-6934/[telegraph]-allow-disabled-state-without-type-error-on-combobox) so that we can pass the `disabled` prop to the select component and combobox component.

### Tasks
[KNO-7249](https://linear.app/knock/issue/KNO-7249/[telegraph]-select-component)
[KNO-6934](https://linear.app/knock/issue/KNO-6934/[telegraph]-allow-disabled-state-without-type-error-on-combobox)
[KNO-6849](https://linear.app/knock/issue/KNO-6849/[telegraph]-allow-combobox-labels-to-be-react-nodes)