### PR TITLE
feat: use motion/react-m and remove animate presence to further reduce bundle sizes

### DIFF
--- a/.changeset/gold-guests-learn.md
+++ b/.changeset/gold-guests-learn.md
@@ -1,0 +1,10 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/popover": patch
+"@telegraph/tooltip": patch
+"@telegraph/modal": patch
+"@telegraph/menu": patch
+"@telegraph/tag": patch
+---
+
+update packages to use react-m and remove animate presence to shrink bundle

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -6,7 +6,7 @@ import { Tooltip } from "@telegraph/tooltip";
 import { TooltipIfTruncated } from "@telegraph/truncate";
 import { Text } from "@telegraph/typography";
 import { ChevronDown, X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import * as motion from "motion/react-m";
 import React from "react";
 
 import { ComboboxContext } from "./Combobox";
@@ -210,50 +210,46 @@ const TriggerTagsContainer = ({ children }: TriggerTagsContainerProps) => {
         flexGrow: 1,
       }}
     >
-      <AnimatePresence>{children}</AnimatePresence>
-      <AnimatePresence>
-        {layout === "truncate" && context.value.length > 2 && (
-          <Stack
-            as={motion.div}
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.1, type: "spring", bounce: 0 }}
-            h="full"
-            pr="1"
-            pl="8"
-            align="center"
-            aria-label={`${context.value.length - 2} more selected`}
-            position="absolute"
-            right="0"
-            style={{
-              backgroundImage:
-                "linear-gradient(to left, var(--tgph-surface-1) 0 60%, transparent 90% 100%)",
-            }}
-          >
-            <Text as="span" size="1" style={{ whiteSpace: "nowrap" }}>
-              +
-              <AnimatePresence>
-                {truncatedLengthStringArray.map((n) => (
-                  <Box
-                    as={motion.span}
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.1, type: "spring", bounce: 0 }}
-                    w="2"
-                    display="inline-block"
-                    key={n}
-                  >
-                    {n}
-                  </Box>
-                ))}{" "}
-              </AnimatePresence>
-              more
-            </Text>
-          </Stack>
-        )}
-      </AnimatePresence>
+      {children}
+      {layout === "truncate" && context.value.length > 2 && (
+        <Stack
+          as={motion.div}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.1, type: "spring", bounce: 0 }}
+          h="full"
+          pr="1"
+          pl="8"
+          align="center"
+          aria-label={`${context.value.length - 2} more selected`}
+          position="absolute"
+          right="0"
+          style={{
+            backgroundImage:
+              "linear-gradient(to left, var(--tgph-surface-1) 0 60%, transparent 90% 100%)",
+          }}
+        >
+          <Text as="span" size="1" style={{ whiteSpace: "nowrap" }}>
+            +
+            {truncatedLengthStringArray.map((n) => (
+              <Box
+                as={motion.span}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.1, type: "spring", bounce: 0 }}
+                w="2"
+                display="inline-block"
+                key={n}
+              >
+                {n}
+              </Box>
+            ))}{" "}
+            more
+          </Text>
+        </Stack>
+      )}
     </Stack>
   );
 };

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -16,6 +16,7 @@ import { Box, Stack } from "@telegraph/layout";
 import { Menu as TelegraphMenu } from "@telegraph/menu";
 import { Text } from "@telegraph/typography";
 import { Plus, Search as SearchIcon, X } from "lucide-react";
+import { LazyMotion, domAnimation } from "motion/react";
 import React from "react";
 
 import { TRIGGER_MIN_HEIGHT } from "./Combobox.constants";
