### PR TITLE
fix: change logic gate for firing onCreate to not need a field value

### DIFF
--- a/.changeset/flat-carrots-march.md
+++ b/.changeset/flat-carrots-march.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": patch
+---
+
+fix: change logic gate for firing onCreate to not need a field value

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -188,6 +188,44 @@ export const MultiSelectWithWrapLayout: Story = {
   },
 };
 
+export const SingleSelectWithCreate: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = React.useState<string | undefined>(undefined);
+
+    return (
+      <Box w="80">
+        <TelegraphCombobox.Root
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          placeholder={"Select a channel"}
+          closeOnSelect={false}
+        >
+          <TelegraphCombobox.Trigger />
+          <TelegraphCombobox.Content>
+            <TelegraphCombobox.Search />
+            <TelegraphCombobox.Options>
+              {values.map((v, index) => (
+                <TelegraphCombobox.Option value={v}>
+                  {labels[index]}
+                </TelegraphCombobox.Option>
+              ))}
+              <TelegraphCombobox.Create<"div", false>
+                values={values}
+                onCreate={(createdValue) => {
+                  values.push(createdValue);
+                  setValue(createdValue);
+                }}
+              />
+            </TelegraphCombobox.Options>
+          </TelegraphCombobox.Content>
+        </TelegraphCombobox.Root>
+      </Box>
+    );
+  },
+};
+
 export const MultiSelectWithCreate: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -823,7 +823,7 @@ const Create = <T extends TgphElement, LB extends boolean>({
         label={`${leadingText} "${context.searchQuery}"`}
         selected={selected}
         onSelect={() => {
-          if (onCreate && context.value && context.searchQuery) {
+          if (onCreate && context.searchQuery) {
             const value =
               legacyBehavior === true
                 ? { value: context.searchQuery }


### PR DESCRIPTION
### Description
- Checking for `context.value` in the onCreate of the combobox made it so if there was no value in a single select combobox, `onCreate` would never fire.
- Adds single select with create field variation to storybook.