### PR TITLE
fix(KNO-7736): support setting maxHeight on Combobox.Options

### DIFF
--- a/.changeset/bright-chairs-mix.md
+++ b/.changeset/bright-chairs-mix.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": patch
+---
+
+Support setting `maxHeight` prop on `Combobox.Options`

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -721,7 +721,7 @@ const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
       style={{
         overflowY: "auto",
         // maxHeight defaults to available height - padding from edge of screen
-        maxHeight: !maxHeight
+        "--max-height": !maxHeight
           ? "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))"
           : undefined,
       }}

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -711,8 +711,6 @@ type OptionsProps<T extends TgphElement> = TgphComponentProps<typeof Stack<T>>;
 const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
   const context = React.useContext(ComboboxContext);
 
-  const { maxHeight } = props;
-
   return (
     <Stack
       id={context.contentId}
@@ -721,7 +719,7 @@ const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
       style={{
         overflowY: "auto",
         // maxHeight defaults to available height - padding from edge of screen
-        "--max-height": !maxHeight
+        "--max-height": !props.maxHeight
           ? "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))"
           : undefined,
       }}

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -711,6 +711,8 @@ type OptionsProps<T extends TgphElement> = TgphComponentProps<typeof Stack<T>>;
 const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
   const context = React.useContext(ComboboxContext);
 
+  const { maxHeight } = props;
+
   return (
     <Stack
       id={context.contentId}
@@ -718,9 +720,10 @@ const Options = <T extends TgphElement>({ ...props }: OptionsProps<T>) => {
       gap="1"
       style={{
         overflowY: "auto",
-        // Available Height - Padding from edge of screen
-        maxHeight:
-          "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))",
+        // maxHeight defaults to available height - padding from edge of screen
+        maxHeight: !maxHeight
+          ? "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))"
+          : undefined,
       }}
       // Accessibility attributes
       role="listbox"


### PR DESCRIPTION
This PR updates `Combobox.Options` so that the default stack max height of `calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))` is only applied when a custom `maxHeight` prop is not passed in.