### PR TITLE
fix(KNO-12836): use surface-1 bg for default Button, Combobox, Input, TextArea

### DIFF
--- a/.changeset/chatty-humans-wash.md
+++ b/.changeset/chatty-humans-wash.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/combobox": minor
+"@telegraph/textarea": minor
+"@telegraph/button": minor
+"@telegraph/input": minor
+---
+
+Swap in surface-1 bg color for Button, Combobox, Input and TextArea's default variants

--- a/packages/button/src/Button/Button.constants.ts
+++ b/packages/button/src/Button/Button.constants.ts
@@ -243,7 +243,7 @@ export const BUTTON_COLOR_MAP = {
   },
   outline: {
     default: {
-      backgroundColor: "surface-3",
+      backgroundColor: "surface-1",
       buttonShadowColor: "gray-6",
       _hover: {
         backgroundColor: "gray-2",

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -298,7 +298,7 @@ const Trigger = <V extends ChildrenValue>({
       <TelegraphButton.Root
         id={context.triggerId}
         type="button"
-        bg="surface-3"
+        bg="surface-1"
         variant="outline"
         align="center"
         minH={TRIGGER_MIN_HEIGHT[size]}

--- a/packages/input/src/Input/Input.constants.ts
+++ b/packages/input/src/Input/Input.constants.ts
@@ -58,11 +58,11 @@ export const COLOR = {
   Container: {
     default: {
       outline: {
-        bg: "surface-3",
+        bg: "surface-1",
         border: "px",
         borderColor: "gray-6",
         _hover: {
-          backgroundColor: "surface-2",
+          backgroundColor: "surface-1",
           borderColor: "gray-7",
         },
         _focusWithin: {
@@ -98,7 +98,7 @@ export const COLOR = {
     },
     error: {
       outline: {
-        bg: "surface-3",
+        bg: "surface-1",
         border: "px",
         borderColor: "red-6",
         _hover: {
@@ -111,7 +111,7 @@ export const COLOR = {
         },
       },
       ghost: {
-        bg: "surface-3",
+        bg: "surface-1",
         border: "px",
         borderColor: "red-6",
         _hover: {

--- a/packages/input/src/Input/Input.constants.ts
+++ b/packages/input/src/Input/Input.constants.ts
@@ -62,7 +62,7 @@ export const COLOR = {
         border: "px",
         borderColor: "gray-6",
         _hover: {
-          backgroundColor: "surface-1",
+          backgroundColor: "surface-2",
           borderColor: "gray-7",
         },
         _focusWithin: {

--- a/packages/textarea/src/TextArea/TextArea.constants.ts
+++ b/packages/textarea/src/TextArea/TextArea.constants.ts
@@ -93,7 +93,7 @@ export const variantMap: VariantMap = {
 export const stateMap: StateMap = {
   default: {
     outline: {
-      bg: "surface-3",
+      bg: "surface-1",
     },
     ghost: {
       bg: "transparent",

--- a/packages/textarea/src/TextArea/TextArea.constants.ts
+++ b/packages/textarea/src/TextArea/TextArea.constants.ts
@@ -117,14 +117,14 @@ export const stateMap: StateMap = {
   },
   error: {
     outline: {
-      bg: "surface-3",
+      bg: "surface-1",
       borderColor: "red-6",
       _hover: {
         borderColor: "red-7",
       },
     },
     ghost: {
-      bg: "surface-3",
+      bg: "surface-1",
       borderColor: "red-6",
       _hover: {
         borderColor: "red-7",


### PR DESCRIPTION
## Summary
- Swap in `surface-1` for the default variant background of Button, Combobox, Input, and TextArea so interactive surfaces read correctly in dark mode