### PR TITLE
fix: button text wrapping

### DIFF
--- a/.changeset/violet-zebras-roll.md
+++ b/.changeset/violet-zebras-roll.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/button": patch
+---
+
+fix button text wrapping

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -234,7 +234,7 @@ const Text = <T extends TgphElement>({
   color,
   size,
   weight = "medium",
-  className,
+  style,
   ...props
 }: TextProps<T>) => {
   const context = React.useContext(ButtonContext);
@@ -249,10 +249,14 @@ const Text = <T extends TgphElement>({
       color={derivedColor}
       size={size ?? textSizeMap[context.size]}
       weight={weight}
-      className={clsx("no-underline whitespace-nowrap", className)}
       internal_optionalAs={true}
       data-button-text
       data-button-text-color={derivedColor}
+      style={{
+        textDecoration: "none",
+        whiteSpace: "nowrap",
+        ...style,
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
### Description
We missed adding `whiteSpace: nowrap` to the text in buttons after the tailwind migration.

### Tasks
[KNO-7332](https://linear.app/knock/issue/KNO-7332/[telegraph]-make-button-text-not-wrap)