### PR TITLE
fix: remove debug color as default border

### DIFF
--- a/.changeset/moody-lamps-film.md
+++ b/.changeset/moody-lamps-film.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/layout": patch
+---
+
+change border color back to default from debug

--- a/packages/layout/src/Box/Box.styles.css
+++ b/packages/layout/src/Box/Box.styles.css
@@ -1,6 +1,6 @@
 .tgph-box {
   --background-color: none;
-  --border-color: var(--tgph-red-6);
+  --border-color: var(--tgph-gray-6);
   --box-shadow: none;
   --border-style: solid;
   --border-width: 0;


### PR DESCRIPTION
### Description
I forgot to revert the default border on `<Box/>` back to `gray-6` after settings it to `red-6` when debugging things in the tailwind removal PR. This reverts that change 🤦‍♂️ .