### PR TITLE
fix: kbd component displaying text instead of icon

### DIFF
--- a/.changeset/tiny-mayflies-knock.md
+++ b/.changeset/tiny-mayflies-knock.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/kbd": patch
+---
+
+fixes kbd component issue where the icon name was being dispalyed instead of the icon

--- a/packages/kbd/src/Kbd/Kbd.helpers.ts
+++ b/packages/kbd/src/Kbd/Kbd.helpers.ts
@@ -1,51 +1,53 @@
-import { Lucide } from "@telegraph/icon";
+import { Lucide, type LucideIcon } from "@telegraph/icon";
 
-export const getIconOrKey = (key: string) => {
+export const getIconOrKey = (
+  key: string,
+): { icon: LucideIcon; text?: never } | { text: string; icon?: never } => {
   const isMac = navigator.userAgent.includes("Mac");
 
   if (key === "Meta") {
-    return isMac ? Lucide.Command : "Ctrl";
+    return isMac ? { icon: Lucide.Command } : { text: "Ctrl" };
   }
 
   if (key === "Enter") {
-    return Lucide.CornerDownLeft;
+    return { icon: Lucide.CornerDownLeft };
   }
 
   if (key === "Shift") {
-    return Lucide.ArrowBigUp;
+    return { icon: Lucide.ArrowBigUp };
   }
 
   if (key === "Escape") {
-    return "Esc";
+    return { text: "Esc" };
   }
 
   if (key === "Backspace") {
-    return Lucide.Delete;
+    return { icon: Lucide.Delete };
   }
 
   if (key === "Alt") {
-    return isMac ? Lucide.Option : "Alt";
+    return isMac ? { icon: Lucide.Option } : { text: "Alt" };
   }
 
   if (key === "Control") {
-    return "Ctrl";
+    return { text: "Ctrl" };
   }
 
   if (key === "ArrowRight") {
-    return Lucide.ArrowRight;
+    return { icon: Lucide.ArrowRight };
   }
 
   if (key === "ArrowLeft") {
-    return Lucide.ArrowLeft;
+    return { icon: Lucide.ArrowLeft };
   }
 
   if (key === "ArrowDown") {
-    return Lucide.ArrowDown;
+    return { icon: Lucide.ArrowDown };
   }
 
   if (key === "ArrowUp") {
-    return Lucide.ArrowUp;
+    return { icon: Lucide.ArrowUp };
   }
 
-  return key.length === 1 ? key.toUpperCase() : key;
+  return key.length === 1 ? { text: key.toUpperCase() } : { text: key };
 };

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -21,11 +21,12 @@ const Kbd = ({
   style,
   ...props
 }: KbdProps) => {
-  const { appearance } = useAppearance();
+  const { appearance: appearanceProp } = useAppearance();
   const { pressed } = usePressed({ key: props.eventKey || label });
-  const key = getIconOrKey(label);
+  const { icon, text } = getIconOrKey(label);
 
   const contrast = contrastProp ? "contrast" : "default";
+  const appearance = appearanceProp || "light";
 
   return (
     <Stack
@@ -47,17 +48,20 @@ const Kbd = ({
       }}
       {...props}
     >
-      {typeof key === "string" ? (
+      {appearance}
+      {contrast}
+      {text && (
         <Text
           as="span"
           {...sizeMap[size].text}
           {...colorMap[appearance][contrast].text}
         >
-          {key}
+          {text}
         </Text>
-      ) : (
+      )}
+      {icon && (
         <Icon
-          icon={key}
+          icon={icon}
           alt={label}
           {...sizeMap[size].icon}
           {...colorMap[appearance][contrast].icon}

--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -48,8 +48,6 @@ const Kbd = ({
       }}
       {...props}
     >
-      {appearance}
-      {contrast}
       {text && (
         <Text
           as="span"


### PR DESCRIPTION
### Description
The `<Kbd/>` component relied on `Lucide.IconName` to be an object an not string to decide if it would display an icon or text inside of it. The latest update to `<Icon/>` made it so the value `Lucide.IconName` returns is the kebab cased icon name. This PR updates the `<Kbd/>` component `getIconOrKey` helper to return a different variable based on the type. It also fixes an issue in the case of `appearance` not being defined when then the constants are spread onto the individual components.