### PR TITLE
fix: ci running back to `pull_request`

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -2,7 +2,7 @@ name: Code Checks
 
 on:
   merge_group:
-  pull_request_target:
+  pull_request:
 
 concurrency:
   group: code-checks-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -2,19 +2,7 @@ name: Code Checks
 
 on:
   merge_group:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
   pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
-    branches:
-      - main
-      - 'changeset-release/**'
 
 concurrency:
   group: code-checks-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description
Attempted to fix an issue where sometimes code checks don't run in a `version packages` pr but this seemed to just make things work, so reverting back.