### PR TITLE
feat(kno-7970): allow skipping the children wrapper on Buttons

### DIFF
--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -256,11 +256,13 @@ type BaseDefaultProps =
       leadingIcon?: DefaultIconProps;
       trailingIcon?: DefaultIconProps;
       icon?: never;
+      skipChildrenWrapper?: boolean;
     }
   | {
       icon?: DefaultIconProps;
       leadingIcon?: never;
       trailingIcon?: never;
+      skipChildrenWrapper?: boolean;
     };
 type DefaultProps<T extends TgphElement> = PolymorphicProps<T> &
   TgphComponentProps<typeof Root> &
@@ -271,15 +273,18 @@ const Default = <T extends TgphElement>({
   trailingIcon,
   icon,
   children,
+  skipChildrenWrapper,
   ...props
 }: DefaultProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
+  const child =
+    children && skipChildrenWrapper ? children : <Text>{children}</Text>;
   return (
     <Root {...props}>
       {combinedLeadingIcon && (
         <Icon {...combinedLeadingIcon} internal_iconType="leading" />
       )}
-      {children && <Text>{children}</Text>}
+      {child}
       {trailingIcon && <Icon {...trailingIcon} internal_iconType="trailing" />}
     </Root>
   );

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -277,8 +277,13 @@ const Default = <T extends TgphElement>({
   ...props
 }: DefaultProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
-  const child =
-    children && skipChildrenWrapper ? children : <Text>{children}</Text>;
+  const child = children ? (
+    skipChildrenWrapper ? (
+      children
+    ) : (
+      <Text>{children}</Text>
+    )
+  ) : null;
   return (
     <Root {...props}>
       {combinedLeadingIcon && (


### PR DESCRIPTION
fix()### TL;DR
Added a `skipChildrenWrapper` prop to Button component to allow direct rendering of children without Text wrapper

### What changed?
- Added new `skipChildrenWrapper` boolean prop to Button component
- When `skipChildrenWrapper` is true, children are rendered directly instead of being wrapped in a Text component
- When false or undefined, maintains existing behavior of wrapping children in Text component

### How to test?
1. Import Button component
2. Render Button with `skipChildrenWrapper={true}` and custom children
3. Verify children render directly without Text wrapper
4. Compare with default behavior (skipChildrenWrapper omitted) to ensure Text wrapper is present

### Why make this change?
Provides flexibility for cases where the Text wrapper is not desired or where custom text styling needs to be applied directly to the button's children. This enhancement allows for more customization while maintaining the default wrapped behavior for backward compatibility.