### PR TITLE
fix: wrap combobox content in portal

### DIFF
--- a/.changeset/twelve-ears-drum.md
+++ b/.changeset/twelve-ears-drum.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/modal": patch
+---
+
+fix: wrap combobox content in portal

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dismissable-layer": "^1.1.1",
+    "@radix-ui/react-portal": "^1.1.3",
     "@radix-ui/react-use-controllable-state": "^1.1.0",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@telegraph/button": "workspace:^",

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1,4 +1,5 @@
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
+import * as Portal from "@radix-ui/react-portal";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button as TelegraphButton } from "@telegraph/button";
@@ -472,72 +473,76 @@ const Content = <T extends TgphElement>({
         }
       }}
     >
-      <Box tgphRef={composedRef}>
-        <TelegraphMenu.Content
-          // as={motion.div}
-          mt="1"
-          // onAnimationComplete={() => {
-          //   // Set height when the initial animation for
-          //   // displaying the content completes
-          //   if (!initialAnimationComplete && internalContentRef) {
-          //     const element = internalContentRef.current as unknown as Element;
-          //     setHeightFromContent(element);
-          //   }
-          // }}
-          onCloseAutoFocus={(event: Event) => {
-            if (!hasInteractedOutside.current)
-              context.triggerRef?.current?.focus();
-            hasInteractedOutside.current = false;
+      {/* We add the className "tgph" here so that styles within
+    the portal get scoped properly to telegraph */}
+      <Portal.Root className="tgph">
+        <Box tgphRef={composedRef}>
+          <TelegraphMenu.Content
+            // as={motion.div}
+            mt="1"
+            // onAnimationComplete={() => {
+            //   // Set height when the initial animation for
+            //   // displaying the content completes
+            //   if (!initialAnimationComplete && internalContentRef) {
+            //     const element = internalContentRef.current as unknown as Element;
+            //     setHeightFromContent(element);
+            //   }
+            // }}
+            onCloseAutoFocus={(event: Event) => {
+              if (!hasInteractedOutside.current)
+                context.triggerRef?.current?.focus();
+              hasInteractedOutside.current = false;
 
-            event.preventDefault();
-          }}
-          bg="surface-1"
-          style={{
-            width: "var(--tgph-comobobox-trigger-width)",
-            ...style,
-            ...{
-              "--tgph-comobobox-content-transform-origin":
-                "var(--radix-popper-transform-origin)",
-              "--tgph-combobox-content-available-width":
-                "var(--radix-popper-available-width)",
-              "--tgph-combobox-content-available-height":
-                "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
-              "--tgph-comobobox-trigger-width":
-                "var(--radix-popper-anchor-width)",
-              "--tgph-combobox-trigger-height":
-                "var(--radix-popper-anchor-height)",
-            },
-          }}
-          {...props}
-          tgphRef={composedRef}
-          data-tgph-combobox-content
-          data-tgph-combobox-content-open={context.open}
-          // Cancel out accessibility attirbutes related to aria menu
-          role={undefined}
-          aria-orientation={undefined}
-          onKeyDown={(event: React.KeyboardEvent) => {
-            // Don't allow the event to bubble up outside of the menu
-            event.stopPropagation();
+              event.preventDefault();
+            }}
+            bg="surface-1"
+            style={{
+              width: "var(--tgph-comobobox-trigger-width)",
+              ...style,
+              ...{
+                "--tgph-comobobox-content-transform-origin":
+                  "var(--radix-popper-transform-origin)",
+                "--tgph-combobox-content-available-width":
+                  "var(--radix-popper-available-width)",
+                "--tgph-combobox-content-available-height":
+                  "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
+                "--tgph-comobobox-trigger-width":
+                  "var(--radix-popper-anchor-width)",
+                "--tgph-combobox-trigger-height":
+                  "var(--radix-popper-anchor-height)",
+              },
+            }}
+            {...props}
+            tgphRef={composedRef}
+            data-tgph-combobox-content
+            data-tgph-combobox-content-open={context.open}
+            // Cancel out accessibility attirbutes related to aria menu
+            role={undefined}
+            aria-orientation={undefined}
+            onKeyDown={(event: React.KeyboardEvent) => {
+              // Don't allow the event to bubble up outside of the menu
+              event.stopPropagation();
 
-            // If the first option is focused and the user presses the up
-            // arrow key, focus the search input
-            const options = context.contentRef?.current?.querySelectorAll(
-              "[data-tgph-combobox-option]",
-            );
+              // If the first option is focused and the user presses the up
+              // arrow key, focus the search input
+              const options = context.contentRef?.current?.querySelectorAll(
+                "[data-tgph-combobox-option]",
+              );
 
-            if (
-              document.activeElement === options?.[0] &&
-              LAST_KEYS.includes(event.key)
-            ) {
-              context.searchRef?.current?.focus();
-            }
-          }}
-        >
-          <Stack direction="column" gap="1" tgphRef={internalContentRef}>
-            {children}
-          </Stack>
-        </TelegraphMenu.Content>
-      </Box>
+              if (
+                document.activeElement === options?.[0] &&
+                LAST_KEYS.includes(event.key)
+              ) {
+                context.searchRef?.current?.focus();
+              }
+            }}
+          >
+            <Stack direction="column" gap="1" tgphRef={internalContentRef}>
+              {children}
+            </Stack>
+          </TelegraphMenu.Content>
+        </Box>
+      </Portal.Root>
     </DismissableLayer>
   );
 };

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-focus-scope": "^1.1.0",
-    "@radix-ui/react-portal": "^1.1.2",
+    "@radix-ui/react-portal": "^1.1.3",
     "@radix-ui/react-visually-hidden": "^1.1.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,6 +3989,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-compose-refs@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-compose-refs@npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/3e84580024e66e3cc5b9ae79355e787815c1d2a3c7d46e7f47900a29c33751ca24cf4ac8903314957ab1f7788aebe1687e2258641c188cf94653f7ddf8f70627
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-context@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-context@npm:1.0.1"
@@ -4511,11 +4524,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-portal@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@radix-ui/react-portal@npm:1.1.2"
+"@radix-ui/react-portal@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-portal@npm:1.1.3"
   dependencies:
