### PR TITLE
fix(ci): add persist-credentials: false to release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## What changed

- Added `persist-credentials: false` to the `actions/checkout` step in `.github/workflows/release.yml`.

## Why

When a follow-up commit with a new changeset is pushed to `main`, `changesets/action` force-pushes updated version bumps to `changeset-release/main`. That push was silently using the default `GITHUB_TOKEN` (baked into the git remote URL by `actions/checkout`), which GitHub treats as a bot push and does not fire `pull_request` events for — leaving the Version Packages PR permanently blocked with "Required workflows never started."

The release workflow already passes `KNOCK_ENG_BOT_GITHUB_TOKEN` as `GITHUB_TOKEN` to `changesets/action`, but that only covers Octokit API calls. The git push itself was still using the default token persisted by checkout. Setting `persist-credentials: false` clears that, so the force-push uses the PAT instead — which GitHub recognizes as a real user push and correctly triggers `pull_request` workflows.

Confirmed fix in [changesets/action#70](https://github.com/changesets/action/issues/70).
