### PR TITLE
fix: interaction styles dont stick on click

### DIFF
--- a/.changeset/slimy-kiwis-laugh.md
+++ b/.changeset/slimy-kiwis-laugh.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+fix: interaction styles dont stick on click

--- a/packages/layout/src/Box/Box.styles.css
+++ b/packages/layout/src/Box/Box.styles.css
@@ -54,7 +54,7 @@
   background-color: var(--hover_backgroundColor);
 }
 
-.tgph-box--interactive:focus {
+.tgph-box--interactive:focus-visible {
   background-color: var(--focus_backgroundColor);
 }
 


### PR DESCRIPTION
Currently, when you click an interactive item like `MenuItem` or `Tab`, the background color will stay darker until the user clicks somewhere else.

I think this is annoying. We shouldn't need this styling because we style separately for `active` state. This change makes it so that our custom styles for focusing are only triggered via keyboard, not when the user clicks.

Here is a tab in its current form (click around): https://telegraph-storybook.vercel.app/?path=/story/components-tabs--basic

Here is a tab from this PR (now click around): https://telegraph-storybook-git-mc-change-focus-identifier-knocklabs.vercel.app/?path=/story/components-tabs--basic

