### PR TITLE
fix(KNO-8096): Do not override button "type" prop typing in telegraph button

### DIFF
--- a/.changeset/large-actors-compete.md
+++ b/.changeset/large-actors-compete.md
@@ -2,6 +2,6 @@
 "@telegraph/button": patch
 ---
 
-fix: make type prop compatible with HTMLButtonProps['type']
+fix: Make button "type" prop fully compatible with HTML button type prop
 
-In 0.2.0, we were only supporting submit and button, there is also reset and undefined values to support
+In 0.2.0, we mistakenly overrode the typing for the type prop (which also broke full compatibility with html button) and modified the behavior of it. It was unnecessary to override the typing for the prop.

--- a/.changeset/large-actors-compete.md
+++ b/.changeset/large-actors-compete.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/button": patch
+---
+
+fix: make type prop compatible with HTMLButtonProps['type']
+
+In 0.2.0, we were only supporting submit and button, there is also reset and undefined values to support

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -56,6 +56,7 @@ export const Example = () => (
 | `state`        | `"default" \| "loading"`                                                                | `"default"` | Button state                   |
 | `active`       | `boolean`                                                                               | `false`     | Whether button appears pressed |
 | `disabled`     | `boolean`                                                                               | `false`     | Whether button is disabled     |
+| `type`         | `"button" \| "submit" \| "reset"`                                                       | `"button"`  | Button type attribute          |
 | `leadingIcon`  | `IconProps`                                                                             | `undefined` | Icon before text               |
 | `trailingIcon` | `IconProps`                                                                             | `undefined` | Icon after text                |
 | `icon`         | `IconProps`                                                                             | `undefined` | Icon-only button               |

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -114,7 +114,7 @@ describe("Button", () => {
     );
     expect(container.firstChild?.nodeName).toBe("BUTTON");
   });
-  it("default button should not submit form", () => {
+  it("default button is BUTTON behavior, should not submit form", () => {
     const handleSubmit = vi.fn();
     const { container } = render(
       <form onSubmit={handleSubmit}>
@@ -125,7 +125,7 @@ describe("Button", () => {
     button?.click();
     expect(handleSubmit).not.toHaveBeenCalled();
   });
-  it('button with type="submit" should submit form', () => {
+  it('type="submit" should submit form', () => {
     const handleSubmit = vi.fn((e) => e.preventDefault());
     const { container } = render(
       <form onSubmit={handleSubmit}>
@@ -136,6 +136,33 @@ describe("Button", () => {
     button?.click();
     expect(handleSubmit).toHaveBeenCalled();
   });
+  it("type=reset should RESET form", () => {
+    const { container } = render(
+      <form>
+        <input name="foo" defaultValue="bar" />
+        <Button type="reset">Reset</Button>
+      </form>,
+    );
+    const input = container.querySelector(
+      'input[name="foo"]',
+    ) as HTMLInputElement;
+    input.value = "changed";
+    const button = container.querySelector("button");
+    button?.click();
+    expect(input.value).toBe("bar");
+  });
+  it("type=undefined should submit form", () => {
+    const handleSubmit = vi.fn((e) => e.preventDefault());
+    const { container } = render(
+      <form onSubmit={handleSubmit}>
+        <Button type={undefined}>Submit</Button>
+      </form>,
+    );
+    const button = container.querySelector("button");
+    button?.click();
+    expect(handleSubmit).toHaveBeenCalled();
+  });
+
   it('type prop is not passed when as="a"', () => {
     const { container } = render(
       <Button as="a" type="submit">

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -125,6 +125,17 @@ describe("Button", () => {
     button?.click();
     expect(handleSubmit).not.toHaveBeenCalled();
   });
+  it("type=undefined should not submit form", () => {
+    const handleSubmit = vi.fn((e) => e.preventDefault());
+    const { container } = render(
+      <form onSubmit={handleSubmit}>
+        <Button type={undefined}>Submit</Button>
+      </form>,
+    );
+    const button = container.querySelector("button");
+    button?.click();
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
   it('type="submit" should submit form', () => {
     const handleSubmit = vi.fn((e) => e.preventDefault());
     const { container } = render(
@@ -151,18 +162,6 @@ describe("Button", () => {
     button?.click();
     expect(input.value).toBe("bar");
   });
-  it("type=undefined should submit form", () => {
-    const handleSubmit = vi.fn((e) => e.preventDefault());
-    const { container } = render(
-      <form onSubmit={handleSubmit}>
-        <Button type={undefined}>Submit</Button>
-      </form>,
-    );
-    const button = container.querySelector("button");
-    button?.click();
-    expect(handleSubmit).toHaveBeenCalled();
-  });
-
   it('type prop is not passed when as="a"', () => {
     const { container } = render(
       <Button as="a" type="submit">

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -114,7 +114,7 @@ describe("Button", () => {
     );
     expect(container.firstChild?.nodeName).toBe("BUTTON");
   });
-  it("default button is BUTTON behavior, should not submit form", () => {
+  it("default button should not submit form", () => {
     const handleSubmit = vi.fn();
     const { container } = render(
       <form onSubmit={handleSubmit}>

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -13,7 +13,7 @@ import { useStyleEngine } from "@telegraph/style-engine";
 import { Text as TelegraphText } from "@telegraph/typography";
 import clsx from "clsx";
 import { LoaderCircle } from "lucide-react";
-import React, { ButtonHTMLAttributes } from "react";
+import React from "react";
 
 import {
   BUTTON_COLOR_MAP,
@@ -35,7 +35,6 @@ type RootBaseProps = {
   size?: ButtonSize;
   state?: "default" | "loading";
   active?: boolean;
-  type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
 };
 
 type InternalProps = {
@@ -60,7 +59,6 @@ const ButtonContext = React.createContext<
   state: "default",
   layout: "default",
   active: false,
-  type: "button",
 });
 
 type DeriveStateParams = {
@@ -132,7 +130,7 @@ const Root = <T extends TgphElement>({
 
   return (
     <ButtonContext.Provider
-      value={{ variant, size, color, state, layout, active, type }}
+      value={{ variant, size, color, state, layout, active }}
     >
       <Stack
         as={derivedAs}

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -13,7 +13,7 @@ import { useStyleEngine } from "@telegraph/style-engine";
 import { Text as TelegraphText } from "@telegraph/typography";
 import clsx from "clsx";
 import { LoaderCircle } from "lucide-react";
-import React from "react";
+import React, { ButtonHTMLAttributes } from "react";
 
 import {
   BUTTON_COLOR_MAP,
@@ -35,7 +35,7 @@ type RootBaseProps = {
   size?: ButtonSize;
   state?: "default" | "loading";
   active?: boolean;
-  type?: "button" | "submit";
+  type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
 };
 
 type InternalProps = {


### PR DESCRIPTION
In trying to upgrade the control repo, I found a usecase where we need Button's type prop to be fully compatible with HTML button's type prop.

Also, I forgot to document the prop in readme


**Testing:**
- Add 2 more test cases for comprehensive coverage of 4 potential types


**Verify this package doesn't break control**
In telegraph
`yarn build:packages`
In button directory
`yarn pack`

(copy tgz file version of button to control)

In control
Update `package.json` for `@telegraph/button` to be `"@telegraph/button": "file:package.tgz"`
`yarn install`
`yarn tc` 

No type errors
<img width="2108" height="743" alt="Screenshot 2025-09-19 at 11 11 58 AM" src="https://github.com/user-attachments/assets/3e934e0c-f8ce-4a0b-819e-77347f88ab62" />
