### PR TITLE
feat(kno-7951): add flexible filter component package

### DIFF
--- a/packages/filter/.eslintrc.js
+++ b/packages/filter/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  root: true,
+  extends: [
+    "@knocklabs/eslint-config/library.js",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
+  ],
+  parser: "@typescript-eslint/parser",
+};

--- a/packages/filter/README.md
+++ b/packages/filter/README.md
@@ -1,0 +1,17 @@
+![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
+
+[![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/filter)
+
+# @telegraph/filter
+> A flexible filter component
+
+## Installation Instructions
+
+```
+npm install @telegraph/filter
+```
+
+### Add stylesheet
+```
+@import "@telegraph/filter"
+```

--- a/packages/filter/package.json
+++ b/packages/filter/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@telegraph/filter",
+  "version": "0.0.0",
+  "description": "A flexible filter component",
+  "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/filter",
+  "author": "@knocklabs",
+  "license": "MIT",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "private": true,
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.mjs",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/css/default.css"
+    },
+    "./default.css": "./dist/css/default.css"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "prettier": "@telegraph/prettier-config",
+  "scripts": {
+    "clean": "rm -rf dist",
+    "dev": "vite build --watch --emptyOutDir false",
+    "build": "yarn clean && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
+    "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@telegraph/button": "workspace:^",
+    "@telegraph/combobox": "workspace:^",
+    "@telegraph/icon": "workspace:^",
+    "@telegraph/layout": "workspace:^",
+    "@telegraph/menu": "workspace:^"
+  },
+  "devDependencies": {
+    "@knocklabs/eslint-config": "^0.0.3",
+    "@knocklabs/typescript-config": "^0.0.2",
+    "@telegraph/postcss-config": "workspace:^",
+    "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/vite-config": "workspace:^",
+    "@types/react": "^18.3.18",
+    "eslint": "^8.56.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.11"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  }
+}

--- a/packages/filter/postcss.config.mjs
+++ b/packages/filter/postcss.config.mjs
@@ -1,0 +1,5 @@
+import pkg from "@telegraph/postcss-config";
+
+const { styleEnginePostCssConfig } = pkg;
+
+export default styleEnginePostCssConfig;

