### PR TITLE
fix(KNO-7992): Fix margin and marginX in Box constants

### DIFF
--- a/.changeset/good-ghosts-rush.md
+++ b/.changeset/good-ghosts-rush.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+Fix `margin` and `marginX` in `Box` constants

--- a/packages/layout/src/Box/Box.constants.ts
+++ b/packages/layout/src/Box/Box.constants.ts
@@ -160,10 +160,12 @@ const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
   margin: {
     cssVar: "--margin",
     value: "var(--tgph-spacing-VARIABLE)",
+    direction: "all",
   },
   marginX: {
     cssVar: "--margin",
-    value: "0 var(--tgph-spacing-VARIABLE)",
+    value: "var(--tgph-spacing-VARIABLE)",
+    direction: "x",
   },
   marginY: {
     cssVar: "--margin",


### PR DESCRIPTION
I noticed some weirdness when adding an `mb` prop to the `<Heading>` component. This fixes it.