@@ -195,21 +196,23 @@ const TriggerValue = () => {
     }
 
     return (
-      <Primitives.TriggerTagsContainer>
-        {context.value.map((v, i) => {
-          const value = getValueFromOption(v, context.legacyBehavior);
-          if (
-            value &&
-            ((layout === "truncate" && i <= 1) || layout === "wrap")
-          ) {
-            return (
-              <RefToTgphRef key={value}>
-                <Primitives.TriggerTag.Default value={value} />
-              </RefToTgphRef>
-            );
-          }
-        })}
-      </Primitives.TriggerTagsContainer>
+      <LazyMotion features={domAnimation}>
+        <Primitives.TriggerTagsContainer>
+          {context.value.map((v, i) => {
+            const value = getValueFromOption(v, context.legacyBehavior);
+            if (
+              value &&
+              ((layout === "truncate" && i <= 1) || layout === "wrap")
+            ) {
+              return (
+                <RefToTgphRef key={value}>
+                  <Primitives.TriggerTag.Default value={value} />
+                </RefToTgphRef>
+              );
+            }
+          })}
+        </Primitives.TriggerTagsContainer>
+      </LazyMotion>
     );
   }
 

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -2,7 +2,8 @@ import { Button } from "@telegraph/button";
 import { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Check } from "lucide-react";
-import { motion } from "motion/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import * as motion from "motion/react-m";
 
 type MenuItemProps<T extends TgphElement> = TgphComponentProps<
   typeof Button<T>