--- a/packages/filter/src/Filter/Filter.stories.tsx
+++ b/packages/filter/src/Filter/Filter.stories.tsx
@@ -1,0 +1,95 @@
+import { Filter } from ".";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@telegraph/button";
+import { TgphComponentProps } from "@telegraph/helpers";
+import { Lucide } from "@telegraph/icon";
+import React from "react";
+
+const meta = {
+  title: "Components/Filter",
+  component: Filter.Root,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof Filter.Root>;
+
+export default meta;
+type Story = StoryObj<TgphComponentProps<typeof Filter.Root>>;
+
+export const Default: Story = {
+  render: () => {
+    return (
+      <Filter.Root>
+        <Filter.ChipDisplay />
+        <Filter.Trigger>
+          <Button
+            variant="outline"
+            size="1"
+            leadingIcon={{
+              icon: Lucide.ListFilter,
+              "aria-hidden": true,
+            }}
+          >
+            Filter
+          </Button>
+        </Filter.Trigger>
+        <Filter.Content>
+          <Filter.Parameter
+            name="Favorite Beverage"
+            value="favorite-beverage"
+            icon={Lucide.Apple}
+          >
+            <Filter.Menu name="Beverages" icon={Lucide.Apple} isSearchable>
+              <Filter.Menu name="Sodas">
+                <Filter.Option name="Sprite" value="sprite" />
+                <Filter.Option name="Dr. Pepper" value="dr-pepper" />
+              </Filter.Menu>
+              <Filter.Menu name="Juices">
+                <Filter.Parameter
+                  value="favorite-juice"
+                  name="Favorite Juice"
+                  icon={Lucide.Fish}
+                >
+                  <Filter.Menu name="Fruit Juices" icon={Lucide.Fish}>
+                    <Filter.Option value="apple-juice" icon={Lucide.Amphora} />
+                    <Filter.Option name="Orange Juice" value="orange-juice" />
+                  </Filter.Menu>
+                </Filter.Parameter>
+                <Filter.Option name="Vegetable Juice" value="vegetable-juice" />
+                <Filter.Option name="Prune Juice" value="prune-juice" />
+              </Filter.Menu>
+              <Filter.Menu name="Flavored Water">
+                <Filter.Option
+                  name="Berry Sparkling Water"
+                  value="sparkling-water"
+                />
+                <Filter.Option name="Lemon Soda Water" value="soda-water" />
+              </Filter.Menu>
+            </Filter.Menu>
+          </Filter.Parameter>
+          <Filter.Divider />
+          <Filter.Parameter
+            name="Favorite Snacks"
+            value="favorite-snacks"
+            icon={Lucide.Mountain}
+            isMulti
+            pluralNoun="snacks"
+          >
+            <Filter.Menu name="Snacks" icon={Lucide.Mountain}>
+              <Filter.Option
+                name="Chocolate"
+                value="chocolate"
+                icon={Lucide.MemoryStick}
+              />
+              <Filter.Option
+                name="Pretzels"
+                value="pretzels"
+                icon={Lucide.Moon}
+              />
+            </Filter.Menu>
+          </Filter.Parameter>
+        </Filter.Content>
+      </Filter.Root>
+    );
+  },
+};

--- a/packages/filter/src/Filter/Filter.tsx
+++ b/packages/filter/src/Filter/Filter.tsx
@@ -1,0 +1,572 @@
+import { Button } from "@telegraph/button";
+import { Combobox } from "@telegraph/combobox";
+import { Lucide } from "@telegraph/icon";
+import { Input } from "@telegraph/input";
+import { Box, Stack } from "@telegraph/layout";
+import { Menu } from "@telegraph/menu";
+import { Text } from "@telegraph/typography";
+import React from "react";
+
+import {
+  getOperatorOptions,
+  getSelectedIcon,
+  getSelectedLabel,
+} from "./helpers";
+import type {
+  ContentProps,
+  FilterContextValue,
+  FilterProps,
+  MenuContextValue,
+  MenuProps,
+  OptionProps,
+  ParameterProps,
+  TriggerProps,
+} from "./types";
+import {
+  OPERATOR_CONFIGS,
+  OperatorValue,
+  useInternalFilterState,
+} from "./useInternalStateController";
+import {
+  DEFAULT_OPERATOR,
+  type FilterStateValue,
+} from "./useInternalStateController";
+
+/**
+ * This will be our data store for the filter
+ */
+const FilterContext = React.createContext<FilterContextValue | null>(null);
+
+/**
+ * Hook to reuse the filter context
+ */
+export const useFilter = () => {
+  const context = React.useContext(FilterContext);
+
+  if (!context) {
+    throw new Error("useFilter must be used within a Filter.Root");
+  }
+  return context;
+};
+
+/**
+ * The root component for the filter
+ */
+export const Root = ({ children }: FilterProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [menuContext, setMenuContext] = React.useState<MenuContextValue | null>(
+    null,
+  );
+  const [searchValue, setSearchValue] = React.useState<string>("");
+  const triggerRef = React.useRef<HTMLDivElement>(null);
+
+  // Initialize state at the Root level, the only time this hook should be used
+  const stateControl = useInternalFilterState();
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+
+    if (!isOpen) {
+      // Wait for the menu to close before resetting the state to avoid flickering
+      setTimeout(() => {
+        setMenuContext(null);
+        setSearchValue("");
+        triggerRef.current?.focus();
+      }, 250);
+    }
+  };
+
+  return (
+    <FilterContext.Provider
+      value={{
+        isOpen,
+        setMenuOpen: handleOpenChange,
+        menuContext,
+        setMenuContext,
+        searchValue,
+        setSearchValue,
+        stateControl,
+        triggerRef,
+      }}
+    >
+      <Menu.Root open={isOpen} onOpenChange={handleOpenChange}>
+        {children}
+      </Menu.Root>
+    </FilterContext.Provider>
+  );
+};
+
+export const Trigger = ({ children }: TriggerProps) => {
+  const { triggerRef } = useFilter();
+  return (
+    <Menu.Trigger tgphRef={triggerRef} asChild={true}>
+      {children}
+    </Menu.Trigger>
+  );
+};
+
+/**
+ * Content to render within the panel
+ * This is where we can do some searchin'
+ *
+ * Desired behavior:
+ * - autofocus the input, have a highlighted element below
+ * - when enter is hit, select the first item
+ * - when arrow down is hit once, remove focus from the input and move focus to the highlighted element below
+ * - when arrow down is hit again, move focus to the next element down
+ * - when arrow is down at the bottom, move focus to the input
+ * - tldr: input should be another element in the stack, but we should have a psuedo active state for the first item to make it very snappy to use
+ */
+export const Content = ({
+  children,
+  isTopSearchable = false,
+}: ContentProps) => {
+  const { menuContext, searchValue, setSearchValue } = useFilter();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const childrenRefs = React.useRef<Array<HTMLSpanElement>>([]);
+
+  const isTopLevelMenu = !menuContext;
+  const isSearchable =
+    (isTopLevelMenu && isTopSearchable) || menuContext?.isSearchable;
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchValue = e.target.value;
+    setSearchValue(searchValue);
+  };
+
+  const childrenToUse = isTopLevelMenu ? children : menuContext?.children;
+
+  // Determines the children to render with regards to the search value
+  const filteredChildren = React.useMemo(() => {
+    // Important to reset the refs array so we don't have null or refs from the past in the array
+    childrenRefs.current = [];
+    // Focus the input when the menu opens, if there is one
+    inputRef.current?.focus();
+    return !searchValue
+      ? childrenToUse
+      : React.Children.toArray(childrenToUse).filter((child) => {
+          // Check for TS
+          if (React.isValidElement(child)) {
+            let menuItemName = child.props?.name || "";
+            let menuItemValue = child.props?.value || "";
+
+            // Wild block of code to get the actual name and value to filter by
+            // from the nested menu item within a nested Parameter component
+            const componentType =
+              child?.type as React.JSXElementConstructor<unknown>;
+            const componentName = componentType?.name
+              ? componentType?.name
+              : "";
+            // Name of the sub-component we defined
+            if (componentName === "Parameter") {
+              menuItemName = child?.props?.children?.props?.name || "";
+              menuItemValue = child?.props?.children?.props?.value || "";
+            }
+
+            const shouldShowOption: boolean =
+              menuItemName.toLowerCase().includes(searchValue.toLowerCase()) ||
+              menuItemValue.toLowerCase().includes(searchValue.toLowerCase());
+
+            return shouldShowOption;
+          }
+          return true;
+        });
+  }, [searchValue, childrenToUse]);
+
+  // We add a ref to each child so we have an array of refs to work with
+  // this helps us focus the correct item when we need to
+  // Hacky because I can't get this to work with tgphRefs
+  const childrenWithRefs = React.Children.map(
+    filteredChildren,
+    (child, index) => {
+      return (
+        <span
+          ref={(el) => {
+            if (el) {
+              childrenRefs.current[index] = el;
+            }
+          }}
+        >
+          {child}
+        </span>
+      );
+    },
+  );
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Quick fix to remove null refs in case array size changes between renders
+    // const els = childrenRefs.current.filter((ref) => ref !== null);
+    // childrenRefs.current = els;
+    const activeElement = document.activeElement;
+    const isSearchInputFocused = activeElement === inputRef.current;
+    const firstChild = childrenRefs.current[0];
+    const lastChild = childrenRefs.current[childrenRefs.current.length - 1];
+    const firstChildButton = firstChild?.firstElementChild as HTMLButtonElement;
+    const lastChildButton = lastChild?.firstElementChild as HTMLButtonElement;
+    const isFirstChildFocused = activeElement === firstChildButton;
+    const isLastChildFocused = activeElement === lastChildButton;
+
+    // We have to reimplement the loop behavior
+    // so bottom elements cycle back to the top using arrow keys
+    // and top elements cycle back to the bottom using arrow keys
+
+    // No cycling for one item and no search input
+    if (!isSearchable && childrenRefs.current.length === 1) {
+      return;
+    }
+
+    // Trigger the first item for speedy navigation
+    if (isSearchInputFocused && e.key === "Enter") {
+      e.preventDefault();
+      return firstChildButton?.click();
+    }
+
+    // Focus the first item when the user hits arrow down when they're in search input
+    if (isSearchInputFocused && e.key === "ArrowDown") {
+      e.preventDefault();
+      return firstChildButton?.focus();
+    }
+
+    // Focus the first item when the user hits arrow down when they're in search input
+    if (!isSearchable && isLastChildFocused && e.key === "ArrowDown") {
+      e.preventDefault();
+      return firstChildButton?.focus();
+    }
+
+    // Focus the first item when the user hits arrow up when they're in search input
+    if (!isSearchable && isFirstChildFocused && e.key === "ArrowUp") {
+      e.preventDefault();
+      return lastChildButton?.focus();
+    }
+
+    // Focus the first item when the user hits arrow up when they're in search input
+    if (isSearchable && isFirstChildFocused && e.key === "ArrowUp") {
+      e.preventDefault();
+      return inputRef.current?.focus();
+    }
+
+    // Focus the first item when the user hits arrow up when they're in search input
+    if (isSearchable && isLastChildFocused && e.key === "ArrowDown") {
+      e.preventDefault();
+      return inputRef.current?.focus();
+    }
+
+    // Focus the last item when the user hits arrow up when they're in search input
+    // Maybe we don't want this behavior?
+    if (isSearchInputFocused && e.key === "ArrowUp") {
+      e.preventDefault();
+      return lastChildButton?.focus();
+    }
+
+    // Focus the search input when the user hits arrow up when they're on first item
+    if (isFirstChildFocused && e.key === "ArrowUp") {
+      e.preventDefault();
+      return inputRef.current?.focus();
+    }
+
+    // Focus the search input when the user hits arrow down when they're on last item
+    if (isLastChildFocused && e.key === "ArrowDown") {
+      e.preventDefault();
+      return inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <Box onKeyDown={handleKeyPress}>
+      <Menu.Content hideWhenDetached>
+        <ParameterContext.Provider
+          value={menuContext?.parameterContext || null}
+        >
+          {isSearchable && (
+            <Input
+              tgphRef={inputRef}
+              type="text"
+              value={searchValue}
+              autoFocus
+              placeholder={menuContext?.parameterContext?.name || "Search"}
+              onChange={handleSearchChange}
+            />
+          )}
+          {childrenWithRefs}
+        </ParameterContext.Provider>
+      </Menu.Content>
+    </Box>
+  );
+};
+
+const ParameterContext = React.createContext<ParameterProps | null>(null);
+
+/**
+ * Hook to reuse the context of the current filter key
+ *
+ * A filter will have a key, name, value, icon, etc.
+ * This hook makes it easy to access that context from sub components.
+ */
+const useParameterContext = () => {
+  const context = React.useContext(ParameterContext);
+  if (!context) {
+    throw new Error(
+      "useFilterKeyContext must be used within a FilterKeyContext",
+    );
+  }
+  return context;
+};
+
+/**
+ * General sub menu, can be nested within each other infinitely
+ * This will render an item that will navigate to a deeper menu
+ */
+export const FilterMenu = ({
+  children,
+  name,
+  icon: iconProp,
+  isSearchable,
+}: MenuProps) => {
+  const { setMenuContext, setSearchValue } = useFilter();
+  const parameterContext = useParameterContext();
+
+  // When the item is clicked, we navigate to the deeper menu
+  const handleClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    // Prevent the menu from auto closing on us
+    event.preventDefault();
+
+    // Reset the search value for the next menu
+    setSearchValue("");
+
+    // This is a little funky, but since we're going to replace the children we're rendering
+    // via MenuContext update, we need to also wrap the new children in the filter key context so that
+    // the new children can know what filter we're working with.
+    setMenuContext({
+      parameterContext,
+      // This is the magic that renders the next menu, handled by Content component above
+      children,
+      isSearchable,
+    });
+  };
+
+  const icon = iconProp
+    ? { icon: iconProp, "aria-hidden": true as const }
+    : undefined;
+
+  return (
+    <Menu.Button leadingIcon={icon} onClick={handleClick}>
+      <Text as="span">{name}</Text>
+    </Menu.Button>
+  );
+};
+
+/**
+ * Wrapper to pass filter key context to subcomponents.
+ *
+ * Keeping it composable gives us the flexibility to use nested filters,
+ * e.g. a menu like
+ * Account > isActive
+ * OR
+ * Account > Users (_change filter key_) > isAdmin
+ */
+export const Parameter = ({ isMulti = false, ...props }: ParameterProps) => {
+  const context = { ...props, isMulti };
+  return (
+    // Initialize the parameter context around the menu
+    // @ts-expect-error shut up for now
+    <ParameterContext.Provider value={context}>
+      {props.children}
+    </ParameterContext.Provider>
+  );
+};
+
+/**
+ * A selectable filter option
+ */
+export const Option = ({ name, value, icon: optionIcon }: OptionProps) => {
+  const { setMenuOpen, stateControl } = useFilter();
+  const {
+    isMulti,
+    icon: filterIcon,
+    name: filterName,
+    value: filterKey,
+    pluralNoun,
+  } = useParameterContext();
+
+  const updateFilterState = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    // This block of code is to prevent the multi-select menu from auto-closing when the user clicks on an option
+    const currentValue = stateControl.getValue(filterKey);
+    const isRemoving = stateControl.isKeyValueActive(filterKey, value);
+    if (!isRemoving) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    if (Array.isArray(currentValue)) {
+      if (isRemoving && currentValue.length > 1) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+
+    // If there's no children and no key, warn and do nothing
+    if (!filterKey) {
+      console.warn(
+        `Filter menu warning: tried to set a filter but no key is active, make sure all of your Items have values or this filter won't set! Check the parent of \`${value}\``,
+      );
+      return;
+    }
+
+    // This is the main spot where we "lift" the filter option upwards to render a chip
+    stateControl.toggle(filterKey, {
+      filterKey,
+      filterName,
+      option: { value, name, icon: optionIcon },
+      isMulti,
+      icon: filterIcon,
+      // In the future, we can pass this in as a prop or something
+      operator: DEFAULT_OPERATOR,
+      pluralNoun,
+    });
+
+    // After selection, close the menu if it's not a multi-select
+    if (!isMulti) {
+      setMenuOpen(false);
+    }
+  };
+
+  // Find if the value is present in our state
+  const isSelected = stateControl.isKeyValueActive(filterKey, value);
+
+  const icon = isSelected
+    ? { icon: Lucide.SquareCheckBig, "aria-hidden": true as const }
+    : optionIcon
+      ? { icon: optionIcon, "aria-hidden": true as const }
+      : undefined;
+
+  return (
+    <Menu.Button leadingIcon={icon} onClick={updateFilterState}>
+      <Text as="span">{name || value}</Text>
+    </Menu.Button>
+  );
+};
+
+/**
+ * A divider between items
+ */
+export const Divider = () => {
+  return <Menu.Divider />;
+};
+
+/**
+ * A chip to display an active filter
+ */
+export const Chip = (props: FilterStateValue) => {
+  const { filterKey, active, operator, filterName, icon, pluralNoun } = props;
+  const { stateControl } = useFilter();
+  const { clearKey, updateKey } = stateControl;
+
+  if (!active) {
+    return null;
+  }
+
+  // We'll have to access the unselected values here as well to render the option change dropdown
+  // or maybe we can just re-render our top-level node? it'll be the same menu...?
+
+  // This is where we change the operator
+  const handleComboboxChange = (newOperator: OperatorValue) => {
+    updateKey(filterKey, { operator: newOperator });
+  };
+
+  // Determine the label of the rendered chip
+  const selectedValueLabel = getSelectedLabel(active, pluralNoun || "items");
+
+  // If a multi-select and one value, show the icon of the selected value if it exists
+  // if there are multiple values, we don't want to show an icon
+  // if a single-select, show the icon of the selected value if it exists
+  const selectedValueIcon = getSelectedIcon(active);
+
+  const selectedValueIconProp = selectedValueIcon
+    ? { icon: selectedValueIcon, "aria-hidden": true as const }
+    : undefined;
+
+  const numActiveOptions = Array.isArray(active) ? active.length : 1;
+  const validOperatorOptions = getOperatorOptions(numActiveOptions);
+
+  return (
+    // Remove this mt="4" when we have a way to render the chips in a row
+    <Stack direction="row" align="center" my="2">
+      <Button
+        as="div"
+        variant="outline"
+        size="1"
+        // @ts-expect-error icon needs improvement
+        leadingIcon={{ icon, "aria-hidden": true }}
+      >
+        {filterName}
+      </Button>
+      <Box width="24">
+        <Combobox.Root
+          value={operator}
+          onValueChange={handleComboboxChange}
+          disabled
+        >
+          <Combobox.Trigger size="1" />
+          <Combobox.Content>
+            <Combobox.Options>
+              {validOperatorOptions.map((v) => (
+                <Combobox.Option value={v} key={v}>
+                  {OPERATOR_CONFIGS[v].label}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+            <Combobox.Empty />
+          </Combobox.Content>
+        </Combobox.Root>
+      </Box>
+      <Button
+        as="span"
+        variant="outline"
+        size="1"
+        leadingIcon={selectedValueIconProp}
+      >
+        {selectedValueLabel}
+      </Button>
+      <Button variant="outline" size="1" onClick={() => clearKey(filterKey)}>
+        Clear
+      </Button>
+    </Stack>
+  );
+};
+
+/**
+ * A container for active filter chips
+ */
+export const ChipLayout = ({ children }: { children: React.ReactNode }) => {
+  return <Box>{children}</Box>;
+};
+
+/**
+ * A display for a chip
+ */
+export const ChipDisplay = () => {
+  const { stateControl } = useFilter();
+  const { state } = stateControl;
+
+  return (
+    <ChipLayout>
+      {Object.entries(state).map(([key, value]) => {
+        return <Chip key={key} {...value} />;
+      })}
+    </ChipLayout>
+  );
+};
+
+export const Filter = {
+  Root,
+  Trigger,
+  Content,
+  Parameter,
+  Menu: FilterMenu,
+  Option,
+  Divider,
+  Chip,
+  ChipLayout,
+  ChipDisplay,
+};

--- a/packages/filter/src/Filter/helpers.ts
+++ b/packages/filter/src/Filter/helpers.ts
@@ -1,0 +1,110 @@
+import {
+  FilterOption,
+  OPERATORS,
+  OPERATOR_CONFIGS,
+  OperatorValue,
+} from "./useInternalStateController";
+
+/**
+ * Get the operator options based on the number of active options
+ * @param numActive - The number of active options
+ * @returns The operator options
+ */
+const getOperatorOptions = (numActive: number): OperatorValue[] => {
+  const operatorOptions = Object.values(OPERATORS);
+
+  // When a multi-select, with one option: show supportsSingleSelect only
+  // When a multi-select, with multiple options: show supportsMultiSelect only
+  // When a single-select, with one option: show supportsSingleSelect
+  const validOperatorOptions = operatorOptions.filter((v) => {
+    const config = OPERATOR_CONFIGS[v];
+    const showOnlySingleSelectOption = numActive === 1;
+    return showOnlySingleSelectOption
+      ? config.supportsSingleSelect
+      : config.supportsMultiSelect && !config.supportsSingleSelect;
+  });
+
+  return validOperatorOptions;
+};
+
+/**
+ * Get the icon of the selected value, renders within the chip post-selection
+ * @param active - The active value from state
+ * @returns The icon of the selected value
+ */
+const getSelectedIcon = (active: FilterOption | FilterOption[]) => {
+  // If a multi-select and one value, show the icon of the selected value if it exists
+  // if there are multiple values, we don't want to show an icon
+  // if a single-select, show the icon of the selected value if it exists
+
+  // Multi-select
+  if (Array.isArray(active)) {
+    // Use the icon if there's only one value
+    if (active.length === 1 && active[0]?.icon) {
+      return active[0].icon;
+    }
+
+    // If there are multiple values, we don't want to show an icon, going to render "2 items"
+    if (active.length > 1) {
+      return undefined;
+    }
+
+    // If there are no values, we don't want to show an icon, mostly just to make TS happy
+    return undefined;
+  }
+
+  // Single-select
+  if (active?.icon) {
+    return active.icon;
+  }
+
+  return undefined;
+};
+
+/**
+ * Get the label of the selected value, renders within the chip post-selection
+ * @param active - The active value from state
+ * @param pluralNoun - The plural noun for the parameter
+ * @returns The label of the selected value
+ */
+const getSelectedLabel = (
+  active: FilterOption | FilterOption[],
+  pluralNoun: string,
+) => {
+  // Multi-select
+  if (Array.isArray(active)) {
+    if (active.length > 1) {
+      // "2 items"
+      return `${active.length} ${pluralNoun}`;
+    }
+
+    if (active.length === 1 && active[0]) {
+      // Name of the single selected value
+      return active[0].name ?? active[0].value;
+    }
+
+    // If there are no values, we don't want to show an icon, mostly just to make TS happy
+    return undefined;
+  }
+
+  // Single-select
+  if (active?.name) {
+    return active.name;
+  }
+
+  // If there is no name, we'll just show gthe value
+  return active.value;
+};
+
+/**
+ * Get the operator based on the number of active options
+ * @param numActive - The number of active options
+ * @returns The operator
+ */
+const getOperator = (numActive: number) => {
+  const operator = numActive > 1 ? OPERATORS.isAnyOf : OPERATORS.is;
+
+  return operator;
+};
+
+export { getOperatorOptions, getSelectedIcon, getSelectedLabel, getOperator };

--- a/packages/filter/src/Filter/index.ts
+++ b/packages/filter/src/Filter/index.ts
@@ -1,0 +1,1 @@
+export { Filter } from "./Filter";

--- a/packages/filter/src/Filter/types.ts
+++ b/packages/filter/src/Filter/types.ts
@@ -1,0 +1,117 @@
+import { type LucideIcon } from "@telegraph/icon";
+
+import type { InternalFilterState } from "./useInternalStateController";
+
+export type FilterOptionValue = string | boolean | number;
+
+export type MenuContextValue = {
+  parameterContext: ParameterProps;
+  children: React.ReactNode;
+  isSearchable?: boolean;
+};
+
+export type FilterContextValue = {
+  isOpen: boolean;
+  setMenuOpen: (isOpen: boolean) => void;
+  menuContext: MenuContextValue | null;
+  setMenuContext: React.Dispatch<React.SetStateAction<MenuContextValue | null>>;
+  searchValue: string;
+  setSearchValue: (searchValue: string) => void;
+  stateControl: InternalFilterState;
+  triggerRef: React.RefObject<HTMLDivElement>;
+};
+
+export type FilterProps = {
+  children: React.ReactNode;
+};
+
+export type TriggerProps = {
+  children: React.ReactNode;
+};
+
+export type ContentProps = {
+  children: React.ReactNode;
+  isTopSearchable?: boolean;
+};
+
+/**
+ * A Menu is a generic way to refer to a menu of options
+ * It can be a submenu for nested display purposes or
+ * render a list of options for a filter
+ */
+export type MenuProps = {
+  /**
+   * Display name for this node
+   */
+  name?: string;
+  /**
+   * Icon to render in the menu
+   */
+  icon?: LucideIcon;
+  /**
+   * Hotkey to use for navigating to this option
+   */
+  hotKey?: string;
+  /**
+   * Should the list render a combobox to filter the items
+   */
+  isSearchable?: boolean;
+  children?: React.ReactNode;
+};
+
+export type ParameterBaseProps = {
+  children: React.ReactNode;
+  /**
+   * Required. The key for the parameter.
+   */
+  value: string;
+  /**
+   * Whether or not multiple options can be selected
+   */
+  isMulti?: boolean;
+  /**
+   * Display name for this filter
+   */
+  name?: string;
+  /**
+   * Icon to render for this filter when it's active
+   */
+  icon?: LucideIcon;
+};
+
+export type MultiSelectParameterProps = ParameterBaseProps & {
+  /**
+   * The plural noun for the parameter.
+   * This will be used to generate the label for the parameter.
+   * e.g. "workflow" -> "workflows"
+   */
+  pluralNoun: string;
+  /**
+   * Whether or not multiple options can be selected
+   */
+  isMulti?: true;
+};
+
+export type SingleSelectOptionProps = ParameterBaseProps & {
+  /**
+   * Not needed for single select options
+   */
+  pluralNoun?: never;
+  isMulti?: false;
+};
+
+export type ParameterProps =
+  | MultiSelectParameterProps
+  | SingleSelectOptionProps;
+
+/**
+ * Values that child menus can access about their parent parameter
+ */
+export type FilterKeyContextProps = Omit<ParameterProps, "children">;
+
+export type OptionProps = {
+  value: FilterOptionValue;
+  name?: string;
+  hotKey?: string;
+  icon?: LucideIcon;
+};

--- a/packages/filter/src/Filter/useInternalStateController.ts
+++ b/packages/filter/src/Filter/useInternalStateController.ts
@@ -1,0 +1,324 @@
+import type { LucideIcon } from "@telegraph/icon";
+import React from "react";
+
+import { getOperator } from "./helpers";
+import { FilterOptionValue, OptionProps } from "./types";
+
+export type UseInternalFilterStateProps = {
+  /**
+   * Whether to use query params to store the filter state
+   */
+  useQueryParams?: boolean;
+};
+
+/**
+ * Values for the operators.
+ *
+ * These values may be used in the URL query params, so they must be URL-safe.
+ * Query params may look like this:
+ * `?drinks=is:sodas,milk&foods=is_not:fruits,vegetables`
+ *
+ * We can get our value + operator via splitting at `:` → `["is", "sodas,milk"]`
+ * and split at `,` → `["sodas", "milk"]`
+ *
+ * We can then use the operator to determine how to process the value.
+ *
+ * TODO: Account for multi-select values, "is one of", "contains", etc.
+ */
+export const OPERATORS = {
+  is: "is",
+  isAnyOf: "is_any_of",
+} as const;
+
+export const OPERATOR_CONFIGS = {
+  [OPERATORS.is]: {
+    label: "is",
+    supportsSingleSelect: true,
+    supportsMultiSelect: true,
+  },
+  [OPERATORS.isAnyOf]: {
+    label: "is any of",
+    supportsSingleSelect: false,
+    supportsMultiSelect: true,
+  },
+} as const;
+
+export const DEFAULT_OPERATOR = OPERATORS.is;
+export type Operator = keyof typeof OPERATORS;
+export type OperatorValue = (typeof OPERATORS)[Operator];
+
+export type FilterOption = Pick<OptionProps, "value" | "name" | "icon">;
+
+export type FilterStateValue = {
+  /**
+   * The param key to use for the filter
+   */
+  filterKey: string;
+  /**
+   * The operator to use for the filter
+   * e.g. "is" or "is_any_of"
+   */
+  operator: OperatorValue;
+  /**
+   * Active options for this parameter
+   */
+  active: FilterOption | FilterOption[];
+  /**
+   * Top-level display name for the parameter
+   */
+  filterName?: string;
+  /**
+   * Top-level icon for the parameter
+   */
+  icon?: LucideIcon;
+  /**
+   * Whether the value is an array
+   */
+  isMulti?: boolean;
+  /**
+   * The plural noun for the parameter
+   */
+  pluralNoun?: string;
+};
+
+// Our filter state can receive a variety of data for passing it around to different places to render
+// Will only accept one value at a time
+export type FilterFunctionParams = Omit<FilterStateValue, "active"> & {
+  /**
+   * The upserted option to use for the filter
+   */
+  option: FilterOption;
+};
+
+type FilterState = Record<string, FilterStateValue>;
+
+/**
+ * Let's say we have a grocery list and we want to filter by certain categories
+ * Here in our example, the filter state will be refining to show only certain drinks and foods
+ * Internally, state will look like this:
+ *
+ * {
+ *  "drinks": {
+ *    "active": [
+ *      {
+ *        "value": "sodas",
+ *        "name": "Sodas",
+ *        "icon": Lucide.CupSoda
+ *      },
+ *      {
+ *        "value": "milk",
+ *        "name": "Milk",
+ *        "icon": Lucide.CupMilk
+ *      }
+ *    ],
+ *    "operator": "is_any_of",
+ *    "paramName": "Drinks",
+ *    "filterKey": "drinks",
+ *    "icon": Lucide.CupSoda,
+ *    "isMulti": true,
+ *    "pluralNoun": "drinks"
+ *  },
+ *  "foods": {...}
+ * }
+ */
+
+/**
+ * **To reference this in downstream components, use the `stateControl` property on the useFilter() hook.**
+ *
+ * This state controller for filters provides functions to manipulate filter state easily and predictably.
+ *
+ * This hook should be used only once directly, internally, at the top level of the Filter.Root component.
+ */
+export const useInternalFilterState = () => {
+  const [filterState, setFilterState] = React.useState<FilterState>({});
+
+  /**
+   * Add a value to the filter state
+   * For arrays, add the value to the array
+   * For single values, set the value
+   */
+  const add = (filterKey: string, filterObj: FilterFunctionParams) => {
+    // Pull out things we don't want to spread on the FilterStateValue
+    const { option, ...rest } = filterObj;
+    const { isMulti = false } = rest;
+
+    setFilterState((prev) => {
+      const currentFilterObj = prev[filterKey];
+      const currentValue = isMulti
+        ? ((currentFilterObj?.active || []) as FilterOption[])
+        : (currentFilterObj?.active as FilterOption);
+
+      // What the length will be after adding the new value
+      // Important for determining the operator below
+      // Length of a single-select will always be 1
+      const newLength = Array.isArray(currentValue)
+        ? currentValue.length + 1
+        : 1;
+
+      // Handle adjusting the operator based on the number of values in an array on update
+      const operator = getOperator(newLength);
+
+      const newFilterState: FilterState = {
+        // Maintain any existing state
+        ...prev,
+        [filterKey]: {
+          // Maintain any existing state on this particular key
+          ...currentFilterObj,
+          // Spread any new stuff passed in, most commonly for initial creation
+          ...rest,
+          operator,
+          // If an array, add the value to the array, otherwise just set the value
+          active: Array.isArray(currentValue)
+            ? [...currentValue, option]
+            : option,
+        },
+      };
+      return newFilterState;
+    });
+  };
+
+  /**
+   * Remove a value from the filter state
+   * For arrays, remove the value from the array
+   * For single values, remove the key from state
+   * For both, if empty, remove the key from state
+   */
+  const remove = (filterKey: string, value: FilterOptionValue) => {
+    const currentFilterObj = filterState[filterKey] as FilterStateValue;
+    const currentValue = currentFilterObj.active;
+
+    // newValue will always be null if it's not an array
+    // For non multi-select, we're just going to unset the value
+    const newValue = Array.isArray(currentValue)
+      ? currentValue.filter((v) => v.value !== value)
+      : null;
+
+    // What the length will be after adding the new value
+    // Important for determining the operator below
+    // Length of a single-select will always be 1
+    const newLength = Array.isArray(newValue) ? newValue.length : 1;
+
+    // Handle adjusting the operator based on the number of values in an array on update
+    const operator = getOperator(newLength);
+
+    // If the value is null or an empty array, remove the key
+    const shouldRemoveKey = !newValue || newValue?.length === 0;
+
+    // If the value is empty or null, remove the key
+    if (shouldRemoveKey) {
+      return setFilterState((prev) => {
+        const newFilterState = { ...prev };
+        delete newFilterState[filterKey];
+        return newFilterState;
+      });
+    }
+
+    // If there are still values in the array, update the value
+    return setFilterState(
+      (prev) =>
+        ({
+          ...prev,
+          [filterKey]: {
+            ...currentFilterObj,
+            active: newValue,
+            operator,
+          },
+        }) as FilterState,
+    );
+  };
+
+  /**
+   * Update a key in the filter state
+   */
+  const updateKey = (
+    filterKey: string,
+    newFilterObj: Partial<FilterStateValue>,
+  ) => {
+    // If the key doesn't exist, do nothing
+    if (!filterState[filterKey]) {
+      console.warn(
+        `Calling updateKey on ${filterKey} but it does not exist in filter state`,
+      );
+      return;
+    }
+    // Maintain existing state and spread any updates onto the existing key
+    return setFilterState(
+      (prev) =>
+        ({
+          ...prev,
+          [filterKey]: {
+            ...prev[filterKey],
+            ...newFilterObj,
+          },
+        }) as FilterState,
+    );
+  };
+
+  /**
+   * Remove a specific key from the filter state
+   */
+  const clearKey = (filterKey: string) => {
+    // If the key doesn't exist, do nothing
+    if (!filterState[filterKey]) return;
+    return setFilterState((prev) => {
+      const newFilterState = { ...prev };
+      delete newFilterState[filterKey];
+      return newFilterState;
+    });
+  };
+
+  /**
+   * Reset to an empty filter state
+   */
+  const reset = () => {
+    return setFilterState({});
+  };
+
+  /**
+   * Check if a specific key/value pair is present in the filter state
+   */
+  const isKeyValueActive = (filterKey: string, value: FilterOptionValue) => {
+    const currentFilterObj = filterState[filterKey];
+    const currentValue = currentFilterObj?.active;
+    return Array.isArray(currentValue)
+      ? !!currentValue.find((v) => v.value === value)
+      : currentValue?.value === value;
+  };
+
+  /**
+   * Toggle the presence of a specific key/value pair in the filter state
+   * if the value is already present, remove it, otherwise add it
+   * functions like an upsert for a specific key/value pair
+   */
+  const toggle = (filterKey: string, filterObj: FilterFunctionParams) => {
+    const { option } = filterObj;
+    const isValueActive = isKeyValueActive(filterKey, option.value);
+
+    return isValueActive
+      ? remove(filterKey, option.value)
+      : add(filterKey, filterObj);
+  };
+
+  /**
+   * Get the value of a specific key in the filter state
+   */
+  const getValue = (filterKey: string) => {
+    const currentFilterObj = filterState[filterKey];
+    const currentValue = currentFilterObj?.active;
+    return currentValue;
+  };
+
+  return {
+    state: filterState,
+    add,
+    remove,
+    updateKey,
+    clearKey,
+    reset,
+    toggle,
+    getValue,
+    isKeyValueActive,
+  };
+};
+
+export type InternalFilterState = ReturnType<typeof useInternalFilterState>;

--- a/packages/filter/src/index.ts
+++ b/packages/filter/src/index.ts
@@ -1,0 +1,1 @@
+export { Filter } from "./Filter";

--- a/packages/filter/tsconfig.json
+++ b/packages/filter/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@knocklabs/typescript-config/react-library.json",
+  "display": "@telegraph/filter",
+  "compilerOptions": {
+    "outDir": "dist",
+    "paths": {
+      "vitest.*": ["../../vitest/*"]
+    },
+    "types": ["@testing-library/jest-dom", "node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
+}

--- a/packages/filter/vite.config.mts
+++ b/packages/filter/vite.config.mts
@@ -1,0 +1,7 @@
+import {
+  defaultViteConfig,
+  styleEngineViteConfig,
+} from "@telegraph/vite-config";
+import { mergeConfig } from "vite";
+
+export default mergeConfig(defaultViteConfig, styleEngineViteConfig);

--- a/packages/filter/vitest.config.mts
+++ b/packages/filter/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "filter",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/menu/src/MenuItem/MenuItem.stories.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.stories.tsx
@@ -79,12 +79,26 @@ export const Default: Story = {
     const selected = type === "selectable" ? selectedProp : undefined;
     console.log(selected, type, args);
     return (
-      <TelegraphMenuItem
-        selected={selected}
-        leadingIcon={leadingIcon}
-        trailingIcon={trailingIcon}
-        {...args}
-      />
+      <>
+        <TelegraphMenuItem
+          selected={selected}
+          leadingIcon={leadingIcon}
+          trailingIcon={trailingIcon}
+          {...args}
+        />
+        <TelegraphMenuItem
+          selected={selected}
+          leadingIcon={leadingIcon}
+          trailingIcon={trailingIcon}
+          {...args}
+        />
+        <TelegraphMenuItem
+          selected={selected}
+          leadingIcon={leadingIcon}
+          trailingIcon={trailingIcon}
+          {...args}
+        />
+      </>
     );
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4949,7 +4949,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@telegraph/combobox@workspace:*, @telegraph/combobox@workspace:packages/combobox":
+"@telegraph/combobox@workspace:*, @telegraph/combobox@workspace:^, @telegraph/combobox@workspace:packages/combobox":
   version: 0.0.0-use.local
   resolution: "@telegraph/combobox@workspace:packages/combobox"
   dependencies:
@@ -4991,6 +4991,32 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.3"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/prettier-config": "workspace:^"
+    "@telegraph/vite-config": "workspace:^"
+    "@types/react": "npm:^18.3.18"
+    eslint: "npm:^8.56.0"
+    react: "npm:^18.3.1"
+    react-dom: "npm:^18.3.1"
+    typescript: "npm:^5.7.3"
+    vite: "npm:^6.0.11"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  languageName: unknown
+  linkType: soft
+
+"@telegraph/filter@workspace:packages/filter":
+  version: 0.0.0-use.local
+  resolution: "@telegraph/filter@workspace:packages/filter"
+  dependencies:
+    "@knocklabs/eslint-config": "npm:^0.0.3"
+    "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@telegraph/button": "workspace:^"
+    "@telegraph/combobox": "workspace:^"
+    "@telegraph/icon": "workspace:^"
+    "@telegraph/layout": "workspace:^"
+    "@telegraph/menu": "workspace:^"
+    "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^18.3.18"


### PR DESCRIPTION
### TL;DR

This component is a WIP. When writing this component originally, I intended to move it into Telegraph further down the line.

Some things I wanted to improve before making this package available:
- Finish styling to match designs
- Better typing to remove `@ts-expect-errors`
- Better flexibility around rendering support component (not just passing in a LucideIcon -- what if we want something else?)
- Better composibility around secondary update (when clicking a Chip, update value -- what kind of component gets shown?)
- Microanimations
- Remove query param for telegraph -- this should be done by consumer by accessing the state
- Add docs
- Add hotkey support

Add a new Filter component package to Telegraph

### What changed?

- Created a new `@telegraph/filter` package with a flexible filter component
- Implemented a composable filter system with support for:
  - Single and multi-select filtering
  - Nested filter menus
  - Filter operators (is, is any of)
  - Filter chips to display active filters
- Added comprehensive state management with `useInternalFilterState` hook
- Included Storybook examples to demonstrate usage

### How to test?

1. Run the Storybook and navigate to the Filter component
2. Test the filter functionality:
   - Click on filter options to select them
   - Test multi-select functionality
   - Navigate through nested menus
   - Verify filter chips appear when options are selected
   - Test clearing filters

### Why make this change?

This adds a new component to the Telegraph design system that allows users to create complex filtering interfaces. The filter component is designed to be flexible and composable, supporting both simple and advanced filtering scenarios while maintaining a consistent user experience.