### PR TITLE
fix(kbd): KNO-9729 - prevent eventKey prop from being passed to DOM

### DIFF
--- a/packages/kbd/src/Kbd/Kbd.tsx
+++ b/packages/kbd/src/Kbd/Kbd.tsx
@@ -19,10 +19,11 @@ const Kbd = ({
   contrast: contrastProp = false,
   label,
   style,
+  eventKey,
   ...props
 }: KbdProps) => {
   const { appearance: appearanceProp } = useAppearance();
-  const { pressed } = usePressed({ key: props.eventKey || label });
+  const { pressed } = usePressed({ key: eventKey || label });
   const { icon, text } = getIconOrKey(label);
 
   const contrast = contrastProp ? "contrast" : "default";


### PR DESCRIPTION
# fix(kbd): KNO-9729 - prevent eventKey prop from being passed to DOM

## Summary
Fixed a React warning in the Kbd component where the `eventKey` prop was being passed down to DOM elements. The issue occurred because `eventKey` was defined in the `KbdProps` interface but wasn't destructured from the props object, causing it to be included when `{...props}` was spread onto the Stack component.

**Changes:**
- Destructured `eventKey` from props in the component function signature
- Updated the `usePressed` hook call to use the destructured `eventKey` variable instead of accessing `props.eventKey`

## Review & Testing Checklist for Human
- [ ] **Verify React warning is resolved**: Test the Kbd component in a browser and confirm no more DOM property warnings
- [ ] **Test keyboard interaction**: Verify that keyboard event handling still works correctly (press detection should still function)
- [ ] **Code review**: Confirm the prop destructuring and hook usage changes are correct

### Testing Plan
1. Use a Kbd component with an `eventKey` prop in a test application
2. Open browser developer tools and check console for React warnings
3. Test keyboard interaction to ensure the component still responds to key presses

### Notes
- All existing tests pass, including Kbd-specific tests
- No breaking changes to the component API
- Link to Devin run: https://app.devin.ai/sessions/3249eabe9cbf4991a4cd33fdf2dcb1df
- Requested by: @MikeCarbone