@@ -79,28 +80,30 @@ const MenuItemLeading = ({
 
   if (isSelectableButton) {
     return (
-      <Button.Icon
-        as={motion.span}
-        variant="primary"
-        icon={Check}
-        aria-hidden={true}
-        animate={
-          selected
-            ? {
-                opacity: 1,
-                rotate: 0,
-                scale: 1,
-              }
-            : {
-                opacity: 0,
-                rotate: -45,
-                scale: 0.3,
-              }
-        }
-        transition={{ duration: 0.15, type: "spring", bounce: 0 }}
-        style={{ transformOrigin: "center" }}
-        display="block"
-      />
+      <LazyMotion features={domAnimation}>
+        <Button.Icon
+          as={motion.span}
+          variant="primary"
+          icon={Check}
+          aria-hidden={true}
+          animate={
+            selected
+              ? {
+                  opacity: 1,
+                  rotate: 0,
+                  scale: 1,
+                }
+              : {
+                  opacity: 0,
+                  rotate: -45,
+                  scale: 0.3,
+                }
+          }
+          transition={{ duration: 0.15, type: "spring", bounce: 0 }}
+          style={{ transformOrigin: "center" }}
+          display="block"
+        />
+      </LazyMotion>
     );
   }
 

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -13,7 +13,8 @@ import type {
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { X } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import * as motion from "motion/react-m";
 import React from "react";
 
 import { useModalStacking } from "./ModalStacking";
@@ -90,49 +91,49 @@ const RootComponent = ({
   const isTopLayer = id === stacking.layers[stacking.layers.length - 1];
 
   return (
-    <DismissableLayer
-      onEscapeKeyDown={(event) => {
-        if (!isTopLayer) return;
-        event.preventDefault();
-        stacking.removeTopLayer();
-        onOpenChange(false);
-      }}
-      onPointerDownOutside={(event) => {
-        if (!isTopLayer) return;
-        event.preventDefault();
-        stacking.removeTopLayer();
-        onOpenChange(false);
-      }}
-    >
-      <Dialog.Root
-        open={open}
-        onOpenChange={(value) => {
-          const hasLayers = stacking?.layers?.length > 0;
-
-          if (hasLayers) {
-            if (
-              value === false &&
-              id === stacking.layers[stacking.layers.length - 1]
-            ) {
-              stacking.removeLayer(id);
-              return onOpenChange(false);
-            }
-            // If the modal is not the top layer, do not call onOpenChange
-            // when we are stacking the modals
-            return;
-          }
-
-          onOpenChange(value);
+    <LazyMotion features={domAnimation}>
+      <DismissableLayer
+        onEscapeKeyDown={(event) => {
+          if (!isTopLayer) return;
+          event.preventDefault();
+          stacking.removeTopLayer();
+          onOpenChange(false);
         }}
-        key={id}
+        onPointerDownOutside={(event) => {
+          if (!isTopLayer) return;
+          event.preventDefault();
+          stacking.removeTopLayer();
+          onOpenChange(false);
+        }}
       >
-        <VisuallyHidden.Root>
-          <Dialog.Title>{a11yTitle}</Dialog.Title>
-          {a11yDescription && (
-            <Dialog.Description>{a11yDescription}</Dialog.Description>
-          )}
-        </VisuallyHidden.Root>
-        <AnimatePresence>
+        <Dialog.Root
+          open={open}
+          onOpenChange={(value) => {
+            const hasLayers = stacking?.layers?.length > 0;
+
+            if (hasLayers) {
+              if (
+                value === false &&
+                id === stacking.layers[stacking.layers.length - 1]
+              ) {
+                stacking.removeLayer(id);
+                return onOpenChange(false);
+              }
+              // If the modal is not the top layer, do not call onOpenChange
+              // when we are stacking the modals
+              return;
+            }
+
+            onOpenChange(value);
+          }}
+          key={id}
+        >
+          <VisuallyHidden.Root>
+            <Dialog.Title>{a11yTitle}</Dialog.Title>
+            {a11yDescription && (
+              <Dialog.Description>{a11yDescription}</Dialog.Description>
+            )}
+          </VisuallyHidden.Root>
           {open && (
             // We add the className "tgph" here so that styles within
             // the portal get scoped properly to telegraph
@@ -197,9 +198,9 @@ const RootComponent = ({
               </Overlay>
             </Portal.Root>
           )}
-        </AnimatePresence>
-      </Dialog.Root>
-    </DismissableLayer>
+        </Dialog.Root>
+      </DismissableLayer>
+    </LazyMotion>
   );
 };
 

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -6,7 +6,8 @@ import {
   TgphElement,
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
-import { AnimatePresence, motion } from "motion/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import * as motion from "motion/react-m";
 import React from "react";
 
 type RootProps = React.ComponentProps<typeof RadixPopover.Root> & {
@@ -37,11 +38,13 @@ const Root = ({
   });
 
   return (
-    <PopoverContext.Provider value={{ open, setOpen }}>
-      <RadixPopover.Root open={open} onOpenChange={setOpen} {...props}>
-        <AnimatePresence>{children}</AnimatePresence>
-      </RadixPopover.Root>
-    </PopoverContext.Provider>
+    <LazyMotion features={domAnimation}>
+      <PopoverContext.Provider value={{ open, setOpen }}>
+        <RadixPopover.Root open={open} onOpenChange={setOpen} {...props}>
+          {children}
+        </RadixPopover.Root>
+      </PopoverContext.Provider>
+    </LazyMotion>
   );
 };
 

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -13,7 +13,8 @@ import { Tooltip } from "@telegraph/tooltip";
 import { Text as TelegraphText } from "@telegraph/typography";
 import { clsx } from "clsx";
 import { Check, Copy, X } from "lucide-react";
-import { motion } from "motion/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import * as motion from "motion/react-m";
 import React from "react";
 
 import { COLOR, SIZE, SPACING } from "./Tag.constants";
@@ -118,48 +119,50 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
   }, [copied]);
 
   return (
-    <Tooltip label="Copy text">
-      <TelegraphButton.Root
-        onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-          // Still run onClick incase the consumer wants to do something else
-          onClick?.(event);
-          setCopied(true);
-          textToCopy && navigator.clipboard.writeText(textToCopy);
-          event.currentTarget?.blur();
-        }}
-        size={context.size}
-        color={COLOR.Button[context.variant][context.color]}
-        variant={context.variant}
-        roundedTopRight="3"
-        roundedBottomRight="3"
-        roundedTopLeft="0"
-        roundedBottomLeft="0"
-        position="relative"
-        overflow="hidden"
-        p="2"
-        {...props}
-      >
-        <TelegraphButton.Icon
-          as={motion.span}
-          initial={false}
-          animate={{ y: copied ? 0 : "150%", opacity: copied ? 1 : 1 }}
-          transition={{ duration: 0.15, type: "spring", bounce: 0 }}
-          icon={Check}
-          alt="Copied text"
-          aria-hidden={!copied}
-        />
-        <TelegraphButton.Icon
-          as={motion.span}
-          initial={false}
-          animate={{ y: !copied ? 0 : "-150%", opacity: !copied ? 1 : 1 }}
-          transition={{ duration: 0.15, type: "spring", bounce: 0 }}
-          icon={Copy}
-          position="absolute"
-          alt="Copy text"
-          aria-hidden={copied}
-        />
-      </TelegraphButton.Root>
-    </Tooltip>
+    <LazyMotion features={domAnimation}>
+      <Tooltip label="Copy text">
+        <TelegraphButton.Root
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+            // Still run onClick incase the consumer wants to do something else
+            onClick?.(event);
+            setCopied(true);
+            textToCopy && navigator.clipboard.writeText(textToCopy);
+            event.currentTarget?.blur();
+          }}
+          size={context.size}
+          color={COLOR.Button[context.variant][context.color]}
+          variant={context.variant}
+          roundedTopRight="3"
+          roundedBottomRight="3"
+          roundedTopLeft="0"
+          roundedBottomLeft="0"
+          position="relative"
+          overflow="hidden"
+          p="2"
+          {...props}
+        >
+          <TelegraphButton.Icon
+            as={motion.span}
+            initial={false}
+            animate={{ y: copied ? 0 : "150%", opacity: copied ? 1 : 1 }}
+            transition={{ duration: 0.15, type: "spring", bounce: 0 }}
+            icon={Check}
+            alt="Copied text"
+            aria-hidden={!copied}
+          />
+          <TelegraphButton.Icon
+            as={motion.span}
+            initial={false}
+            animate={{ y: !copied ? 0 : "-150%", opacity: !copied ? 1 : 1 }}
+            transition={{ duration: 0.15, type: "spring", bounce: 0 }}
+            icon={Copy}
+            position="absolute"
+            alt="Copy text"
+            aria-hidden={copied}
+          />
+        </TelegraphButton.Root>
+      </Tooltip>
+    </LazyMotion>
   );
 };
 

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -8,7 +8,8 @@ import {
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
-import { motion } from "motion/react";
+import { LazyMotion, domAnimation } from "motion/react";
+import * as motion from "motion/react-m";
 import React from "react";
 
 import { TooltipContentProps } from "./Tooltip.constants";
@@ -108,89 +109,91 @@ const Tooltip = <T extends TgphElement>({
   };
 
   return (
-    <RadixTooltip.Provider
-      delayDuration={derivedDelayDuration}
-      skipDelayDuration={skipDelayDuration}
-      disableHoverableContent={disableHoverableContent}
-    >
-      <RadixTooltip.Root
-        open={enabled === false ? false : open}
-        onOpenChange={setOpen}
+    <LazyMotion features={domAnimation}>
+      <RadixTooltip.Provider
+        delayDuration={derivedDelayDuration}
+        skipDelayDuration={skipDelayDuration}
+        disableHoverableContent={disableHoverableContent}
       >
-        <RadixTooltip.Trigger asChild={true} ref={triggerRef}>
-          <RefToTgphRef>{children}</RefToTgphRef>
-        </RadixTooltip.Trigger>
-        <RadixTooltip.Portal>
-          <RadixTooltip.Content
-            aria-label={ariaLabel}
-            onEscapeKeyDown={onEscapeKeyDown}
-            onPointerDownOutside={onPointerDownOutside}
-            forceMount={forceMount}
-            side={side}
-            sideOffset={sideOffset}
-            align={align}
-            alignOffset={alignOffset}
-            avoidCollisions={avoidCollisions}
-            collisionBoundary={collisionBoundary}
-            collisionPadding={collisionPadding}
-            arrowPadding={arrowPadding}
-            sticky={sticky}
-            hideWhenDetached={hideWhenDetached}
-            style={{
-              zIndex: `var(--tgph-zIndex-tooltip)`,
-            }}
-          >
-            <OverrideAppearance appearance={appearance} asChild>
-              <Stack
-                as={motion.div}
-                // Add tgph class so that this always works in portals
-                className="tgph"
-                initial={
-                  shouldAnimate && !skipAnimation
-                    ? {
-                        opacity: 0,
-                        scale: 0.5,
-                        ...deriveAnimationBasedOnSide(side),
-                      }
-                    : {}
-                }
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                  x: 0,
-                  y: 0,
-                }}
-                transition={{
-                  duration: 0.1,
-                  type: "spring",
-                  bounce: 0,
-                }}
-                bg="gray-1"
-                rounded="3"
-                py="2"
-                px="3"
-                align="center"
-                justify="center"
-                style={{
-                  transformOrigin:
-                    "var(--radix-tooltip-content-transform-origin)",
-                }}
-                {...(labelProps ? { labelProps } : {})}
-                {...TooltipContentProps[appearance]}
-              >
-                {typeof label === "string" ? (
-                  <Text as="span" size="1">
-                    {label}
-                  </Text>
-                ) : (
-                  label
-                )}
-              </Stack>
-            </OverrideAppearance>
-          </RadixTooltip.Content>
-        </RadixTooltip.Portal>
-      </RadixTooltip.Root>
-    </RadixTooltip.Provider>
+        <RadixTooltip.Root
+          open={enabled === false ? false : open}
+          onOpenChange={setOpen}
+        >
+          <RadixTooltip.Trigger asChild={true} ref={triggerRef}>
+            <RefToTgphRef>{children}</RefToTgphRef>
+          </RadixTooltip.Trigger>
+          <RadixTooltip.Portal>
+            <RadixTooltip.Content
+              aria-label={ariaLabel}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onPointerDownOutside={onPointerDownOutside}
+              forceMount={forceMount}
+              side={side}
+              sideOffset={sideOffset}
+              align={align}
+              alignOffset={alignOffset}
+              avoidCollisions={avoidCollisions}
+              collisionBoundary={collisionBoundary}
+              collisionPadding={collisionPadding}
+              arrowPadding={arrowPadding}
+              sticky={sticky}
+              hideWhenDetached={hideWhenDetached}
+              style={{
+                zIndex: `var(--tgph-zIndex-tooltip)`,
+              }}
+            >
+              <OverrideAppearance appearance={appearance} asChild>
+                <Stack
+                  as={motion.div}
+                  // Add tgph class so that this always works in portals
+                  className="tgph"
+                  initial={
+                    shouldAnimate && !skipAnimation
+                      ? {
+                          opacity: 0,
+                          scale: 0.5,
+                          ...deriveAnimationBasedOnSide(side),
+                        }
+                      : {}
+                  }
+                  animate={{
+                    opacity: 1,
+                    scale: 1,
+                    x: 0,
+                    y: 0,
+                  }}
+                  transition={{
+                    duration: 0.1,
+                    type: "spring",
+                    bounce: 0,
+                  }}
+                  bg="gray-1"
+                  rounded="3"
+                  py="2"
+                  px="3"
+                  align="center"
+                  justify="center"
+                  style={{
+                    transformOrigin:
+                      "var(--radix-tooltip-content-transform-origin)",
+                  }}
+                  {...(labelProps ? { labelProps } : {})}
+                  {...TooltipContentProps[appearance]}
+                >
+                  {typeof label === "string" ? (
+                    <Text as="span" size="1">
+                      {label}
+                    </Text>
+                  ) : (
+                    label
+                  )}
+                </Stack>
+              </OverrideAppearance>
+            </RadixTooltip.Content>
+          </RadixTooltip.Portal>
+        </RadixTooltip.Root>
+      </RadixTooltip.Provider>
+    </LazyMotion>
   );
 };
 


### PR DESCRIPTION
### Description
I realized I can use a combination of `motion/react-m` and `LazyMotion` + `domAnimation` to reduce the bundle size of packages using `motion` even further. I also went ahead and removed `AnimatePresence` as it's not really doing anything with how our component structure is working.

Here's some more info about reducing bundle sizes with the `motion` package: https://motion.dev/docs/react-reduce-bundle-size