### PR TITLE
fix: onClick handler no longer fires twice when using Menu.Button component

### DIFF
--- a/.changeset/happy-ducks-clean.md
+++ b/.changeset/happy-ducks-clean.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+fix: onClick handler no longer fires twice when using Menu.Button component

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -140,6 +140,7 @@ const Button = <T extends TgphElement>({
   trailingComponent,
   selected,
   tgphRef,
+  onClick,
   ...props
 }: ButtonProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
@@ -147,6 +148,7 @@ const Button = <T extends TgphElement>({
     <RadixMenu.Item {...props} asChild={asChild} ref={tgphRef}>
       <RefToTgphRef>
         <MenuItem
+          onClick={onClick}
           selected={selected}
           leadingIcon={combinedLeadingIcon}
           trailingIcon={trailingIcon}


### PR DESCRIPTION
### TL;DR

Fixed  `onClick` support to the Menu Button component. The `{...props}` spreading was passing it out twice and the onClick functions were firing twice.

### How to test?

1. Open the Menu component storybook
2. Click on the "Manage workflow" button in the Default story
3. Verify that "clicked" appears in the console

### Why make this change?

This change enables interactive functionality for Menu buttons, allowing developers to handle click events. This is a fundamental feature for menus that need to trigger actions when items are selected.

[Linear](https://linear.app/knock/issue/KNO-8209/[telegraph]-menubutton-fires-onclick-events-twice)