### PR TITLE
fix: typescript build errors

### DIFF
--- a/.changeset/lemon-tomatoes-dance.md
+++ b/.changeset/lemon-tomatoes-dance.md
@@ -1,0 +1,10 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/popover": patch
+"@telegraph/tooltip": patch
+"@telegraph/modal": patch
+"@telegraph/radio": patch
+"@telegraph/menu": patch
+---
+
+fix typescript build issues

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -127,7 +127,7 @@ const Root = <
   const [searchQuery, setSearchQuery] = React.useState<string>("");
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
-    defaultProp: defaultOpenProp,
+    defaultProp: defaultOpenProp ?? false,
     onChange: onOpenChangeProp,
   });
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -34,7 +34,7 @@ const Root = ({
 }: RootProps) => {
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
-    defaultProp: defaultOpenProp,
+    defaultProp: defaultOpenProp ?? false,
     onChange: onOpenChangeProp,
   });
   return (
@@ -145,7 +145,11 @@ const Button = <T extends TgphElement>({
 }: ButtonProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
   return (
-    <RadixMenu.Item {...props} asChild={asChild} ref={tgphRef}>
+    <RadixMenu.Item
+      {...props}
+      asChild={asChild}
+      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+    >
       <RefToTgphRef>
         <MenuItem
           onClick={onClick}

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -38,7 +38,7 @@ const Root = ({
   const [open, onOpenChange] = useControllableState({
     prop: openProp,
     onChange: onOpenChangeProp,
-    defaultProp: defaultOpenProp,
+    defaultProp: defaultOpenProp ?? false,
   });
 
   const stacking = useModalStacking();

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -32,7 +32,7 @@ const Root = ({
 }: RootProps) => {
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
-    defaultProp: defaultOpenProp,
+    defaultProp: defaultOpenProp ?? false,
     onChange: onOpenChangeProp,
   });
 

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -22,7 +22,7 @@ const RadioButtonContext = React.createContext<RadioButtonInternalContext>({
 
 const Root = ({ value, children, onValueChange, ...props }: RootProps) => {
   return (
-    <RadioButtonContext.Provider value={{ value }}>
+    <RadioButtonContext.Provider value={{ value: value ?? "" }}>
       <RadioGroup.Root
         value={value}
         onValueChange={onValueChange}

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -67,7 +67,7 @@ const Tooltip = <T extends TgphElement>({
   const [open, setOpen] = useControllableState({
     prop: openProp,
     onChange: onOpenChangeProp,
-    defaultProp: defaultOpenProp,
+    defaultProp: defaultOpenProp ?? false,
   });
   const { groupOpen } = useTooltipGroup({ open: !!open, delay: delayDuration });
 


### PR DESCRIPTION
### Description
- There were a few typescript errors that would throw when running `yarn build:packages`. Some were related to `@radix-ui/react-controllable-state` updating so that `defaultProp` can only be a boolean, the other was just a ref that needed to be typed correctly.

### Tasks
[KNO-9017](https://linear.app/knock/issue/KNO-9017/telegraph-typescript-build-errors)