### PR TITLE
feat: combobox primitive trigger parts

### DIFF
--- a/.changeset/tender-taxis-invite.md
+++ b/.changeset/tender-taxis-invite.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/button": patch
+"@telegraph/tag": patch
+---
+
+add combobox primitive trigger components

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,6 +1,7 @@
 import {
   type PolymorphicProps,
   type PolymorphicPropsWithTgphRef,
+  RemappedOmit,
   type Required,
   type TgphComponentProps,
   type TgphElement,
@@ -209,7 +210,7 @@ const Icon = <T extends TgphElement>({
   );
 };
 
-type TextProps<T extends TgphElement> = Omit<
+type TextProps<T extends TgphElement> = RemappedOmit<
   TgphComponentProps<typeof TelegraphText<T>>,
   "as"
 > & {

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -3,6 +3,7 @@
 [![npm version](https://img.shields.io/npm/v/@telegraph/button.svg)](https://www.npmjs.com/package/@telegraph/combobox)
 
 # @telegraph/combobox
+
 > A styled menu, triggered by a Select, that combines an Input and Single- or Multi-select.
 
 ## Installation Instructions
@@ -12,6 +13,479 @@ npm install @telegraph/combobox
 ```
 
 ### Add stylesheet
+
 ```
 @import "@telegraph/combobox"
 ```
+
+### Basic Usage
+
+A combobox component that combines input and select functionality with a searchable dropdown menu.
+
+#### `<Combobox/>`
+
+```tsx
+import { Combobox } from "@telegraph/combobox";
+import { useState } from "react";
+
+// Single select example
+const SingleSelectExample = () => {
+  const [value, setValue] = useState<string>("");
+
+  return (
+    <Combobox.Root value={value} onValueChange={setValue}>
+      <Combobox.Trigger placeholder="Select an option..." />
+      <Combobox.Content>
+        <Combobox.Search />
+        <Combobox.Options>
+          <Combobox.Option value="option1">Option 1</Combobox.Option>
+          <Combobox.Option value="option2">Option 2</Combobox.Option>
+        </Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+
+// Multi select example
+const MultiSelectExample = () => {
+  const [values, setValues] = useState<string[]>([]);
+
+  return (
+    <Combobox.Root value={values} onValueChange={setValues}>
+      <Combobox.Trigger placeholder="Select options..." />
+      <Combobox.Content>
+        <Combobox.Search />
+        <Combobox.Options>
+          <Combobox.Option value="option1">Option 1</Combobox.Option>
+          <Combobox.Option value="option2">Option 2</Combobox.Option>
+        </Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+```
+
+### Type Examples
+
+#### Single Select Types
+
+```tsx
+// String values (recommended)
+const [value, setValue] = useState<string>("");
+```
+
+#### Multi Select Types
+
+```tsx
+// String array values (recommended)
+const [values, setValues] = useState<string[]>([]);
+```
+
+### Accessibility
+
+The combobox implements the [ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), providing:
+
+- Proper ARIA roles and attributes
+- Keyboard navigation:
+  - `↓` / `↑`: Navigate options
+  - `Enter` / `Space`: Select option
+  - `Escape`: Close dropdown
+  - `Tab`: Move focus
+- Screen reader announcements for selection changes
+- Focus management
+
+### Common Patterns
+
+#### Form Integration
+
+```tsx
+import { useForm } from "react-hook-form";
+
+const MyForm = () => {
+  const { register, setValue } = useForm();
+
+  return (
+    <form>
+      <Combobox.Root onValueChange={(value) => setValue("field", value)}>
+        {/* ... */}
+      </Combobox.Root>
+    </form>
+  );
+};
+```
+
+#### Custom Filtering
+
+```tsx
+const MyCombobox = () => {
+  const [searchQuery, setSearchQuery] = useState("");
+  const options = useMemo(
+    () =>
+      allOptions.filter((opt) =>
+        opt.toLowerCase().includes(searchQuery.toLowerCase()),
+      ),
+    [searchQuery],
+  );
+
+  return (
+    <Combobox.Root>
+      <Combobox.Content>
+        <Combobox.Search value={searchQuery} onValueChange={setSearchQuery} />
+        <Combobox.Options>
+          {options.map((opt) => (
+            <Combobox.Option key={opt} value={opt}>
+              {opt}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+```
+
+#### Async Loading
+
+```tsx
+const AsyncCombobox = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [options, setOptions] = useState([]);
+
+  const loadOptions = async (query) => {
+    setIsLoading(true);
+    const results = await fetchOptions(query);
+    setOptions(results);
+    setIsLoading(false);
+  };
+
+  return (
+    <Combobox.Root>
+      <Combobox.Content>
+        <Combobox.Search onValueChange={loadOptions} />
+        <Combobox.Options>
+          {isLoading ? (
+            <Box p="4" textAlign="center">
+              Loading...
+            </Box>
+          ) : (
+            options.map((opt) => (
+              <Combobox.Option key={opt} value={opt}>
+                {opt}
+              </Combobox.Option>
+            ))
+          )}
+        </Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+```
+
+#### Error States
+
+```tsx
+const ErrorCombobox = () => {
+  const [error, setError] = useState("");
+
+  return (
+    <Stack gap="1">
+      <Combobox.Root errored={!!error}>{/* ... */}</Combobox.Root>
+      {error && (
+        <Text color="red" size="1">
+          {error}
+        </Text>
+      )}
+    </Stack>
+  );
+};
+```
+
+### Component Parts
+
+#### `<Combobox.Root/>`
+
+The root component that manages the state and context for the combobox.
+
+##### Props
+
+| Name           | Type                                                      | Default    | Description                        |
+| -------------- | --------------------------------------------------------- | ---------- | ---------------------------------- |
+| value          | string \| string[] \| Option \| Option[]                  | undefined  | The selected value(s)              |
+| onValueChange  | (value: string \| string[] \| Option \| Option[]) => void | undefined  | Callback when selection changes    |
+| layout         | "truncate" \| "wrap"                                      | "truncate" | How to display multiple selections |
+| open           | boolean                                                   | undefined  | Controlled open state              |
+| defaultOpen    | boolean                                                   | false      | Initial open state                 |
+| errored        | boolean                                                   | false      | Shows error styling                |
+| placeholder    | string                                                    | undefined  | Placeholder text                   |
+| onOpenChange   | (open: boolean) => void                                   | undefined  | Callback when open state changes   |
+| modal          | boolean                                                   | true       | Whether to render in a modal       |
+| closeOnSelect  | boolean                                                   | true       | Close menu after selection         |
+| clearable      | boolean                                                   | false      | Show clear button                  |
+| disabled       | boolean                                                   | false      | Disable the combobox               |
+| legacyBehavior | boolean                                                   | false      | Use legacy object format           |
+
+#### `<Combobox.Trigger/>`
+
+The button that triggers the combobox dropdown.
+
+For advanced customization of the trigger's internal components (indicator, clear button, text display, etc.), see the [Trigger Primitives](#trigger-primitives) section below.
+
+##### Props
+
+| Name        | Type              | Default   | Description            |
+| ----------- | ----------------- | --------- | ---------------------- |
+| size        | "1" \| "2" \| "3" | "2"       | Size of the trigger    |
+| placeholder | string            | undefined | Placeholder text       |
+| children    | ReactNode         | undefined | Custom trigger content |
+
+#### `<Combobox.Content/>`
+
+The dropdown menu content container.
+
+##### Props
+
+Accepts all props from `TelegraphMenu.Content`
+
+#### `<Combobox.Options/>`
+
+Container for the option items.
+
+##### Props
+
+Accepts all props from `Stack` component
+
+#### `<Combobox.Option/>`
+
+Individual selectable option item.
+
+##### Props
+
+| Name     | Type    | Default   | Description          |
+| -------- | ------- | --------- | -------------------- |
+| value    | string  | required  | Option value         |
+| label    | string  | undefined | Display label        |
+| selected | boolean | undefined | Force selected state |
+
+#### `<Combobox.Search/>`
+
+Search input field for filtering options.
+
+##### Props
+
+| Name        | Type   | Default  | Description         |
+| ----------- | ------ | -------- | ------------------- |
+| label       | string | "Search" | Accessibility label |
+| placeholder | string | "Search" | Input placeholder   |
+
+#### `<Combobox.Empty/>`
+
+Empty state component shown when no options match search.
+
+##### Props
+
+| Name    | Type              | Default            | Description         |
+| ------- | ----------------- | ------------------ | ------------------- |
+| icon    | IconProps \| null | SearchIcon         | Empty state icon    |
+| message | string \| null    | "No results found" | Empty state message |
+
+#### `<Combobox.Create/>`
+
+Option to create new values when none match search.
+
+##### Props
+
+| Name        | Type                              | Default   | Description              |
+| ----------- | --------------------------------- | --------- | ------------------------ |
+| leadingText | string                            | "Create"  | Text before search value |
+| values      | string[] \| Option[]              | undefined | Existing values          |
+| onCreate    | (value: string \| Option) => void | undefined | Creation callback        |
+
+### Primitives
+
+The combobox includes several primitive components for advanced customization. These primitives allow you to build custom trigger layouts and behaviors while maintaining the combobox's core functionality.
+
+#### Trigger Primitives
+
+##### `<Combobox.Primitives.TriggerIndicator/>`
+
+The dropdown chevron icon that rotates based on the combobox's open state.
+
+###### Props
+
+| Name        | Type      | Default     | Description                         |
+| ----------- | --------- | ----------- | ----------------------------------- |
+| icon        | IconProps | ChevronDown | The icon to display                 |
+| aria-hidden | boolean   | true        | Whether to hide from screen readers |
+
+```tsx
+<Combobox.Primitives.TriggerIndicator icon={CustomIcon} aria-hidden={false} />
+```
+
+##### `<Combobox.Primitives.TriggerClear/>`
+
+A button to clear the current selection(s). Only shown when `clearable` is true and there are selections.
+
+###### Props
+
+| Name         | Type                               | Default   | Description           |
+| ------------ | ---------------------------------- | --------- | --------------------- |
+| tooltipProps | TgphComponentProps<typeof Tooltip> | undefined | Props for the tooltip |
+
+Accepts all props from `Button`
+
+```tsx
+<Combobox.Primitives.TriggerClear tooltipProps={{ delay: 300 }} />
+```
+
+##### `<Combobox.Primitives.TriggerText/>`
+
+Displays the selected value's text or label. Used in single-select mode.
+
+###### Props
+
+Accepts all props from `Button.Text`
+
+```tsx
+<Combobox.Primitives.TriggerText color="blue" weight="medium" />
+```
+
+##### `<Combobox.Primitives.TriggerPlaceholder/>`
+
+Shows placeholder text when no value is selected.
+
+###### Props
+
+Accepts all props from `Button.Text`
+
+```tsx
+<Combobox.Primitives.TriggerPlaceholder color="gray-8" />
+```
+
+##### `<Combobox.Primitives.TriggerTagsContainer/>`
+
+Container for selected value tags in multi-select mode. Handles tag layout and truncation.
+
+###### Props
+
+Accepts all props from `Stack`
+
+```tsx
+<Combobox.Primitives.TriggerTagsContainer gap="2" wrap="wrap" />
+```
+
+##### `<Combobox.Primitives.TriggerTag/>`
+
+A collection of components for building custom tags in multi-select mode:
+
+###### `<Combobox.Primitives.TriggerTag.Root/>`
+
+The base container for a tag.
+
+Props:
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| value | string | required | The value this tag represents |
+
+###### `<Combobox.Primitives.TriggerTag.Text/>`
+
+The text content of a tag.
+
+Props: Accepts all props from `Text`
+
+###### `<Combobox.Primitives.TriggerTag.Button/>`
+
+The remove button for a tag.
+
+Props: Accepts all props from `Button`
+
+###### `<Combobox.Primitives.TriggerTag.Default/>`
+
+A pre-composed tag with text and remove button.
+
+Props:
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| value | string | required | The value this tag represents |
+
+Example of a custom tag layout:
+
+```tsx
+<Combobox.Primitives.TriggerTag.Root value="example">
+  <Icon icon={CustomIcon} />
+  <Combobox.Primitives.TriggerTag.Text>
+    Custom Tag
+  </Combobox.Primitives.TriggerTag.Text>
+  <Combobox.Primitives.TriggerTag.Button
+    icon={{ icon: XIcon, alt: "Remove" }}
+  />
+</Combobox.Primitives.TriggerTag.Root>
+```
+
+Example of using the default tag:
+
+```tsx
+<Combobox.Primitives.TriggerTag.Default value="example" />
+```
+
+Complete example using primitives for a custom trigger layout:
+
+```tsx
+<Combobox.Root>
+  <Combobox.Trigger>
+    <Stack direction="row" justify="space-between" align="center" w="full">
+      {/* Left side: Text or Tags */}
+      <Box flex="1" overflow="hidden">
+        <Combobox.Primitives.TriggerTagsContainer>
+          <Combobox.Primitives.TriggerTag.Default value="tag1" />
+          <Combobox.Primitives.TriggerTag.Default value="tag2" />
+        </Combobox.Primitives.TriggerTagsContainer>
+      </Box>
+
+      {/* Right side: Clear and Indicator */}
+      <Stack direction="row" gap="1" align="center">
+        <Combobox.Primitives.TriggerClear />
+        <Box borderLeft="1" h="4" />
+        <Combobox.Primitives.TriggerIndicator />
+      </Stack>
+    </Stack>
+  </Combobox.Trigger>
+  <Combobox.Content>{/* ... */}</Combobox.Content>
+</Combobox.Root>
+```
+
+### Legacy Behavior (⚠️ Deprecated)
+
+> **Warning**: Legacy behavior is deprecated and will be removed in a future version. New implementations should use string values instead of objects.
+
+The `legacyBehavior` prop changes how values are handled:
+
+- When `false` (default, recommended): Values are simple strings
+- When `true` (deprecated): Values are objects with `{ value: string; label?: string }`
+
+#### Legacy Single Select Types
+
+```tsx
+// ⚠️ Deprecated - Don't use in new code
+const [value, setValue] = useState<{ value: string; label?: string }>()
+
+<Combobox.Root
+  value={value}
+  onValueChange={setValue}
+  legacyBehavior={true}
+>
+```
+
+#### Legacy Multi Select Types
+
+```tsx
+// ⚠️ Deprecated - Don't use in new code
+const [values, setValues] = useState<Array<{ value: string; label?: string }>>([])
+
+<Combobox.Root
+  value={values}
+  onValueChange={setValues}
+  legacyBehavior={true}
+>
+```
+
+This object-based value pattern is only maintained for backwards compatibility and should not be used in new code. It will be removed in a future major version.

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -1,10 +1,7 @@
 import React from "react";
 
-export type DefinedOption = {
-  value: string;
-  label?: string | React.ReactNode;
-};
-export type Option = DefinedOption | string | React.ReactNode;
+import type { DefinedOption, Option } from "./Combobox.types";
+
 export const isMultiSelect = (
   value: Option | Array<Option> | undefined,
 ): value is Array<Option> => {

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -1,0 +1,420 @@
+import { Button } from "@telegraph/button";
+import { type TgphComponentProps, type TgphElement } from "@telegraph/helpers";
+import { Lucide } from "@telegraph/icon";
+import { Box, Stack } from "@telegraph/layout";
+import { AnimatePresence, motion } from "@telegraph/motion";
+import { Tag } from "@telegraph/tag";
+import { Tooltip } from "@telegraph/tooltip";
+import { Text } from "@telegraph/typography";
+import React from "react";
+
+import { ComboboxContext } from "./Combobox";
+import {
+  getCurrentOption,
+  getValueFromOption,
+  isMultiSelect,
+  isSingleSelect,
+} from "./Combobox.helpers";
+import type {
+  DefinedOption,
+  MultiSelect,
+  Option,
+  SingleSelect,
+} from "./Combobox.types";
+
+type TriggerIndicatorProps<T extends TgphElement> = Partial<
+  TgphComponentProps<typeof Button.Icon<T>>
+>;
+
+const TriggerIndicator = <T extends TgphElement>({
+  icon = Lucide.ChevronDown,
+  "aria-hidden": ariaHidden = true,
+  ...props
+}: TriggerIndicatorProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+  return (
+    <Button.Icon
+      as={motion.span}
+      animate={{ rotate: context.open ? 180 : 0 }}
+      transition={{ duration: 150, type: "spring" }}
+      icon={icon}
+      aria-hidden={ariaHidden}
+      {...props}
+    />
+  );
+};
+
+type TriggerClearProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button<T>
+> & {
+  tooltipProps?: TgphComponentProps<typeof Tooltip>;
+};
+
+const TriggerClear = <T extends TgphElement>({
+  tooltipProps,
+  ...props
+}: TriggerClearProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+
+  const handleClear = () => {
+    if (isMultiSelect(context.value)) {
+      const onValueChange =
+        context.onValueChange as MultiSelect["onValueChange"];
+      onValueChange?.([]);
+    }
+
+    if (isSingleSelect(context.value)) {
+      const onValueChange =
+        context.onValueChange as SingleSelect["onValueChange"];
+      onValueChange?.(undefined);
+    }
+    context.triggerRef?.current?.focus();
+  };
+
+  const shouldShowClearable = React.useMemo(() => {
+    if (isSingleSelect(context.value)) {
+      return context.clearable && context.value;
+    }
+
+    if (isMultiSelect(context.value)) {
+      return context.clearable && context.value?.length > 0;
+    }
+  }, [context.clearable, context.value]);
+
+  if (!shouldShowClearable) return null;
+
+  return (
+    <Tooltip label="Clear field" {...tooltipProps}>
+      <Button
+        type="button"
+        icon={{ icon: Lucide.X, alt: "Clear field" }}
+        size="1"
+        variant="ghost"
+        onClick={(event: React.MouseEvent) => {
+          if (!context.value) return;
+          event.stopPropagation();
+          handleClear();
+        }}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.stopPropagation();
+            handleClear();
+          }
+        }}
+        data-tgph-combobox-clear
+        style={{
+          // Remove margin to make the clear button flush
+          // with the trigger button
+          marginTop: "calc(-1 * var(--tgph-spacing-1)",
+          marginBottom: "calc(-1 * var(--tgph-spacing-1)",
+        }}
+        {...props}
+      />
+    </Tooltip>
+  );
+};
+
+type TriggerTextProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button.Text<T>
+>;
+
+const TriggerText = <T extends TgphElement>({
+  children,
+  ...props
+}: TriggerTextProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+
+  const label = React.useMemo(() => {
+    if (!isSingleSelect(context.value)) return;
+
+    const currentOption = getCurrentOption(
+      context.value,
+      context.options,
+      context.legacyBehavior,
+    );
+
+    const label =
+      currentOption?.label || currentOption?.value || context.placeholder;
+
+    // In `legacyBehavior` mode, we can override the label of the combobox via the `label` prop
+    // in context value. So, if we're in `legacyBehavior` mode and the context value has a
+    // label, we want to use that label instead of the label from the current option
+    const legacyLabelOverride =
+      context.legacyBehavior && (context?.value as DefinedOption)?.label;
+
+    return legacyLabelOverride ? legacyLabelOverride : label;
+  }, [
+    context.value,
+    context.options,
+    context.legacyBehavior,
+    context.placeholder,
+  ]);
+
+  return (
+    <Button.Text
+      color={!context.value ? "gray" : "default"}
+      textOverflow="ellipsis"
+      overflow="hidden"
+      {...props}
+    >
+      {children || label}
+    </Button.Text>
+  );
+};
+
+type TriggerPlaceholderProps<T extends TgphElement> = TgphComponentProps<
+  typeof Button.Text<T>
+>;
+
+const TriggerPlaceholder = <T extends TgphElement>({
+  children,
+  ...props
+}: TriggerPlaceholderProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+  return (
+    <Button.Text color="gray" {...props}>
+      {children || context.placeholder}
+    </Button.Text>
+  );
+};
+
+type TriggerTagsContainerProps = TgphComponentProps<typeof Stack>;
+
+const TriggerTagsContainer = ({ children }: TriggerTagsContainerProps) => {
+  const context = React.useContext(ComboboxContext);
+
+  if (!isMultiSelect(context.value)) return null;
+
+  const layout = context.layout || "truncate";
+  const truncatedLength = context.value.length - 2;
+  const truncatedLengthStringArray = truncatedLength.toString().split("");
+
+  return (
+    <Stack
+      gap="1"
+      w="full"
+      wrap={layout === "wrap" ? "wrap" : "nowrap"}
+      align="center"
+      style={{
+        position: "relative",
+        flexGrow: 1,
+      }}
+    >
+      <AnimatePresence
+        presenceMap={context.value.map((v) => {
+          const value = getValueFromOption(v, context.legacyBehavior);
+          return {
+            "tgph-motion-key": value || "",
+            value: true,
+          };
+        })}
+      >
+        {children}
+      </AnimatePresence>
+      <AnimatePresence
+        presenceMap={[
+          {
+            "tgph-motion-key": "combobox-more",
+            value: true,
+          },
+        ]}
+      >
+        {layout === "truncate" && context.value.length > 2 && (
+          <Stack
+            as={motion.div}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 100, type: "spring" }}
+            h="full"
+            pr="1"
+            pl="8"
+            align="center"
+            aria-label={`${context.value.length - 2} more selected`}
+            position="absolute"
+            right="0"
+            style={{
+              backgroundImage:
+                "linear-gradient(to left, var(--tgph-surface-1) 0 60%, transparent 90% 100%)",
+            }}
+          >
+            <Text as="span" size="1" style={{ whiteSpace: "nowrap" }}>
+              +
+              <AnimatePresence
+                presenceMap={truncatedLengthStringArray.map((n) => ({
+                  "tgph-motion-key": n,
+                  value: true,
+                }))}
+              >
+                {truncatedLengthStringArray.map((n) => (
+                  <Box
+                    as={motion.span}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 100, type: "spring" }}
+                    w="2"
+                    display="inline-block"
+                    tgph-motion-key={n}
+                    key={n}
+                  >
+                    {n}
+                  </Box>
+                ))}{" "}
+              </AnimatePresence>
+              more
+            </Text>
+          </Stack>
+        )}
+      </AnimatePresence>
+    </Stack>
+  );
+};
+
+const TriggerTagContext = React.createContext<{
+  value: string;
+}>({
+  value: "",
+});
+
+type TriggerTagRootProps<T extends TgphElement> = {
+  value: string;
+} & TgphComponentProps<typeof Tag.Root<T>>;
+
+const TriggerTagRoot = <T extends TgphElement>({
+  value,
+  children,
+  ...props
+}: TriggerTagRootProps<T>) => {
+  return (
+    <TriggerTagContext.Provider value={{ value }}>
+      <Tag.Root
+        as={motion.span}
+        initializeWithAnimation={false}
+        initial={{ opacity: 0, scale: 0.5 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.5 }}
+        transition={{ duration: 100, type: "spring" }}
+        tgph-motion-key={value}
+        size="1"
+        layout="position"
+        {...props}
+      >
+        {children}
+      </Tag.Root>
+    </TriggerTagContext.Provider>
+  );
+};
+
+type TriggerTagTextProps<T extends TgphElement> = TgphComponentProps<
+  typeof Tag.Text<T>
+>;
+
+const TriggerTagText = <T extends TgphElement>({
+  children,
+  ...props
+}: TriggerTagTextProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+  const triggerTagContext = React.useContext(TriggerTagContext);
+
+  const option = React.useMemo(() => {
+    // Find option amongst other options
+    const foundOption = context.options.find(
+      (o) => o.value === triggerTagContext.value,
+    );
+    if (foundOption) return foundOption.label || foundOption.value;
+
+    // Find option amongst the current values in the case of creation
+    if (!context.value) return undefined;
+    const contextValue = context.value as Array<Option>;
+    const foundValue = contextValue.find(
+      (v) =>
+        getValueFromOption(v, context.legacyBehavior) ===
+        triggerTagContext.value,
+    );
+
+    if (!foundValue) return undefined;
+
+    return foundValue;
+  }, [
+    context.options,
+    context.value,
+    triggerTagContext.value,
+    context.legacyBehavior,
+  ]);
+
+  return <Tag.Text {...props}>{children || option}</Tag.Text>;
+};
+
+type TriggerTagButtonProps<T extends TgphElement> = TgphComponentProps<
+  typeof Tag.Button<T>
+>;
+
+const TriggerTagButton = <T extends TgphElement>({
+  children,
+  ...props
+}: TriggerTagButtonProps<T>) => {
+  const context = React.useContext(ComboboxContext);
+  const triggerTagContext = React.useContext(TriggerTagContext);
+
+  return (
+    <Tag.Button
+      icon={{ icon: Lucide.X, alt: `Remove ${triggerTagContext.value}` }}
+      onClick={(event: React.MouseEvent) => {
+        if (!context.onValueChange) return;
+        const onValueChange =
+          context.onValueChange as MultiSelect["onValueChange"];
+        const contextValue = context.value as Array<Option>;
+
+        const newValue = contextValue.filter((v) => {
+          const valueOption = getValueFromOption(v, context.legacyBehavior);
+          return valueOption !== triggerTagContext.value;
+        });
+
+        onValueChange?.(newValue);
+        // Stop click event from bubbling up
+        event.stopPropagation();
+        // Stop the button "submit" action from triggering
+        event.preventDefault();
+      }}
+      {...props}
+    >
+      {children}
+    </Tag.Button>
+  );
+};
+
+type TriggerTagDefaultProps<T extends TgphElement> = TgphComponentProps<
+  typeof TriggerTagRoot<T>
+>;
+
+const TriggerTagDefault = <T extends TgphElement>({
+  value,
+  children,
+  ...props
+}: TriggerTagDefaultProps<T>) => {
+  return (
+    <TriggerTag.Root value={value} {...props}>
+      <TriggerTag.Text>{children}</TriggerTag.Text>
+      <TriggerTag.Button />
+    </TriggerTag.Root>
+  );
+};
+
+const TriggerTag = {
+  Root: TriggerTagRoot,
+  Text: TriggerTagText,
+  Button: TriggerTagButton,
+  Default: TriggerTagDefault,
+};
+
+const Primitives = {
+  TriggerIndicator,
+  TriggerClear,
+  TriggerText,
+  TriggerPlaceholder,
+  TriggerTagsContainer,
+  TriggerTag,
+};
+
+export { Primitives };

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -454,7 +454,16 @@ export const MultiSelectWithCustomTrigger: Story = {
           clearable
         >
           <TelegraphCombobox.Trigger<typeof value>>
-            {(params) => params.value.map((v) => v.label)?.join(", ")}
+            <TelegraphCombobox.Primitives.TriggerTagsContainer>
+              {value.map((v) => (
+                <TelegraphCombobox.Primitives.TriggerTag.Default
+                  value={v}
+                  key={v}
+                >
+                  {v.toUpperCase()}
+                </TelegraphCombobox.Primitives.TriggerTag.Default>
+              ))}
+            </TelegraphCombobox.Primitives.TriggerTagsContainer>
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>

--- a/packages/combobox/src/Combobox/Combobox.types.ts
+++ b/packages/combobox/src/Combobox/Combobox.types.ts
@@ -1,0 +1,15 @@
+export type DefinedOption = {
+  value: string;
+  label?: string | React.ReactNode;
+};
+export type Option = DefinedOption | string | React.ReactNode;
+
+export type SingleSelect = {
+  value?: Option;
+  onValueChange?: (value: Option | undefined) => void;
+};
+
+export type MultiSelect = {
+  value?: Array<Option>;
+  onValueChange?: (value: Array<Option>) => void;
+};

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -2,6 +2,7 @@ import { Button as TelegraphButton } from "@telegraph/button";
 import type {
   PolymorphicProps,
   PolymorphicPropsWithTgphRef,
+  RemappedOmit,
   Required,
   TgphComponentProps,
   TgphElement,
@@ -61,7 +62,7 @@ const Root = <T extends TgphElement>({
   );
 };
 
-type TextProps<T extends TgphElement> = Omit<
+type TextProps<T extends TgphElement> = RemappedOmit<
   TgphComponentProps<typeof TelegraphText<T>>,
   "as"
 > & {
@@ -71,6 +72,7 @@ type TextProps<T extends TgphElement> = Omit<
 const Text = <T extends TgphElement>({
   as = "span" as T,
   maxW = "40",
+  overflow = "hidden",
   style,
   ...props
 }: TextProps<T>) => {
@@ -83,7 +85,8 @@ const Text = <T extends TgphElement>({
       weight="medium"
       mr={SPACING.Text[context.size]}
       maxW={maxW}
-      overflow="hidden"
+      overflow={overflow}
+      internal_optionalAs={true}
       style={{
         whiteSpace: "nowrap",
         textOverflow: "ellipsis",


### PR DESCRIPTION
### Description
- Added `Primitives` to the combobox so you can build custom trigger layouts while still using the built-in trigger parts.
- Refactored the combobox to use these new primitives internally.
- Improved type safety by updating types in some of the existing components.
- Added a detailed README for the combobox, including how to use the new primitives.

### Tasks
[KNO-8287](https://linear.app/knock/issue/KNO-8287/[telegraph]-improve-flexibility-of-combobox-trigger)