-    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-primitive": "npm:2.0.1"
     "@radix-ui/react-use-layout-effect": "npm:1.1.0"
   peerDependencies:
     "@types/react": "*"
@@ -4527,7 +4540,7 @@ __metadata:
       optional: true
     "@types/react-dom":
       optional: true
-  checksum: 10c0/836967330893b16b85371775ed1a59e038ce99189f4851cfa976bde2710d704c2a9e49e0a5206e7ac3fcf8a67ddd2d126b8352a88f295d6ef49d04e269736ed1
+  checksum: 10c0/b3cd1a81513e528d261599cffda8d7d6094a8598750eaa32bac0d64dbc9a3b4d4e1c10f5bdadf7051b5fd77033b759dbeb4838dae325b94bf8251804c61508c5
   languageName: node
   linkType: hard
 
@@ -4608,6 +4621,25 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/00cb6ca499252ca848c299212ba6976171cea7608b10b3f9a9639d6732dea2df1197ba0d97c001a4fdb29313c3e7fc2a490f6245dd3579617a0ffd85ae964fdd
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-primitive@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@radix-ui/react-primitive@npm:2.0.1"
+  dependencies:
+    "@radix-ui/react-slot": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/6a562bec14f8e9fbfe0012d6c2932b0e54518fed898fa0622300c463611e77a4ca28a969f0cd484efd6570c01c5665dd6151f736262317d01715bc4da1a7dea6
   languageName: node
   linkType: hard
 
@@ -4783,6 +4815,21 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/a2e8bfb70c440506dd84a1a274f9a8bc433cca37ceae275e53552c9122612e3837744d7fc6f113d6ef1a11491aa914f4add71d76de41cb6d4db72547a8e261ae
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-slot@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-slot@npm:1.1.1"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/f3cc71c16529c67a8407a89e0ac13a868cafa0cd05ca185b464db609aa5996a3f00588695518e420bd47ffdb4cc2f76c14cc12ea5a38fc2ca3578a30d2ca58b9
   languageName: node
   linkType: hard
 
@@ -6483,6 +6530,7 @@ __metadata:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@radix-ui/react-dismissable-layer": "npm:^1.1.1"
+    "@radix-ui/react-portal": "npm:^1.1.3"
     "@radix-ui/react-use-controllable-state": "npm:^1.1.0"
     "@radix-ui/react-visually-hidden": "npm:^1.1.0"
     "@telegraph/button": "workspace:^"
@@ -6693,7 +6741,7 @@ __metadata:
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@radix-ui/react-dialog": "npm:^1.1.1"
     "@radix-ui/react-focus-scope": "npm:^1.1.0"
-    "@radix-ui/react-portal": "npm:^1.1.2"
+    "@radix-ui/react-portal": "npm:^1.1.3"
     "@radix-ui/react-visually-hidden": "npm:^1.1.0"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"


### PR DESCRIPTION
Wraps combobox content in radix portal like we do with the modal to fix overlapping issues when within other components like popovers.

![CleanShot 2025-01-28 at 11 38 22](https://github.com/user-attachments/assets/b5d81674-bcbd-42a4-9278-c79a9279f4df)
