### PR TITLE
chore(ci): harden GitHub Actions against supply-chain attacks

### DIFF
--- a/.github/workflows/check-package-sizes.yml
+++ b/.github/workflows/check-package-sizes.yml
@@ -3,6 +3,9 @@ name: Check Package Sizes
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: check-package-sizes-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check-package-sizes.yml
+++ b/.github/workflows/check-package-sizes.yml
@@ -43,7 +43,7 @@ jobs:
           previous-package-sizes: ${{ steps.main-package-sizes.outputs.package-sizes }}
         id: compare-package-sizes
       - name: Find Comment
-        uses: peter-evans/find-comment@v1
+        uses: peter-evans/find-comment@d2dae40ed151c634e4189471272b57e76ec19ba8 # v1.3.0
         id: fc
         with:
           token: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }} 
@@ -52,14 +52,14 @@ jobs:
           body-includes: ### Package size differences
       - name: Create comment
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # v1.4.5
         with:
           token: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }} 
           issue-number: ${{ github.event.pull_request.number }}
           body: ${{ steps.compare-package-sizes.outputs.pr-comment }}
       - name: Update comment
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v1
+        uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # v1.4.5
         with:
           token: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }} 
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/check-package-sizes.yml
+++ b/.github/workflows/check-package-sizes.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
           cache: "yarn"
@@ -29,7 +29,7 @@ jobs:
         uses: ./.github/actions/check-package-sizes-action
         id: current-package-sizes
       - name: Checkout Main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
       - name: Install Dependencies

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -4,6 +4,9 @@ on:
   merge_group:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: code-checks-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/commitlint-pr.yml
+++ b/.github/workflows/commitlint-pr.yml
@@ -6,11 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
 
 permissions:
   pull-requests: read
@@ -24,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Commitlint on PR Title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Checkout the PR branch for package.json analysis and committing.
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ steps.pr.outputs.ref }}
           token: ${{ secrets.KNOCK_ENG_BOT_GITHUB_TOKEN }}
@@ -55,14 +55,14 @@ jobs:
       # This ensures we never execute code from an untrusted PR branch
       # when triggered via workflow_dispatch.
       - name: Checkout trusted script from main
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: main
           sparse-checkout: .github/scripts
           path: .trusted
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
 

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -3,6 +3,9 @@ name: Check Project Formatting
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: format-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,15 +15,15 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - name: Checkout
-         uses: actions/checkout@v4
+         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
        - name: Setup Node
-         uses: actions/setup-node@v4
+         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
          with:
           node-version-file: "package.json"
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v4
+         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
          with:
            path: |
              **/dist

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v3
+         uses: actions/cache@v4
          with:
            path: |
              **/dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,15 +15,15 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - name: Checkout
-         uses: actions/checkout@v4
+         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
        - name: Setup Node
