### PR TITLE
fix: read-only warning in dev mode

### DIFF
--- a/.changeset/gold-adults-draw.md
+++ b/.changeset/gold-adults-draw.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/style-engine": patch
+---
+
+fix read-only warning that occurs in dev mode

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
@@ -197,6 +197,13 @@ export const getStyleProp = <
       return;
     }
 
+    // If there is already a value for the css var, delete it
+    // so the new value can be assigned. This prevents the
+    // "read-only" warning we sometimes see in dev mode
+    if (styleProp?.[cssVarName]) {
+      delete styleProp?.[cssVarName];
+    }
+
     Object.assign(styleProp, { [cssVarName]: mappedValueOfCssVar });
   });
 

--- a/packages/style-engine/src/hooks/useStyleEngine.ts
+++ b/packages/style-engine/src/hooks/useStyleEngine.ts
@@ -1,6 +1,8 @@
 import React from "react";
 
-import { type CssVarsPropObject, getStyleProp } from "../helpers/getStyleProp";
+import { type CssVarProp, getStyleProp } from "../helpers/getStyleProp";
+
+type CssVarsPropObject<CssVars> = Record<keyof CssVars, CssVarProp>;
 
 export const useStyleEngine = <
   CssVars extends CssVarsPropObject<CssVars>,


### PR DESCRIPTION
### Description
- Read-only errors will sometimes appear in dev mode when assigning a value to an existing item. This change should suppress that issue.
![image](https://github.com/user-attachments/assets/36fef4ec-ba81-430c-b637-ed36434bb4ca)

### Tasks
KNO-7742