### PR TITLE
feat: add skipAnimation prop to motion, apply skipAnimation prop to tooltip and popover

### DIFF
--- a/.changeset/silly-phones-cheat.md
+++ b/.changeset/silly-phones-cheat.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/popover": patch
+"@telegraph/tooltip": patch
+"@telegraph/motion": patch
+---
+
+adds `skipAnimation` prop to `<Motion/>` and integrates into `<Popover/>` and `<Tooltip/>`

--- a/packages/motion/src/Motion/Motion.tsx
+++ b/packages/motion/src/Motion/Motion.tsx
@@ -27,6 +27,7 @@ type MotionProps<T extends TgphElement> = PolymorphicPropsWithTgphRef<
   T,
   TgphElement
 > & {
+  skipAnimation?: boolean;
   initial?: MotionValues;
   animate?: MotionValues;
   exit?: MotionValues;
@@ -46,6 +47,7 @@ const Motion = <T extends TgphElement>({
   exit,
   transition,
   initializeWithAnimation = true,
+  skipAnimation = false,
   style,
   children,
   "tgph-motion-key": motionKey,
@@ -136,28 +138,30 @@ const Motion = <T extends TgphElement>({
     <Component
       className={clsx("tgph-motion", className)}
       style={{
-        "--motion-opacity": currentValues?.opacity,
-        "--motion-scale": currentValues?.scale,
-        "--motion-x":
-          typeof currentValues?.x === "number"
-            ? `${currentValues?.x}px`
-            : typeof currentValues?.x === "string"
-              ? currentValues?.x
+        ...(!skipAnimation && {
+          "--motion-opacity": currentValues?.opacity,
+          "--motion-scale": currentValues?.scale,
+          "--motion-x":
+            typeof currentValues?.x === "number"
+              ? `${currentValues?.x}px`
+              : typeof currentValues?.x === "string"
+                ? currentValues?.x
+                : null,
+          "--motion-y":
+            typeof currentValues?.y === "number"
+              ? `${currentValues?.y}px`
+              : typeof currentValues?.y === "string"
+                ? currentValues?.y
+                : null,
+          "--motion-rotate":
+            typeof currentValues?.rotate === "number"
+              ? `${currentValues?.rotate}deg`
               : null,
-        "--motion-y":
-          typeof currentValues?.y === "number"
-            ? `${currentValues?.y}px`
-            : typeof currentValues?.y === "string"
-              ? currentValues?.y
-              : null,
-        "--motion-rotate":
-          typeof currentValues?.rotate === "number"
-            ? `${currentValues?.rotate}deg`
-            : null,
-        "--motion-transition-duration": `${transitionDuration}ms`,
-        "--motion-transition-type": getAnimationTimingFunction(
-          transition?.type,
-        ),
+          "--motion-transition-duration": `${transitionDuration}ms`,
+          "--motion-transition-type": getAnimationTimingFunction(
+            transition?.type,
+          ),
+        }),
         ...style,
       }}
       {...props}

--- a/packages/popover/src/Popover/Popover.stories.tsx
+++ b/packages/popover/src/Popover/Popover.stories.tsx
@@ -23,16 +23,25 @@ const meta: Meta = {
         type: "select",
       },
     },
+    skipAnimation: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   args: {
     side: "bottom",
     align: "center",
+    skipAnimation: false,
   },
 };
 
 export default meta;
 
-type Story = StoryObj<TgphComponentProps<typeof Popover.Root>>;
+type Story = StoryObj<
+  TgphComponentProps<typeof Popover.Root> &
+    TgphComponentProps<typeof Popover.Content>
+>;
 
 export const Default: Story = {
   render: ({ ...args }) => {
@@ -45,7 +54,12 @@ export const Default: Story = {
               leadingIcon={{ icon: Lucide.Ellipsis, "aria-hidden": true }}
             />
           </Popover.Trigger>
-          <Popover.Content {...args} px="4">
+          <Popover.Content
+            px="4"
+            align={args.align}
+            side={args.side}
+            skipAnimation={args.skipAnimation}
+          >
             <p>Test popover content</p>
           </Popover.Content>
         </Popover.Root>

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -85,6 +85,7 @@ type ContentProps<T extends TgphElement> = React.ComponentProps<
 > &
   Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
     contentStackRef?: React.RefObject<HTMLDivElement>;
+    skipAnimation?: TgphComponentProps<typeof motion.div>["skipAnimation"];
   };
 
 const Content = <T extends TgphElement>({
@@ -101,6 +102,7 @@ const Content = <T extends TgphElement>({
   alignOffset,
   tgphRef,
   style,
+  skipAnimation,
   children,
   ...props
 }: ContentProps<T>) => {
@@ -148,6 +150,7 @@ const Content = <T extends TgphElement>({
             // Add tgph class so that this always works in portals
             className="tgph"
             initializeWithAnimation={false}
+            skipAnimation={skipAnimation}
             initial={{
               opacity: 0.5,
               scale: 0.6,

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -39,6 +39,11 @@ const meta: Meta = {
         type: "boolean",
       },
     },
+    skipAnimation: {
+      control: {
+        type: "boolean",
+      },
+    },
   },
   args: {
     label: "Tooltip",

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -19,6 +19,7 @@ type TooltipBaseProps<T extends TgphElement> = {
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
   appearance?: TgphComponentProps<typeof OverrideAppearance>["appearance"];
+  skipAnimation?: TgphComponentProps<typeof motion.div>["skipAnimation"];
 };
 
 type TooltipProps<T extends TgphElement> = React.ComponentPropsWithoutRef<
@@ -52,6 +53,7 @@ const Tooltip = <T extends TgphElement>({
   arrowPadding,
   sticky,
   hideWhenDetached,
+  skipAnimation,
   // Label Props
   label,
   labelProps,
@@ -139,6 +141,7 @@ const Tooltip = <T extends TgphElement>({
                   as={motion.div}
                   // Add tgph class so that this always works in portals
                   className="tgph"
+                  skipAnimation={skipAnimation}
                   initial={
                     shouldAnimate
                       ? {


### PR DESCRIPTION
### Description
- In the new template editor, the "Send test" popover animation feels overly pronounced due to its size. To address this, we added a `skipAnimation` prop to `<Motion />` that allows disabling the animation entirely when needed.
- This prop is now integrated into both the `<Popover />` and `<Tooltip />` components to support cases where animation should be skipped.

### Tasks
[KNO-8353](https://linear.app/knock/issue/KNO-8353/[telegraph]-add-ability-to-skip-animations-on-popover-and-tooltips)