-         uses: actions/setup-node@v4
+         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
          with:
           node-version-file: "package.json"
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v4
+         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
          with:
            path: |
             **/dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint Project
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: lint-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v3
+         uses: actions/cache@v4
          with:
            path: |
             **/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 concurrency:
   group: publish-${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -38,7 +41,7 @@ jobs:
         run: yarn build:packages
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           commit: "chore(repo): version packages"
           title: "chore(repo): version packages"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-tags: true
           fetch-depth: 0
           persist-credentials: false
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           registry-url: "https://registry.npmjs.org"
           node-version-file: "package.json"

--- a/.github/workflows/setup-files.yml
+++ b/.github/workflows/setup-files.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Latest
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: "package.json"
           cache: 'yarn'
@@ -25,7 +25,7 @@ jobs:
         run: yarn --immutable
       - name: Cache Build
         id: build-packages-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: |
             **/dist

--- a/.github/workflows/setup-files.yml
+++ b/.github/workflows/setup-files.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Latest
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -22,7 +22,7 @@ jobs:
         run: yarn --immutable
       - name: Cache Build
         id: build-packages-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             **/dist

--- a/.github/workflows/setup-files.yml
+++ b/.github/workflows/setup-files.yml
@@ -3,6 +3,9 @@ name: Setup Files
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: setup-files-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -15,15 +15,15 @@ jobs:
      runs-on: ubuntu-latest
      steps:
        - name: Checkout
-         uses: actions/checkout@v4
+         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
        - name: Setup Node
-         uses: actions/setup-node@v4
+         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
          with:
           node-version-file: "package.json"
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v4
+         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
          with:
            path: |
              **/dist

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'yarn'
        - name: Cache Build
          id: build-packages-cache
-         uses: actions/cache@v3
+         uses: actions/cache@v4
          with:
            path: |
              **/dist

--- a/.github/workflows/unit-test-packages.yml
+++ b/.github/workflows/unit-test-packages.yml
@@ -3,6 +3,9 @@ name: Unit Test Packages
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 concurrency:
   group: unit-test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "packageManager": "yarn@4.9.1",
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   },
   "scripts": {
     "generate:package": "moon generate package",


### PR DESCRIPTION
## Summary

Adjacent supply-chain hygiene from the [TanStack npm compromise audit](https://linear.app/knock/issue/KNO-13134). We are **not** vulnerable to the exact TanStack cache-poisoning chain (no `pull_request_target` + checkout + install combination, and `release.yml` only runs on `push: main`). This PR closes the residual gaps the review surfaced — mirroring the pattern from [knocklabs/javascript#994](https://github.com/knocklabs/javascript/pull/994).

- **Pin every third-party and first-party action to a commit SHA** (with version comment). Tag-pinning means an action publisher compromise would execute attacker code with whatever permissions the surrounding job has — including `release.yml` where `NPM_TOKEN` is live. SHA pinning is the [GitHub-recommended](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) standard.

  | Action | Pinned SHA | Version |
  |---|---|---|
  | `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
  | `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
  | `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4.3.0 |
  | `changesets/action` | `63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b` | v1.8.0 |
  | `peter-evans/find-comment` | `d2dae40ed151c634e4189471272b57e76ec19ba8` | v1.3.0 |
  | `peter-evans/create-or-update-comment` | `a35cf36e5301d70b76f316e867e7788a55a31dae` | v1.4.5 |
  | `amannn/action-semantic-pull-request` | `0723387faaf9b38adef4775cd42cfd5155ed6017` | v5.5.3 |

- **Default `permissions: contents: read`** on every workflow so the default `GITHUB_TOKEN` is read-only. Any step that needs more must opt in explicitly. `commitlint-pr.yml` keeps its existing `pull-requests: read`, and `dependabot-changeset.yml` keeps its existing explicit block.

- **Bump stale action majors**: `actions/checkout@v3` → `@v4` in `setup-files.yml`; `actions/cache@v3` → `@v4` everywhere (v3 is EOL).

- **Drop unused `pull_request_target` trigger from `commitlint-pr.yml`.** It only reads the PR title; the elevated trigger isn't needed and removed a latent footgun (one careless future commit adding `actions/checkout` here would have created the TanStack vector).

- **Bump Node engines `22.x` → `24.x`** in `package.json`. Node 24 ships npm 11.x, which is a prerequisite for the OIDC follow-up below.

## Follow-up

- [KNO-13135](https://linear.app/knock/issue/KNO-13135) — migrate to npm OIDC trusted publishing. Deliberately split out because it requires a per-package admin step on npmjs.com before the workflow change can ship.

## Test plan

- [ ] All PR checks pass on this PR (lint, format, unit tests, package-size comment, commitlint) after the Node 24 bump.
- [ ] Package-size bot comment still posts (uses the newly-pinned `peter-evans/*` actions).
- [ ] Spot-check `release.yml` permissions after merge: `contents: read` is sufficient because writes go through `KNOCK_ENG_BOT_GITHUB_TOKEN` (a PAT) and checkout uses `persist-credentials: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)