### PR TITLE
fix(kno-8547): fixes tabs weight and spacing

### DIFF
--- a/.changeset/ten-dancers-explain.md
+++ b/.changeset/ten-dancers-explain.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/menu": patch
+"@telegraph/tabs": patch
+---
+
+fix(kno-8547): fixes tabs weight and spacing

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -45,7 +45,7 @@ const MenuItem = <T extends TgphElement>({
           leadingComponent={leadingComponent}
         />
         <Button.Text
-          weight="regular"
+          weight={props?.fontWeight || "regular"}
           w="full"
           overflow="hidden"
           textOverflow="ellipsis"

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -114,6 +114,37 @@ function ControlledTabs() {
 }
 ```
 
+
+## Using Tabs as Navigation Links
+
+You can use tabs as navigation links by passing a Link component to the `as` prop. This is useful for creating tabbed navigation menus that update the URL:
+
+```jsx
+import { Tabs, useTabsContext } from '@telegraph/tabs';
+import { Link } from '@telegraph/link';
+
+function MyTabs() {
+  return (
+    <Tabs defaultValue="tab1">
+      <Tabs.List>
+        <Tabs.Tab as={Link} value="tab1" href="/">Home</Tabs.Tab>
+        <Tabs.Tab as={Link} value="tab2" href="/about">About</Tabs.Tab>
+        <Tabs.Tab as={Link} value="tab3" href="/contact">Contact</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel value="tab1">
+        <Box padding="4">Content for the first tab</Box>
+      </Tabs.Panel>
+      <Tabs.Panel value="tab2">
+        <Box padding="4">Content for the second tab</Box>
+      </Tabs.Panel>
+      <Tabs.Panel value="tab3">
+        <Box padding="4">Content for the third tab</Box>
+      </Tabs.Panel>
+    </Tabs>
+  );
+}
+```
+
 ## Components API
 
 ### Tabs (Root)

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -63,6 +63,7 @@ const Tab = <T extends TgphElement>({
           disabled={disabled}
           py="4"
           px="2"
+          fontWeight="medium"
           position="relative"
           data-tgph-tab=""
           gap="2"

--- a/packages/tabs/src/TabList/TabList.tsx
+++ b/packages/tabs/src/TabList/TabList.tsx
@@ -18,7 +18,7 @@ const TabList = ({ children, loop = true, ...props }: TabListProps) => {
           flexDirection={"row"}
           spacing="2"
           gap="1"
-          paddingBottom={"2"}
+          paddingBottom={"1"}
           paddingRight={"0"}
           marginBottom="4"
           position="relative"

--- a/packages/tabs/src/default.css
+++ b/packages/tabs/src/default.css
@@ -2,7 +2,7 @@
 [data-tgph-tab][data-state="active"]::after {
   animation: tabActivate 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   background-color: var(--tgph-accent-9, #ff4f00);
-  bottom: calc(var(--tgph-spacing-2) * -1);
+  bottom: calc(var(--tgph-spacing-1) * -1);
   border-radius: 1px;
   content: '';
   height: 1px;


### PR DESCRIPTION
[Linear issue](https://linear.app/knock/issue/KNO-8457/[telegraph]-fix-spacing-and-font-weight-for-tabs-list-component)
Reduce vertical Y padding and increase fontWeight to 500, matching the figma
<img width="369" alt="Screenshot 2025-04-21 at 12 06 01 AM" src="https://github.com/user-attachments/assets/36dacc2d-6ae3-4974-8713-aa83a6024f3a" />
