### PR TITLE
fix: modal overflow issue

### DIFF
--- a/.changeset/silly-buses-prove.md
+++ b/.changeset/silly-buses-prove.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/modal": patch
+---
+
+fix modal overflow issue

--- a/packages/modal/src/Modal/Modal.stories.tsx
+++ b/packages/modal/src/Modal/Modal.stories.tsx
@@ -63,6 +63,134 @@ export const Modal: Story = {
   },
 };
 
+export const ScrollingModal: Story = {
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [open, setOpen] = React.useState(true);
+    const Modal = TelegraphModal;
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Modal</Button>
+        <Modal.Root open={open} onOpenChange={setOpen} a11yTitle="Modal title">
+          <Modal.Content>
+            <Modal.Header>
+              <Heading as="h2" size="3">
+                Modal title
+              </Heading>
+              <Modal.Close />
+            </Modal.Header>
+            <Modal.Body>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+              <h1>Modal body</h1>
+            </Modal.Body>
+            <Modal.Footer>
+              <Button variant="outline" size="1">
+                Cancel
+              </Button>
+              <Button color="accent" size="1">
+                Save
+              </Button>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal.Root>
+      </>
+    );
+  },
+};
+
 type NestedModalProps = {
   open: boolean;
   onOpenChange: (value: boolean) => void;

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -201,7 +201,7 @@ type ContentRef = React.ElementRef<typeof Dialog.Content>;
 const Content = React.forwardRef<ContentRef, ContentProps>(
   ({ children, ...props }, forwardedRef) => {
     return (
-      <FocusScope trapped={true}>
+      <FocusScope trapped={true} asChild>
         <Dialog.Content ref={forwardedRef} asChild {...props}>
           <Stack direction="column" h="full" {...props}>
             {children}
@@ -234,9 +234,22 @@ const Close = <T extends TgphElement>({
 type BodyProps<T extends TgphElement> = PolymorphicProps<T> &
   TgphComponentProps<typeof Stack>;
 
-const Body = <T extends TgphElement>({ children, ...props }: BodyProps<T>) => {
+const Body = <T extends TgphElement>({
+  style,
+  children,
+  ...props
+}: BodyProps<T>) => {
   return (
-    <Stack direction="column" px="6" py="4" {...props}>
+    <Stack
+      direction="column"
+      px="6"
+      py="4"
+      style={{
+        overflowY: "auto",
+        ...style,
+      }}
+      {...props}
+    >
       {children}
     </Stack>
   );

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -3,7 +3,7 @@ import { FocusScope } from "@radix-ui/react-focus-scope";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button } from "@telegraph/button";
-import type { Required } from "@telegraph/helpers";
+import { RefToTgphRef, type Required } from "@telegraph/helpers";
 import type {
   PolymorphicProps,
   TgphComponentProps,
@@ -203,9 +203,11 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
     return (
       <FocusScope trapped={true} asChild>
         <Dialog.Content ref={forwardedRef} asChild {...props}>
-          <Stack direction="column" h="full" {...props}>
-            {children}
-          </Stack>
+          <RefToTgphRef>
+            <Stack direction="column" h="full" {...props}>
+              {children}
+            </Stack>
+          </RefToTgphRef>
         </Dialog.Content>
       </FocusScope>
     );

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -202,13 +202,13 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
   ({ children, ...props }, forwardedRef) => {
     return (
       <FocusScope trapped={true} asChild>
-        <Dialog.Content ref={forwardedRef} asChild {...props}>
-          <RefToTgphRef>
+        <RefToTgphRef>
+          <Dialog.Content ref={forwardedRef} asChild {...props}>
             <Stack direction="column" h="full" {...props}>
               {children}
             </Stack>
-          </RefToTgphRef>
-        </Dialog.Content>
+          </Dialog.Content>
+        </RefToTgphRef>
       </FocusScope>
     );
   },


### PR DESCRIPTION
### Description
- The `FocusTrap` component was inserting a `div`. Adding the `asChild` prop + wrapping `Stack` in the ref convertor allows there to be only a single div now. 
- Added `overflowY: "auto"` to `Modal.Body` as default. 
- Added a modal with a lot of content in storybook so we can see if this behavior works as expected.

### Tasks
[KNO-7270](https://linear.app/knock/issue/KNO-7270/[telegraph]-fix-modal-overflow-issue)