### PR TITLE
fix: bump tokens package to get updates

### DIFF
--- a/.changeset/strange-cars-lie.md
+++ b/.changeset/strange-cars-lie.md
@@ -1,0 +1,14 @@
+---
+"@telegraph/button": patch
+"@telegraph/combobox": patch
+"@telegraph/icon": patch
+"@telegraph/input": patch
+"@telegraph/menu": patch
+"@telegraph/modal": patch
+"@telegraph/popover": patch
+"@telegraph/segmented-control": patch
+"@telegraph/textarea": patch
+"@telegraph/tokens": patch
+---
+
+bump packages to get tokens upgrades


### PR DESCRIPTION
### Description
We need to bump the packages that were changed in the last update to get the version bumps in npm.