### PR TITLE
fix: persist style prop through button

### DIFF
--- a/.changeset/sour-boxes-breathe.md
+++ b/.changeset/sour-boxes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/button": patch
+---
+
+persist style prop through to button

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -83,6 +83,7 @@ const Root = <T extends TgphElement>({
   disabled,
   className,
   children,
+  style,
   ...props
 }: RootProps<T>) => {
   const derivedState = deriveState({ state: stateProp, disabled, active });
@@ -93,7 +94,10 @@ const Root = <T extends TgphElement>({
   });
 
   const { styleProp, otherProps } = useStyleEngine({
-    props: BUTTON_COLOR_MAP[variant][color],
+    props: {
+      ...BUTTON_COLOR_MAP[variant][color],
+      ...style,
+    },
     cssVars,
   });
 


### PR DESCRIPTION
### Description
We weren't passing the style prop into the `useStyleEngine` hook so any style prop passed into the button would override any styles we set via the hook.

### Tasks
KNO-7748