### PR TITLE
fix(KNO-12630): Standardize datalist rows

### DIFF
--- a/.changeset/gentle-pumas-march.md
+++ b/.changeset/gentle-pumas-march.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/data-list": minor
+---
+
+Standardize row layouts in `DataList`

--- a/packages/data-list/src/DataList/DataList.stories.tsx
+++ b/packages/data-list/src/DataList/DataList.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "@telegraph/button";
+import { Combobox } from "@telegraph/combobox";
 import { Input } from "@telegraph/input";
+import { Stack } from "@telegraph/layout";
+import { Tag } from "@telegraph/tag";
 import { TextArea } from "@telegraph/textarea";
-import { Text } from "@telegraph/typography";
+import { Code, Text } from "@telegraph/typography";
 import { CornerDownRight } from "lucide-react";
+import React from "react";
 
 import { DataList } from "./DataList";
 
@@ -30,20 +35,28 @@ type Story = StoryObj<typeof DataList.Item>;
 
 export const Default: Story = {
   render: ({ ...args }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [channel, setChannel] = React.useState<string>("email");
+
     return (
       <DataList.List maxW="160">
         <DataList.Item {...args}>
           <Text size="1" as="span">
+            Value slot
+          </Text>
+        </DataList.Item>
+        <DataList.Item {...args} label="Name">
+          <Text size="1" as="span">
             Text
           </Text>
         </DataList.Item>
-        <DataList.Item {...args}>
+        <DataList.Item {...args} label="Bio">
           <Text size="1" as="span">
             Really really really long text that just keeps going and going and
             going. Why is this text so so so so so long?
           </Text>
         </DataList.Item>
-        <DataList.Item {...args}>
+        <DataList.Item {...args} label="Email">
           <Input size="1" stackProps={{ w: "full" }} />
         </DataList.Item>
         <DataList.Item
@@ -65,11 +78,12 @@ export const Default: Story = {
         </DataList.Item>
         <DataList.Item
           {...args}
+          label="Alias"
           icon={{ icon: CornerDownRight, ["aria-hidden"]: true }}
         >
           <Input size="1" stackProps={{ w: "full" }} />
         </DataList.Item>
-        <DataList.Item {...args}>
+        <DataList.Item {...args} label="Notes">
           <TextArea
             size="1"
             w="full"
@@ -79,7 +93,52 @@ export const Default: Story = {
             }}
           />
         </DataList.Item>
-        <DataList.Item {...args} direction="column">
+        <DataList.Item {...args} label="Action">
+          <Button size="1" variant="solid" color="accent">
+            Save changes
+          </Button>
+        </DataList.Item>
+        <DataList.Item {...args} label="Status">
+          <Tag size="1" color="green">
+            Active
+          </Tag>
+        </DataList.Item>
+        <DataList.Item {...args} label="Channels">
+          <Stack direction="row" gap="1">
+            <Tag size="1" color="accent">
+              Email
+            </Tag>
+            <Tag size="1" color="accent">
+              SMS
+            </Tag>
+            <Tag size="1" color="accent">
+              Push
+            </Tag>
+          </Stack>
+        </DataList.Item>
+        <DataList.Item {...args} label="Token">
+          <Code size="1" as="span">
+            sk_live_abc123
+          </Code>
+        </DataList.Item>
+        <DataList.Item {...args} label="Channel">
+          <Combobox.Root
+            value={channel}
+            onValueChange={setChannel}
+            placeholder="Select a channel"
+          >
+            <Combobox.Trigger size="1" />
+            <Combobox.Content>
+              <Combobox.Options>
+                <Combobox.Option value="email">Email</Combobox.Option>
+                <Combobox.Option value="sms">SMS</Combobox.Option>
+                <Combobox.Option value="push">Push</Combobox.Option>
+              </Combobox.Options>
+              <Combobox.Empty />
+            </Combobox.Content>
+          </Combobox.Root>
+        </DataList.Item>
+        <DataList.Item {...args} label="Description" direction="column">
           <Text size="1" as="span">
             This is a column data list item with really really really long text
             that just keeps going and going and going. Why is this text so so so

--- a/packages/data-list/src/DataList/DataList.stories.tsx
+++ b/packages/data-list/src/DataList/DataList.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
           </Text>
         </DataList.Item>
         <DataList.Item {...args}>
-          <Input size="1" w="full" />
+          <Input size="1" stackProps={{ w: "full" }} />
         </DataList.Item>
         <DataList.Item
           {...args}
@@ -67,11 +67,12 @@ export const Default: Story = {
           {...args}
           icon={{ icon: CornerDownRight, ["aria-hidden"]: true }}
         >
-          <Input size="1" />
+          <Input size="1" stackProps={{ w: "full" }} />
         </DataList.Item>
         <DataList.Item {...args}>
           <TextArea
             size="1"
+            w="full"
             textProps={{
               value:
                 "This is content within a text area that stretches a few lines.",

--- a/packages/data-list/src/DataList/DataList.stories.tsx
+++ b/packages/data-list/src/DataList/DataList.stories.tsx
@@ -33,16 +33,18 @@ export const Default: Story = {
     return (
       <DataList.List maxW="160">
         <DataList.Item {...args}>
-          <Text as="span">Text</Text>
+          <Text size="1" as="span">
+            Text
+          </Text>
         </DataList.Item>
         <DataList.Item {...args}>
-          <Text as="span">
+          <Text size="1" as="span">
             Really really really long text that just keeps going and going and
             going. Why is this text so so so so so long?
           </Text>
         </DataList.Item>
         <DataList.Item {...args}>
-          <Input />
+          <Input size="1" w="full" />
         </DataList.Item>
         <DataList.Item
           {...args}
@@ -55,16 +57,21 @@ export const Default: Story = {
           }}
           description="The unique identifier for the user"
         >
-          <Input placeholder="Enter user ID" />
+          <Input
+            size="1"
+            stackProps={{ w: "full" }}
+            placeholder="Enter user ID"
+          />
         </DataList.Item>
         <DataList.Item
           {...args}
           icon={{ icon: CornerDownRight, ["aria-hidden"]: true }}
         >
-          <Input />
+          <Input size="1" />
         </DataList.Item>
         <DataList.Item {...args}>
           <TextArea
+            size="1"
             textProps={{
               value:
                 "This is content within a text area that stretches a few lines.",
@@ -72,7 +79,7 @@ export const Default: Story = {
           />
         </DataList.Item>
         <DataList.Item {...args} direction="column">
-          <Text as="span">
+          <Text size="1" as="span">
             This is a column data list item with really really really long text
             that just keeps going and going and going. Why is this text so so so
             so so long?

--- a/packages/data-list/src/DataList/DataList.tsx
+++ b/packages/data-list/src/DataList/DataList.tsx
@@ -87,7 +87,7 @@ const Label = ({
 export type ValueProps = TgphComponentProps<typeof Stack>;
 
 const Value = ({
-  direction = "column",
+  direction = "row",
   w = "full",
   minW = "0",
   ...props

--- a/packages/data-list/src/DataList/DataList.tsx
+++ b/packages/data-list/src/DataList/DataList.tsx
@@ -34,7 +34,7 @@ export type LabelProps = {
 
 const Label = ({
   maxW = "36",
-  maxH = "6",
+  minH = "6",
   w = "full",
   icon,
   children,
@@ -57,7 +57,7 @@ const Label = ({
       gap="2"
       maxW={maxW}
       w={w}
-      maxH={maxH}
+      minH={minH}
       {...props}
     >
       {icon && (
@@ -66,17 +66,19 @@ const Label = ({
         </Stack>
       )}
       <Tooltip label={description} enabled={!!description} {...tooltipProps}>
-        <Text
-          as="label"
-          {...restTextProps}
-          color={color}
-          weight={weight}
-          size={size}
-          borderBottom={description ? "px" : undefined}
-          borderStyle={description ? "dashed" : undefined}
-        >
-          {children}
-        </Text>
+        <Stack direction="row" align="center" h="6">
+          <Text
+            as="label"
+            {...restTextProps}
+            color={color}
+            weight={weight}
+            size={size}
+            borderBottom={description ? "px" : undefined}
+            borderStyle={description ? "dashed" : undefined}
+          >
+            {children}
+          </Text>
+        </Stack>
       </Tooltip>
     </Stack>
   );
@@ -84,8 +86,13 @@ const Label = ({
 
 export type ValueProps = TgphComponentProps<typeof Stack>;
 
-const Value = ({ ...props }: ValueProps) => {
-  return <Stack {...props} />;
+const Value = ({
+  direction = "column",
+  w = "full",
+  minW = "0",
+  ...props
+}: ValueProps) => {
+  return <Stack direction={direction} w={w} minW={minW} {...props} />;
 };
 
 export type ItemProps = ListItemProps & {

--- a/packages/data-list/src/DataList/DataList.tsx
+++ b/packages/data-list/src/DataList/DataList.tsx
@@ -34,7 +34,6 @@ export type LabelProps = {
 
 const Label = ({
   maxW = "36",
-  minH = "6",
   w = "full",
   icon,
   children,
@@ -57,16 +56,15 @@ const Label = ({
       gap="2"
       maxW={maxW}
       w={w}
-      minH={minH}
       {...props}
     >
       {icon && (
         <Stack alignSelf="center">
-          <Icon size="1" color="gray" {...icon} />
+          <Icon size="0" color="gray" {...icon} />
         </Stack>
       )}
       <Tooltip label={description} enabled={!!description} {...tooltipProps}>
-        <Stack direction="row" align="center" h="6">
+        <Stack direction="row" align="center" minH="6">
           <Text
             as="label"
             {...restTextProps}
@@ -86,13 +84,8 @@ const Label = ({
 
 export type ValueProps = TgphComponentProps<typeof Stack>;
 
-const Value = ({
-  direction = "row",
-  w = "full",
-  minW = "0",
-  ...props
-}: ValueProps) => {
-  return <Stack direction={direction} w={w} minW={minW} {...props} />;
+const Value = ({ w = "full", minW = "0", ...props }: ValueProps) => {
+  return <Stack w={w} minW={minW} {...props} />;
 };
 
 export type ItemProps = ListItemProps & {


### PR DESCRIPTION
### What changed?
- Data list value containers are full width
- Add more examples of different datalist values in storybook


Before
<img width="444" height="479" alt="image" src="https://github.com/user-attachments/assets/5e4113ba-c0ea-431f-a8a1-eab6158ad889" />

After
<img width="472" height="561" alt="image" src="https://github.com/user-attachments/assets/fc359f77-535b-4ee9-9f0f-d5daf1d14d68" />
