### PR TITLE
feat: decrease icon package downstream bundle size by using lucide dynamic

### DIFF
--- a/.changeset/chilled-boxes-check.md
+++ b/.changeset/chilled-boxes-check.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/icon": patch
+---
+
+Changes the export strategy for Lucide icons within @telegraph/icon so that they are individually chunked for easier tree shaking by a downstream user.

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -32,10 +32,11 @@ describe("Button", () => {
     expectToHaveNoViolations(await axe(container));
   });
   it("icon button without alt is inaccessible", async () => {
-    expect(() =>
-      // @ts-expect-error Testing error case
-      render(<Button leadingIcon={{ icon: Lucide.Bell }}>Click me</Button>),
-    ).toThrow("@telegraph/icon: alt prop is required");
+    // @ts-expect-error Testing error case
+    render(<Button leadingIcon={{ icon: Lucide.Bell }}>Click me</Button>);
+    expect(console.error).toHaveBeenCalledWith(
+      "@telegraph/icon: alt prop is required",
+    );
   });
   it("alt text is optional if icon is aria hidden", async () => {
     const { container } = render(

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -34,8 +34,7 @@
     "@telegraph/helpers": "workspace:^",
     "@telegraph/typography": "workspace:^",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.511.0",
-    "lucide-static": "^0.511.0"
+    "lucide-react": "^0.511.0"
   },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.3",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -34,7 +34,8 @@
     "@telegraph/helpers": "workspace:^",
     "@telegraph/typography": "workspace:^",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.436.0"
+    "lucide-react": "^0.511.0",
+    "lucide-static": "^0.511.0"
   },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.3",

--- a/packages/icon/src/Icon/Icon.test.tsx
+++ b/packages/icon/src/Icon/Icon.test.tsx
@@ -16,6 +16,11 @@ vi.mock("lucide-react/dynamic", () => {
     DynamicIcon: () => {
       return dynamicIconPkg.default;
     },
+    dynamicIconImports: {
+      Bell: () => {
+        return dynamicIconPkg.default;
+      },
+    },
   };
 });
 
