### PR TITLE
chore(KNO-7887): clean up vitest setup file

### DIFF
--- a/vitest/setup.ts
+++ b/vitest/setup.ts
@@ -1,22 +1,12 @@
 import "vitest";
-import { afterEach, expect } from "vitest";
+import { afterEach } from "vitest";
 
-import "@testing-library/jest-dom";
-import type { TestingLibraryMatchers } from "@testing-library/jest-dom/matchers";
+import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import * as matchers from "@testing-library/jest-dom/matchers";
-
-expect.extend(matchers);
 
 afterEach(() => {
   cleanup();
 });
-
-declare module "vitest" {
-  export interface Assertion<T = any> extends TestingLibraryMatchers<T, void> {}
-  export interface AsymmetricMatchersContaining<T = any>
-    extends TestingLibraryMatchers<T, void> {}
-}
 
 /*
  fixes: Error: Not implemented: HTMLCanvasElement.prototype.getContext (without installing the canvas npm package)


### PR DESCRIPTION
I think we can clean up our vitest setup file a bit. `@testing-library/jest-dom` provides [vitest-specific setup instructions](https://github.com/testing-library/jest-dom/blob/main/README.md#with-vitest). If we import `@testing-library/jest-dom/vitest`, vitest’s `expect` will [automatically be extended with Testing Library’s matchers](https://github.com/testing-library/jest-dom/blob/918b6fbcde10d4409ee8f05c6e4eecbe96a72b7a/vitest.js#L4) and [vitest’s types will be augmented](https://github.com/testing-library/jest-dom/blob/918b6fbcde10d4409ee8f05c6e4eecbe96a72b7a/types/vitest.d.ts#L4-L15).