### PR TITLE
feat: combobox custom trigger

### DIFF
--- a/.changeset/sharp-ants-drive.md
+++ b/.changeset/sharp-ants-drive.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/helpers": patch
+---
+
+adds support for custom triggers in the combobox

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -420,7 +420,9 @@ export const SingleSelectWithCustomTrigger: Story = {
           placeholder={"Select a channel"}
           clearable
         >
-          <TelegraphCombobox.Trigger size="1">Hello</TelegraphCombobox.Trigger>
+          <TelegraphCombobox.Trigger<typeof value> size="1">
+            {({ value }) => value?.label}
+          </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
               {values.map((v, index) => (
@@ -451,8 +453,8 @@ export const MultiSelectWithCustomTrigger: Story = {
           placeholder={"Select a channel"}
           clearable
         >
-          <TelegraphCombobox.Trigger size="1">
-            {(params) => JSON.stringify(params.value)}
+          <TelegraphCombobox.Trigger<typeof value> size="1">
+            {(params) => params.value.map((v) => v.label)?.join(", ")}
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -405,3 +405,67 @@ export const LegacyComboboxMultiSelect: Story = {
     );
   },
 };
+
+export const SingleSelectWithCustomTrigger: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = React.useState(firstValue);
+
+    return (
+      <Box w="80">
+        <TelegraphCombobox.Root
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          placeholder={"Select a channel"}
+          clearable
+        >
+          <TelegraphCombobox.Trigger size="1">Hello</TelegraphCombobox.Trigger>
+          <TelegraphCombobox.Content>
+            <TelegraphCombobox.Options>
+              {values.map((v, index) => (
+                <TelegraphCombobox.Option value={v}>
+                  {labels[index]}
+                </TelegraphCombobox.Option>
+              ))}
+            </TelegraphCombobox.Options>
+            <TelegraphCombobox.Empty />
+          </TelegraphCombobox.Content>
+        </TelegraphCombobox.Root>
+      </Box>
+    );
+  },
+};
+
+export const MultiSelectWithCustomTrigger: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = React.useState([firstValue]);
+
+    return (
+      <Box w="80">
+        <TelegraphCombobox.Root
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          placeholder={"Select a channel"}
+          clearable
+        >
+          <TelegraphCombobox.Trigger size="1">
+            {(params) => JSON.stringify(params.value)}
+          </TelegraphCombobox.Trigger>
+          <TelegraphCombobox.Content>
+            <TelegraphCombobox.Options>
+              {values.map((v, index) => (
+                <TelegraphCombobox.Option value={v}>
+                  {labels[index]}
+                </TelegraphCombobox.Option>
+              ))}
+            </TelegraphCombobox.Options>
+            <TelegraphCombobox.Empty />
+          </TelegraphCombobox.Content>
+        </TelegraphCombobox.Root>
+      </Box>
+    );
+  },
+};

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -420,7 +420,7 @@ export const SingleSelectWithCustomTrigger: Story = {
           placeholder={"Select a channel"}
           clearable
         >
-          <TelegraphCombobox.Trigger<typeof value> size="1">
+          <TelegraphCombobox.Trigger<typeof value>>
             {({ value }) => value?.label}
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
@@ -453,7 +453,7 @@ export const MultiSelectWithCustomTrigger: Story = {
           placeholder={"Select a channel"}
           clearable
         >
-          <TelegraphCombobox.Trigger<typeof value> size="1">
+          <TelegraphCombobox.Trigger<typeof value>>
             {(params) => params.value.map((v) => v.label)?.join(", ")}
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -390,7 +390,16 @@ const TriggerValue = () => {
   }
 };
 
-type TriggerProps = Omit<
+// When utilizing the `children` prop as a function, we need to infer the type of the value
+// to ensure that the value is always defined. We do this via the generic `V` passed through
+// to the `Trigger` component. This is expected to be `typeof value`.
+type ChildrenFnValue<V extends string | Array<string> | never> = V extends never
+  ? never
+  : V extends string
+    ? DefinedOption | undefined
+    : Array<DefinedOption>;
+
+type TriggerProps<V extends string | Array<string> | never> = Omit<
   React.ComponentProps<typeof TelegraphMenu.Trigger>,
   "children"
 > & {
@@ -398,12 +407,14 @@ type TriggerProps = Omit<
   size?: TgphComponentProps<typeof TelegraphButton.Root>["size"];
   children?:
     | React.ReactNode
-    | ((props: {
-        value: DefinedOption | Array<DefinedOption | undefined> | undefined;
-      }) => React.ReactNode);
+    | ((props: { value: ChildrenFnValue<V> }) => React.ReactNode);
 };
 
-const Trigger = ({ size = "2", children, ...props }: TriggerProps) => {
+const Trigger = <V extends string | Array<string> | never>({
+  size = "2",
+  children,
+  ...props
+}: TriggerProps<V>) => {
   const context = React.useContext(ComboboxContext);
 
   const currentValue = React.useMemo<

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -8,6 +8,7 @@ export type {
   TgphElement,
   TgphComponentProps,
   OptionalAsPropConfig,
+  RemappedOmit,
 } from "./types/utility";
 
 export { RefToTgphRef } from "./components/RefToTgphRef";

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -66,3 +66,12 @@ export type TgphComponentProps<T extends React.ElementType> =
 // The `TgphElement` is a wrapper on the React.ElementType type that allows you to
 // pass a component as a prop to another component.
 export type TgphElement = React.ElementType;
+
+// The `RemappedOmit` type is a utility type that allows you to remove specific
+// fields from a type. Unlike the standard `Omit` type, this ensures the removed
+// fields are completely eliminated rather than potentially resolving to
+// `Record<string, any>`. It takes a type `T` and a union of property keys `K`
+// to remove from that type.
+export type RemappedOmit<T, K extends PropertyKey> = {
+  [P in keyof T as P extends K ? never : P]: T[P];
+};


### PR DESCRIPTION
### Description
- Adds support for passing a custom `children` value (either a React node or a function) to `Combobox.Trigger`, giving you full control over how the trigger is rendered. This is helpful when the trigger’s appearance should differ from the options — for example, if you only want to show a label, display an icon, or format the value in a specific way.
- When using a function, the `children` callback receives the current `value`, and TypeScript will infer its type based on whether the combobox is in single- or multi-select mode. If needed, you can explicitly pass `typeof value` to guide inference.
- Fixes a bug where `Button` and `Menu.Trigger` props weren’t being properly applied to `Combobox.Trigger`.

### Example
```tsx
const [value, setValue] = React.useState("value");

return (
  <Box w="80">
    <TelegraphCombobox.Root
      {...args}
      value={value}
      onValueChange={setValue}
      placeholder="Select a channel"
      clearable
    >
      {/* NOTE 📝 We're passing in `typeof value` here to ensure correct typing inside the `children` function */}
      <TelegraphCombobox.Trigger<typeof value>>
        {({ value }) => value?.label}
      </TelegraphCombobox.Trigger>

      <TelegraphCombobox.Content>
        <TelegraphCombobox.Options>
          {values.map((v, index) => (
            <TelegraphCombobox.Option key={v} value={v}>
              {labels[index]}
            </TelegraphCombobox.Option>
          ))}
        </TelegraphCombobox.Options>
        <TelegraphCombobox.Empty />
      </TelegraphCombobox.Content>
    </TelegraphCombobox.Root>
  </Box>
);
```

### Tasks
[KNO-8261](https://linear.app/knock/issue/KNO-8261/[telegraph]-decouple-styling-of-selected-tags-from-selectable-options)