@@ -38,15 +43,17 @@ describe("Icon", () => {
   });
   it("icon without icon prop throws error", async () => {
     // @ts-expect-error Testing error case
-    expect(() => render(<Icon alt="description" />)).toThrowError(
+    render(<Icon alt="description" />);
+    expect(console.error).toHaveBeenCalledWith(
       "@telegraph/icon: icon prop is required",
     );
   });
   it("icon without alt prop throws error", async () => {
-    expect(() =>
-      // @ts-expect-error Testing error case
-      render(<Icon icon={{ icon: Lucide.Bell }} />),
-    ).toThrowError("@telegraph/icon: alt prop is required");
+    // @ts-expect-error Testing error case
+    render(<Icon icon={{ icon: Lucide.Bell }} />);
+    expect(console.error).toHaveBeenCalledWith(
+      "@telegraph/icon: alt prop is required",
+    );
   });
   it("default props applies correct className", () => {
     const { container } = render(

--- a/packages/icon/src/Icon/Icon.test.tsx
+++ b/packages/icon/src/Icon/Icon.test.tsx
@@ -6,6 +6,19 @@ import { Lucide } from "../index";
 
 import { Icon } from "./Icon";
 
+// @ts-expect-error -- We need top import and mock this because DynamicIcon is ESM and vitest expects CJS :/
+const dynamicIconPkg = import("lucide-react/dist/esm/DynamicIcon.js") as {
+  default: React.ReactNode;
+};
+
+vi.mock("lucide-react/dynamic", () => {
+  return {
+    DynamicIcon: () => {
+      return dynamicIconPkg.default;
+    },
+  };
+});
+
 // Suppress error from showing in console as we are testing for it
 const consoleError = console.error;
 beforeEach(() => {

--- a/packages/icon/src/Icon/Icon.test.tsx
+++ b/packages/icon/src/Icon/Icon.test.tsx
@@ -6,7 +6,7 @@ import { Lucide } from "../index";
 
 import { Icon } from "./Icon";
 
-// @ts-expect-error -- We need top import and mock this because DynamicIcon is ESM and vitest expects CJS :/
+// @ts-expect-error -- We need mock this impport because DynamicIcon is ESM and vitest expects CJS :/
 const dynamicIconPkg = import("lucide-react/dist/esm/DynamicIcon.js") as {
   default: React.ReactNode;
 };

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -77,11 +77,17 @@ const Icon = <T extends TgphElement>({
   ...props
 }: IconProps<T>) => {
   if (!icon) {
-    throw new Error(`@telegraph/icon: icon prop is required`);
+    console.error(`@telegraph/icon: icon prop is required`);
+    return <></>;
+  }
+
+  if (!icon.displayName) {
+    console.error(`@telegraph/icon: icon prop is required with displayName`);
+    return <></>;
   }
 
   if (!alt && !props["aria-hidden"]) {
-    throw new Error(`@telegraph/icon: alt prop is required`);
+    console.error(`@telegraph/icon: alt prop is required`);
   }
 
   return (

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -6,23 +6,30 @@ import type {
 import { Box } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
 import clsx from "clsx";
-import type * as LucideIconsUnslugified from "lucide-react";
 import { DynamicIcon, dynamicIconImports } from "lucide-react/dynamic";
 
 import { COLOR_MAP, SIZE_MAP } from "./Icon.constants";
 import type { TransformKeysToPascal } from "./Icon.types";
 
 type LucideIcon = TransformKeysToPascal<keyof typeof dynamicIconImports>;
+type PascalCaseLucideIconKey = keyof TransformKeysToPascal<
+  typeof dynamicIconImports
+>;
+type KebabCaseLucideIconKey = keyof typeof dynamicIconImports;
 
-// Take a slugified version of the icon like "a-arrow-down" and return
-// the unslugified version like "AArrowDown". We need the unslugified
+// Take a kebab cased version of the icon like "a-arrow-down" and return
+// the pascal cased version like "AArrowDown". We need the pascal-cased
 // version as the object key so that we don't introduce any breaking
-// changes to how the Lucide object works in the icon package.
-const unslugify = (slug: string): string => {
+// changes to how the Lucide object works in the icon package. This is
+// a temporary solution to maintain backwards compatibility with the
+// Lucide object.
+const toPascalCase = (
+  slug: KebabCaseLucideIconKey,
+): PascalCaseLucideIconKey => {
   return slug
     .split(/[-_]/g)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join("");
+    .join("") as PascalCaseLucideIconKey;
 };
 
 // An object of Lucide icons that contain the kebab-cased name of
@@ -30,24 +37,19 @@ const unslugify = (slug: string): string => {
 // instead of needing to bundle the icon directly into the component.
 // We do it in this way to maintain backwards compatibility with the
 // `Lucide.Bell` pattern
-const Lucide = Object.keys(dynamicIconImports).reduce(
+const Lucide = (
+  Object.keys(dynamicIconImports) as Array<KebabCaseLucideIconKey>
+).reduce(
   (acc, key) => {
-    const unslugifiedKey = unslugify(
-      key,
-    ) as keyof typeof LucideIconsUnslugified;
-    acc[unslugifiedKey] = key as TransformKeysToPascal<
-      keyof typeof dynamicIconImports
-    >;
+    const unslugifiedKey = toPascalCase(key);
+    acc[unslugifiedKey] = key;
     return acc;
   },
-  {} as Record<
-    keyof typeof LucideIconsUnslugified,
-    TransformKeysToPascal<keyof typeof dynamicIconImports>
-  >,
+  {} as Record<PascalCaseLucideIconKey, KebabCaseLucideIconKey>,
 );
 
 type BaseIconProps = {
-  icon: LucideIcon;
+  icon: KebabCaseLucideIconKey;
   size?: keyof typeof SIZE_MAP;
   variant?: keyof typeof COLOR_MAP;
   color?: keyof (typeof COLOR_MAP)["primary"];

--- a/packages/icon/src/Icon/Icon.tsx
+++ b/packages/icon/src/Icon/Icon.tsx
@@ -89,6 +89,8 @@ const Icon = <T extends TgphElement>({
       as={as || "span"}
       className={clsx("tgph-icon", className)}
       data-button-icon
+      role="img"
+      aria-label={alt}
       style={{
         // We choose to override these values vs passing them in as props because
         // the icon's sizes aren't all exact telegraph tokens and the colors
@@ -105,7 +107,6 @@ const Icon = <T extends TgphElement>({
       {/* Dynamically import icons as we need them so we don't bloat the bundle */}
       <DynamicIcon
         name={icon.displayName}
-        aria-label={alt}
         width="100%"
         height="100%"
         display="block"

--- a/packages/icon/src/Icon/Icon.types.ts
+++ b/packages/icon/src/Icon/Icon.types.ts
@@ -1,0 +1,12 @@
+// These types are used to convert a kebab-cased string to a PascalCase string
+// specifically for the Lucide icons. We do it in this way to maintain backwards
+// compatibility with the `Lucide.Bell` pattern. Leaving here for now as it doesn't
+// seem like a utility type that would be useful outside of this context.
+export type KebabToPascalCase<S extends string> =
+  S extends `${infer Head}-${infer Tail}`
+    ? `${Capitalize<Head>}${KebabToPascalCase<Capitalize<Tail>>}`
+    : Capitalize<S>;
+
+export type TransformKeysToPascal<T> = {
+  [K in keyof T as KebabToPascalCase<K & string>]: T[K];
+};

--- a/packages/icon/src/Icon/index.ts
+++ b/packages/icon/src/Icon/index.ts
@@ -1,1 +1,1 @@
-export { Icon, type LucideIcon } from "./Icon";
+export { Icon, Lucide, type LucideIcon } from "./Icon";

--- a/packages/icon/src/index.ts
+++ b/packages/icon/src/index.ts
@@ -1,4 +1,3 @@
 // Export as "Lucide" so we have the potential
 // to support other icon libraries in the future
-export * as Lucide from "lucide-react";
-export { Icon, type LucideIcon } from "./Icon";
+export { Icon, Lucide, type LucideIcon } from "./Icon";

--- a/vitest/axe.ts
+++ b/vitest/axe.ts
@@ -6,6 +6,13 @@ import { expect } from "vitest";
 
 // Helper to check for a11y violations while keeping type safety
 export const expectToHaveNoViolations = (element: AxeCore.AxeResults) => {
+  const result = fn(element);
+
+  // Throw underling axe error so it can be see in the console
+  if (!result.pass) {
+    throw new Error(result.message());
+  }
+
   expect(fn(element).pass).toBe(true);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5141,7 +5141,8 @@ __metadata:
     "@types/react": "npm:^18.3.18"
     clsx: "npm:^2.1.1"
     eslint: "npm:^8.56.0"
-    lucide-react: "npm:^0.436.0"
+    lucide-react: "npm:^0.511.0"
+    lucide-static: "npm:^0.511.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.7.3"
@@ -10819,12 +10820,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:^0.436.0":
-  version: 0.436.0
-  resolution: "lucide-react@npm:0.436.0"
+"lucide-react@npm:^0.511.0":
+  version: 0.511.0
+  resolution: "lucide-react@npm:0.511.0"
   peerDependencies:
-    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
-  checksum: 10c0/4cf3dd21de9ab955dd5c4557e0798eb6c780d1df0d4a1f766e89faa88c1a6798da512f29ae2a61577c2d62f1945b9abd1a1108a41f1eb9d7d1cceca79a5e1622
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/bf09dd73cf2233abea90506ad31a91739555d761062722acbe045cb73e274f035b196472de0971a8a8f0645b2b54e3f21b8c1980fe87c909ca93171a9c28428a
+  languageName: node
+  linkType: hard
+
+"lucide-static@npm:^0.511.0":
+  version: 0.511.0
+  resolution: "lucide-static@npm:0.511.0"
+  checksum: 10c0/0378043a06dc032cd686a33eca28510dcc87f498217825c76295c86cab248693998ccd7a8e65a272b00d4940f670fdb79dc5d1bf043760f26527f3ba5c9329f5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5142,7 +5142,6 @@ __metadata:
     clsx: "npm:^2.1.1"
     eslint: "npm:^8.56.0"
     lucide-react: "npm:^0.511.0"
-    lucide-static: "npm:^0.511.0"
     react: "npm:^18.3.1"
     react-dom: "npm:^18.3.1"
     typescript: "npm:^5.7.3"
@@ -10826,13 +10825,6 @@ __metadata:
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10c0/bf09dd73cf2233abea90506ad31a91739555d761062722acbe045cb73e274f035b196472de0971a8a8f0645b2b54e3f21b8c1980fe87c909ca93171a9c28428a
-  languageName: node
-  linkType: hard
-
-"lucide-static@npm:^0.511.0":
-  version: 0.511.0
-  resolution: "lucide-static@npm:0.511.0"
-  checksum: 10c0/0378043a06dc032cd686a33eca28510dcc87f498217825c76295c86cab248693998ccd7a8e65a272b00d4940f670fdb79dc5d1bf043760f26527f3ba5c9329f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description
The `@telegraph/icon` package exported ALL of the icons from `lucide-react` under the `Lucide` object. In doing the export in this way, a downstream bundler would be unable to successfully tree shake the package making it so ALL of the icons were in the main bundle. This PR utilizes [Lucide's Dynamic Icon Component](https://lucide.dev/guide/packages/lucide-react#dynamic-icon-component) so that during telegraph's bundling process each icon is put into its own file making it so a downstream bundler does not have to treeshake telegraph. This PR also maintains backwards compatibility with the previous `Lucide.Bell` pattern so that no code updates will need to be made by the downstream user.

In this PR we also:
- Update the tests to work with `DynamicIcon`, which required a mocking process because `DynamicIcon` is an ES Module and `vitest` expects to be able to work with CJS.
- Update our `axe` utility to throw the actual error from the violation check so that we can see it in the test output.
- Remove the `throw` for icon component issues in favor of a `console.error` to avoid async issues with the `DynamicIcon` component. This also required adjusting the tests within `@telegraph/icon` and `@telegraph/button`.

As an example, here is our bundle before and after for the dashboard. Notice how before how `@telegraph/icon` was within the main bundle and taking up a large chunk of that. In the after, the `@telegraph/icon` is MUCH smaller as each icon exists in it's own chunk and not in the main bundle. 

![Before After Bundle Size](https://github.com/user-attachments/assets/517535d2-0ac1-4705-8212-a4d5fd358142)
