### PR TITLE
feat(tooltip): add `disableFocusOpen` prop and fix `labelProps` spread bug

### DIFF
--- a/.changeset/tooltip-disable-focus-open.md
+++ b/.changeset/tooltip-disable-focus-open.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/tooltip": minor
+---
+
+feat(tooltip): add `disableFocusOpen` prop and fix `labelProps` spread bug
+
+- Added `disableFocusOpen` prop to suppress focus-triggered instant opens (useful when parent components like Select/Combobox move DOM focus on hover, bypassing `delayDuration`).
+- Fixed `labelProps` spread: replaced `{...(labelProps ? { labelProps } : {})}` with `{...(labelProps ?? {})}` so props correctly merge onto the inner Stack.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -78,6 +78,7 @@ The main tooltip component that wraps content and provides contextual informatio
 | `delayDuration`           | `number`                                 | `400`       | Delay before showing tooltip (ms)                            |
 | `skipDelayDuration`       | `number`                                 | -           | Skip delay if another tooltip was recently shown             |
 | `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
+| `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
 | `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
 | `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
 | `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |
@@ -175,6 +176,26 @@ export const CustomDelayTooltips = () => (
   </div>
 );
 ```
+
+### Disable Focus-Triggered Open
+
+When wrapping elements inside a `Select` or `Combobox` (where DOM focus moves to the highlighted option on hover), the tooltip can open instantly — bypassing `delayDuration`. Use `disableFocusOpen` to suppress the focus-triggered open:
+
+```tsx
+import { Tooltip } from "@telegraph/tooltip";
+
+export const ListItemTooltip = ({ item }) => (
+  <Tooltip
+    label={item.description}
+    disableFocusOpen
+    delayDuration={500}
+  >
+    <li>{item.name}</li>
+  </Tooltip>
+);
+```
+
+> **Accessibility note:** When `disableFocusOpen` is enabled, keyboard-only users navigating with arrow keys will not trigger the tooltip on focus. The tooltip remains accessible via hover (`delayDuration`) and pointer interaction.
 
 ### Disabled Elements
 
@@ -452,7 +473,7 @@ export const NestedTooltips = () => (
 
 - ✅ **Keyboard Navigation**: Full keyboard support with proper focus management
 - ✅ **Screen Reader Support**: Proper ARIA attributes and announcements
-- ✅ **Focus Management**: Tooltips appear on focus for keyboard users
+- ✅ **Focus Management**: Tooltips appear on focus for keyboard users (unless `disableFocusOpen` is set)
 - ✅ **High Contrast**: Compatible with high contrast modes
 - ✅ **Reduced Motion**: Respects user's motion preferences
 

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -15,6 +15,15 @@ describe("Tooltip", () => {
       void validProps;
     });
 
+    it("accepts disableFocusOpen prop", () => {
+      const propsWithDisableFocusOpen: TooltipProps = {
+        label: "Tooltip text",
+        disableFocusOpen: true,
+        children: null,
+      };
+      void propsWithDisableFocusOpen;
+    });
+
     it("rejects unknown props on type level", () => {
       // @ts-expect-error unknown prop rejected on TooltipProps
       const invalidProp: TooltipProps = {

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -17,6 +17,14 @@ export type TooltipBaseProps<T extends TgphElement = "div"> = {
   label: string | React.ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
+  /**
+   * When `true`, prevents focus events from instantly opening the tooltip.
+   * Useful when a parent component (e.g. Select/Combobox) moves DOM focus on
+   * hover, which would otherwise bypass `delayDuration` via Radix's composed
+   * `onFocus` handler.
+   * @default false
+   */
+  disableFocusOpen?: boolean;
 
   skipAnimation?: boolean;
   triggerRef?: React.RefObject<HTMLButtonElement>;
@@ -58,6 +66,7 @@ const Tooltip = <T extends TgphElement = "div">({
   labelProps,
   // Telegraph Props
   enabled = true,
+  disableFocusOpen = false,
 
   triggerRef,
   children,
@@ -123,7 +132,13 @@ const Tooltip = <T extends TgphElement = "div">({
           onOpenChange={setOpen}
         >
           <RadixTooltip.Trigger asChild={true} ref={triggerRef}>
-            <RefToTgphRef>{children}</RefToTgphRef>
+            <RefToTgphRef
+              {...(disableFocusOpen
+                ? { onFocus: (e: React.FocusEvent) => e.preventDefault() }
+                : {})}
+            >
+              {children}
+            </RefToTgphRef>
           </RadixTooltip.Trigger>
           <RadixTooltip.Portal>
             <RadixTooltip.Content
@@ -180,7 +195,7 @@ const Tooltip = <T extends TgphElement = "div">({
                   transformOrigin:
                     "var(--radix-tooltip-content-transform-origin)",
                 }}
-                {...(labelProps ? { labelProps } : {})}
+                {...(labelProps ?? {})}
               >
                 {typeof label === "string" ? (
                   <Text as="span" size="1">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Patches `@telegraph/tooltip` with two related fixes:

1. **Add `disableFocusOpen` prop** — allows consumers to suppress focus-triggered instant opens. Radix Tooltip Trigger opens immediately on `onFocus` via `context.onOpen()`, bypassing `delayDuration`. Components like Select/Combobox move DOM focus to the highlighted option on hover, causing list tooltips to pop instantly when scanning.

2. **Fix `labelProps` spread bug** — replaces `{...(labelProps ? { labelProps } : {})}` with `{...(labelProps ?? {})}` so `labelProps` actually merges onto the inner `Stack` (e.g. padding overrides now work correctly).

## Changes

### `packages/tooltip/src/Tooltip/Tooltip.tsx`
- Added `disableFocusOpen?: boolean` to `TooltipBaseProps` with JSDoc (default `false`)
- Destructured `disableFocusOpen = false` in the component
- When enabled, passes `onFocus={(e) => e.preventDefault()}` on `RefToTgphRef` — the child focus handler runs before Radix's composed handler, and `composeEventHandlers` skips Radix when `defaultPrevented`
- Fixed the `labelProps` spread to correctly merge onto the Stack

### `packages/tooltip/src/Tooltip/Tooltip.test.tsx`
- Added type-level test accepting `disableFocusOpen`

### `packages/tooltip/README.md`
- Added `disableFocusOpen` to API reference table
- Added "Disable Focus-Triggered Open" usage section with example and a11y note
- Updated accessibility bullet to reflect the opt-in behavior

### `.changeset/tooltip-disable-focus-open.md`
- Minor changeset for `@telegraph/tooltip`

## Verification

- `yarn workspace @telegraph/tooltip build` ✅
- `yarn vitest run packages/tooltip` — 3 tests pass ✅

## Related

Resolves KNO-13063
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [KNO-13063](https://linear.app/knock/issue/KNO-13063/featkno-patch-telegraphtooltip-disablefocusopen-labelprops-fix)

<div><a href="https://cursor.com/agents/bc-55110933-04b1-4981-90df-3f5b6fedf897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55110933-04b1-4981-90df-3f5b6fedf897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

