### PR TITLE
fix(KNO-12734): add portal around menu content

### DIFF
--- a/.changeset/fast-zebras-fetch.md
+++ b/.changeset/fast-zebras-fetch.md
@@ -1,5 +1,6 @@
 ---
 "@telegraph/menu": patch
+"@telegraph/combobox": patch
 ---
 
-fix(KNO-12734): Wrap menu content in a portal to fix Safari rendering issues and match Popover component behavior
+fix(KNO-12734): Wrap menu content in a portal to fix Safari rendering issues and match Popover component behavior; remove resulting double portal from Combobox

--- a/.changeset/fast-zebras-fetch.md
+++ b/.changeset/fast-zebras-fetch.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+fix(KNO-12734): Wrap menu content in a portal to fix Safari rendering issues and match Popover component behavior

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1,5 +1,4 @@
 import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
-import * as Portal from "@radix-ui/react-portal";
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
 import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button as TelegraphButton } from "@telegraph/button";
@@ -416,84 +415,76 @@ const Content = <T extends TgphElement = "div">({
   }, [context.open, setHeightFromContent]);
 
   return (
-    <Portal.Root asChild>
-      {/* 
-        We add radix's dismissable layer here so that we can swallow any escape
-        key presses to prevent cases like a modal closing when we close the
-        combobox 
-      */}
-      <DismissableLayer
-        onEscapeKeyDown={(event) => {
-          if (context.open) {
-            // Don't allow the event to bubble up outside of the menu
-            event.stopPropagation();
-            event.preventDefault();
-            context.setOpen(false);
+    <DismissableLayer
+      onEscapeKeyDown={(event) => {
+        if (context.open) {
+          // Don't allow the event to bubble up outside of the menu
+          event.stopPropagation();
+          event.preventDefault();
+          context.setOpen(false);
+        }
+      }}
+    >
+      <TelegraphMenu.Content
+        className="tgph"
+        mt="1"
+        onCloseAutoFocus={(event: Event) => {
+          if (!hasInteractedOutside.current) {
+            context.triggerRef?.current?.focus();
+          }
+
+          hasInteractedOutside.current = false;
+
+          event.preventDefault();
+        }}
+        bg="surface-1"
+        style={{
+          width: "var(--tgph-combobox-trigger-width)",
+          transition: "min-height 200ms ease-in-out",
+          minHeight: height ? `${height}px` : "0",
+          ...style,
+          ...{
+            "--tgph-combobox-content-transform-origin":
+              "var(--radix-popper-transform-origin)",
+            "--tgph-combobox-content-available-width":
+              "var(--radix-popper-available-width)",
+            "--tgph-combobox-content-available-height":
+              "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
+            "--tgph-combobox-trigger-width": "var(--radix-popper-anchor-width)",
+            "--tgph-combobox-trigger-height":
+              "var(--radix-popper-anchor-height)",
+          },
+        }}
+        {...props}
+        tgphRef={composedRef}
+        data-tgph-combobox-content
+        data-tgph-combobox-content-open={context.open}
+        // Cancel out accessibility attirbutes related to aria menu
+        role={undefined}
+        aria-orientation={undefined}
+        onKeyDown={(event: React.KeyboardEvent) => {
+          // Don't allow the event to bubble up outside of the menu
+          event.stopPropagation();
+
+          // If the first option is focused and the user presses the up
+          // arrow key, focus the search input
+          const options = context.contentRef?.current?.querySelectorAll(
+            "[data-tgph-combobox-option]",
+          );
+
+          if (
+            document.activeElement === options?.[0] &&
+            LAST_KEYS.includes(event.key)
+          ) {
+            context.searchRef?.current?.focus();
           }
         }}
       >
-        <TelegraphMenu.Content
-          className="tgph"
-          mt="1"
-          onCloseAutoFocus={(event: Event) => {
-            if (!hasInteractedOutside.current) {
-              context.triggerRef?.current?.focus();
-            }
-
-            hasInteractedOutside.current = false;
-
-            event.preventDefault();
-          }}
-          bg="surface-1"
-          style={{
-            width: "var(--tgph-combobox-trigger-width)",
-            transition: "min-height 200ms ease-in-out",
-            minHeight: height ? `${height}px` : "0",
-            ...style,
-            ...{
-              "--tgph-combobox-content-transform-origin":
-                "var(--radix-popper-transform-origin)",
-              "--tgph-combobox-content-available-width":
-                "var(--radix-popper-available-width)",
-              "--tgph-combobox-content-available-height":
-                "calc(var(--radix-popper-available-height) - var(--tgph-spacing-8))",
-              "--tgph-combobox-trigger-width":
-                "var(--radix-popper-anchor-width)",
-              "--tgph-combobox-trigger-height":
-                "var(--radix-popper-anchor-height)",
-            },
-          }}
-          {...props}
-          tgphRef={composedRef}
-          data-tgph-combobox-content
-          data-tgph-combobox-content-open={context.open}
-          // Cancel out accessibility attirbutes related to aria menu
-          role={undefined}
-          aria-orientation={undefined}
-          onKeyDown={(event: React.KeyboardEvent) => {
-            // Don't allow the event to bubble up outside of the menu
-            event.stopPropagation();
-
-            // If the first option is focused and the user presses the up
-            // arrow key, focus the search input
-            const options = context.contentRef?.current?.querySelectorAll(
-              "[data-tgph-combobox-option]",
-            );
-
-            if (
-              document.activeElement === options?.[0] &&
-              LAST_KEYS.includes(event.key)
-            ) {
-              context.searchRef?.current?.focus();
-            }
-          }}
-        >
-          <Stack direction="column" gap="1" tgphRef={internalContentRef}>
-            {children}
-          </Stack>
-        </TelegraphMenu.Content>
-      </DismissableLayer>
-    </Portal.Root>
+        <Stack direction="column" gap="1" tgphRef={internalContentRef}>
+          {children}
+        </Stack>
+      </TelegraphMenu.Content>
+    </DismissableLayer>
   );
 };
 

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it } from "vitest";
+
+import type { MenuContentProps } from "./index";
+
+describe("Menu", () => {
+  describe("type inheritance", () => {
+    it("accepts valid content-specific props", () => {
+      const validProps: MenuContentProps = {
+        sideOffset: 4,
+      };
+      void validProps;
+    });
+
+    it("accepts inherited stack/layout props", () => {
+      const validProps: MenuContentProps = {
+        gap: "2",
+        padding: "4",
+        rounded: "4",
+        bg: "surface-1",
+      };
+      void validProps;
+    });
+
+    it("rejects unknown props on type level", () => {
+      // @ts-expect-error unknown prop rejected on MenuContentProps
+      const invalidProp: MenuContentProps = { invalidProp: "invalid" };
+      void invalidProp;
+    });
+  });
+});

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -93,33 +93,37 @@ const Content = <T extends TgphElement = "div">({
   ...props
 }: ContentProps<T>) => {
   return (
-    <RadixMenu.Content
-      onInteractOutside={onInteractOutside}
-      onKeyDown={onKeyDown}
-      onCloseAutoFocus={onCloseAutoFocus}
-      asChild
-      sideOffset={sideOffset}
-      {...props}
-      // Need to cast this type since RadixMenu.Content doesn't accept tgphRef
-      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-    >
-      <RefToTgphRef>
-        <Stack
-          bg="surface-1"
-          direction={direction}
-          gap={gap}
-          rounded={rounded}
-          py={py}
-          shadow={shadow}
-          style={{
-            overflowY: "auto",
-          }}
-          zIndex="popover"
-        >
-          {children}
-        </Stack>
-      </RefToTgphRef>
-    </RadixMenu.Content>
+    <RadixMenu.Portal>
+      <RadixMenu.Content
+        onInteractOutside={onInteractOutside}
+        onKeyDown={onKeyDown}
+        onCloseAutoFocus={onCloseAutoFocus}
+        asChild
+        sideOffset={sideOffset}
+        {...props}
+        // Need to cast this type since RadixMenu.Content doesn't accept tgphRef
+        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+      >
+        <RefToTgphRef>
+          <Stack
+            bg="surface-1"
+            // Add tgph class so that this always works in portals
+            className="tgph"
+            direction={direction}
+            gap={gap}
+            rounded={rounded}
+            py={py}
+            shadow={shadow}
+            style={{
+              overflowY: "auto",
+            }}
+            zIndex="popover"
+          >
+            {children}
+          </Stack>
+        </RefToTgphRef>
+      </RadixMenu.Content>
+    </RadixMenu.Portal>
   );
 };
 


### PR DESCRIPTION
## What changed

- Wrapped `Menu.Content` in `RadixMenu.Portal` so the menu renders outside the DOM subtree.
- Added `className="tgph"` to the content `Stack` so styles apply correctly in portals.
- Removed the now-redundant `Portal.Root asChild` wrapper from `Combobox.Content` — `Menu.Content` already portals itself, so Combobox was double-portaling to `document.body`.
- Added type-level tests for `MenuContentProps` to match the pattern in `Popover`.

## Why

Menu content was not rendering in a portal, which caused Safari rendering bugs. This also made it inconsistent with the `Popover` component, which already uses `RadixPopover.Portal`. Both components now behave the same way.

The `Portal.Root asChild` in Combobox was originally added as a workaround for the missing portal in `Menu.Content`. With the portal now living inside `Menu.Content`, that wrapper became a no-op double portal and has been removed.

## Notes

The `tgph` class is required whenever content renders in a portal — without it, Telegraph's scoped CSS does not apply to the content. This mirrors the approach already used in `Popover.tsx`.
