### PR TITLE
fix(menu): prevent checkmark flash in Menu/Combobox/Select on open

### DIFF
--- a/.changeset/kno-13490-menu-checkmark-flash.md
+++ b/.changeset/kno-13490-menu-checkmark-flash.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+Fix checkmark flash in Menu/Combobox/Select on open. Menu item checkmarks no longer briefly appear selected for every item before normalizing — the motion element now initializes at its target state (`initial={false}`) instead of flashing visible on mount. Also hoisted the `LazyMotion` provider from each `MenuItem` up into `Menu.Content` so it's instantiated once per menu rather than per item.

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -6,6 +6,7 @@ import {
   type TgphElement,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
+import { LazyMotion, domAnimation } from "motion/react";
 import React from "react";
 
 import { MenuItem } from "../MenuItem";
@@ -119,7 +120,7 @@ const Content = <T extends TgphElement = "div">({
             }}
             zIndex="popover"
           >
-            {children}
+            <LazyMotion features={domAnimation}>{children}</LazyMotion>
           </Stack>
         </RefToTgphRef>
       </RadixMenu.Content>

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -2,7 +2,6 @@ import { Button } from "@telegraph/button";
 import { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Check } from "lucide-react";
-import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
 
 export type MenuItemProps<T extends TgphElement = "button"> =
@@ -79,30 +78,31 @@ const MenuItemLeading = ({
 
   if (isSelectableButton) {
     return (
-      <LazyMotion features={domAnimation}>
-        <Button.Icon
-          as={motion.span}
-          variant="primary"
-          icon={Check}
-          aria-hidden={true}
-          animate={
-            selected
-              ? {
-                  opacity: 1,
-                  rotate: 0,
-                  scale: 1,
-                }
-              : {
-                  opacity: 0,
-                  rotate: -45,
-                  scale: 0.3,
-                }
-          }
-          transition={{ duration: 0.15, type: "spring", bounce: 0 }}
-          style={{ transformOrigin: "center" }}
-          display="block"
-        />
-      </LazyMotion>
+      <Button.Icon
+        as={motion.span}
+        variant="primary"
+        icon={Check}
+        aria-hidden={true}
+        // Mount at the animate target so unselected items don't flash checked
+        // on open. Only blocks the mount animation; toggling still animates.
+        initial={false}
+        animate={
+          selected
+            ? {
+                opacity: 1,
+                rotate: 0,
+                scale: 1,
+              }
+            : {
+                opacity: 0,
+                rotate: -45,
+                scale: 0.3,
+              }
+        }
+        transition={{ duration: 0.15, type: "spring", bounce: 0 }}
+        style={{ transformOrigin: "center" }}
+        display="block"
+      />
     );
   }
 


### PR DESCRIPTION
## What changed

- **`MenuItem.tsx`** — add `initial={false}` to the checkmark `motion` element so it mounts at its target state (hidden/visible) instead of flashing visible. Toggling still animates.
- **`Menu.tsx`** — hoist the `LazyMotion` provider out of each `MenuItem` into `Menu.Content`, so it's created once per menu instead of per item.

## Why

Opening a Combobox/Select/Menu briefly showed *every* item as selected before normalizing. The checkmark's hidden state lived only in motion's `animate` prop with no `initial`, so on mount it painted at browser defaults (`opacity: 1 / rotate: 0 / scale: 1`) — identical to the selected look — then animated unselected items down to hidden. Radix remounts menu content on each open, so it recurred every time.

Closes KNO-13490