### PR TITLE
feat(menu): add hover-to-open submenus (Sub/SubTrigger/SubContent)

### DIFF
--- a/.changeset/kno-13493-menu-submenus.md
+++ b/.changeset/kno-13493-menu-submenus.md
@@ -1,5 +1,11 @@
 ---
 "@telegraph/menu": minor
+"@telegraph/combobox": patch
+"@telegraph/select": patch
+"@telegraph/filter": patch
+"@telegraph/tabs": patch
 ---
 
-Add hover-to-open submenus to Menu via `Menu.Sub`, `Menu.SubTrigger`, and `Menu.SubContent`. These wrap Radix's submenu primitives, so a submenu now opens on hover (and `→` / `Enter`), coordinates open/close with its parent, supports keyboard navigation and "safe triangle" pointer tracking, and positions itself to the side automatically. `Menu.SubTrigger` defaults to a trailing chevron. This replaces the previous nested-`Menu.Root` workaround, which only opened on click. The shared content surface is now reused by both `Menu.Content` and `Menu.SubContent`.
+Add hover-to-open submenus to Menu via `Menu.Sub`, `Menu.SubTrigger`, and `Menu.SubContent`. These wrap Radix's submenu primitives, so a submenu now opens on hover (and `→` / `Enter`), coordinates open/close with its parent, supports keyboard navigation and "safe triangle" pointer tracking, and positions itself to the side automatically. `Menu.SubTrigger` defaults to a trailing chevron. This replaces the previous nested-`Menu.Root` workaround, which only opened on click.
+
+Combobox, Select, Filter, and Tabs receive a patch release so they ship against the new Menu.

--- a/.changeset/kno-13493-menu-submenus.md
+++ b/.changeset/kno-13493-menu-submenus.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": minor
+---
+
+Add hover-to-open submenus to Menu via `Menu.Sub`, `Menu.SubTrigger`, and `Menu.SubContent`. These wrap Radix's submenu primitives, so a submenu now opens on hover (and `→` / `Enter`), coordinates open/close with its parent, supports keyboard navigation and "safe triangle" pointer tracking, and positions itself to the side automatically. `Menu.SubTrigger` defaults to a trailing chevron. This replaces the previous nested-`Menu.Root` workaround, which only opened on click. The shared content surface is now reused by both `Menu.Content` and `Menu.SubContent`.

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -128,10 +128,8 @@ that opens on hover/focus. Render it inside a `Menu.Content`.
 | Prop           | Type                      | Default     | Description                      |
 | -------------- | ------------------------- | ----------- | -------------------------------- |
 | `open`         | `boolean`                 | `undefined` | Controlled open state            |
+| `defaultOpen`  | `boolean`                 | `false`     | Initial open state (uncontrolled)|
 | `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes |
-
-> Note: unlike `Menu.Root`, `Menu.Sub` does not support `defaultOpen` (Radix
-> manages the uncontrolled open state internally).
 
 ### `<Menu.SubTrigger>`
 

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -120,6 +120,50 @@ Individual menu item that can be clicked or selected.
 
 Inherits all Button props for additional styling.
 
+### `<Menu.Sub>`
+
+Groups a `Menu.SubTrigger` with its `Menu.SubContent` to create a nested submenu
+that opens on hover/focus. Render it inside a `Menu.Content`.
+
+| Prop           | Type                      | Default     | Description                      |
+| -------------- | ------------------------- | ----------- | -------------------------------- |
+| `open`         | `boolean`                 | `undefined` | Controlled open state            |
+| `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes |
+
+> Note: unlike `Menu.Root`, `Menu.Sub` does not support `defaultOpen` (Radix
+> manages the uncontrolled open state internally).
+
+### `<Menu.SubTrigger>`
+
+The item inside a `Menu.Sub` that opens the submenu on hover (or `→` / `Enter`).
+Accepts the same props as `Menu.Button` and defaults to a trailing chevron icon.
+
+| Prop           | Type              | Default        | Description                                   |
+| -------------- | ----------------- | -------------- | --------------------------------------------- |
+| `children`     | `React.ReactNode` | required       | Trigger label                                 |
+| `trailingIcon` | `IconProps`       | `ChevronRight` | Trailing icon; pass your own to override      |
+| `leadingIcon`  | `IconProps`       | `undefined`    | Icon before text                              |
+| `disabled`     | `boolean`         | `false`        | Whether the submenu trigger is disabled       |
+
+Inherits all `Menu.Button` props.
+
+### `<Menu.SubContent>`
+
+The container for a submenu's items. Always opens to the side of its trigger
+(`right`, flipping to `left` on collision); `side` and `align` are managed
+automatically and are not accepted.
+
+| Prop          | Type           | Default | Description                           |
+| ------------- | -------------- | ------- | ------------------------------------- |
+| `sideOffset`  | `number`       | `0`     | Distance from the trigger             |
+| `alignOffset` | `number`       | `0`     | Offset along the trigger's edge       |
+| `gap`         | `SpacingToken` | `"1"`   | Gap between menu items                |
+| `py`          | `SpacingToken` | `"1"`   | Vertical padding                      |
+| `rounded`     | `RoundedToken` | `"4"`   | Border radius                         |
+| `shadow`      | `ShadowToken`  | `"2"`   | Drop shadow                           |
+
+All Stack props are also supported for additional styling.
+
 ### `<Menu.Divider>`
 
 Visual separator between menu sections.
@@ -325,9 +369,13 @@ import { Menu } from "@telegraph/menu";
 
 ### Nested Menus (Submenus)
 
+Use `Menu.Sub`, `Menu.SubTrigger`, and `Menu.SubContent` to nest a menu that
+opens on hover (and via `→` / `Enter` for keyboard users). The submenu opens to
+the side of its trigger automatically and stays open while the pointer moves
+toward it.
+
 ```tsx
 import { Menu } from "@telegraph/menu";
-import { ChevronRight } from "lucide-react";
 
 <Menu.Root>
   <Menu.Trigger>
@@ -338,26 +386,25 @@ import { ChevronRight } from "lucide-react";
     <Menu.Button>New File</Menu.Button>
     <Menu.Button>Open File</Menu.Button>
 
-    {/* Submenu trigger */}
-    <Menu.Root>
-      <Menu.Trigger>
-        <Menu.Button trailingIcon={{ icon: ChevronRight, alt: "" }}>
-          Recent Files
-        </Menu.Button>
-      </Menu.Trigger>
-
-      <Menu.Content side="right" sideOffset={-4}>
+    {/* Submenu — opens on hover, no need for a nested Menu.Root */}
+    <Menu.Sub>
+      <Menu.SubTrigger>Recent Files</Menu.SubTrigger>
+      <Menu.SubContent>
         <Menu.Button>Document1.pdf</Menu.Button>
         <Menu.Button>Spreadsheet.xlsx</Menu.Button>
         <Menu.Button>Presentation.pptx</Menu.Button>
-      </Menu.Content>
-    </Menu.Root>
+      </Menu.SubContent>
+    </Menu.Sub>
 
     <Menu.Divider />
     <Menu.Button color="red">Delete File</Menu.Button>
   </Menu.Content>
 </Menu.Root>;
 ```
+
+`Menu.SubTrigger` adds a trailing chevron by default; pass your own
+`trailingIcon` (or `trailingIcon={undefined}`) to override it. Submenus nest
+arbitrarily — a `Menu.SubContent` can contain another `Menu.Sub`.
 
 ### Menu with Keyboard Shortcuts
 

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -401,7 +401,7 @@ import { Menu } from "@telegraph/menu";
 ```
 
 `Menu.SubTrigger` adds a trailing chevron by default; pass your own
-`trailingIcon` (or `trailingIcon={undefined}`) to override it. Submenus nest
+`trailingIcon` or a `trailingComponent` to replace it. Submenus nest
 arbitrarily — a `Menu.SubContent` can contain another `Menu.Sub`.
 
 ### Menu with Keyboard Shortcuts

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -483,51 +483,6 @@ import { Copy, Cut, Paste, Redo, Undo } from "lucide-react";
 </Menu.Root>;
 ```
 
-### Context Menu
-
-```tsx
-import { Menu } from "@telegraph/menu";
-import { useState } from "react";
-
-const ContextMenu = ({ children }) => {
-  const [contextMenu, setContextMenu] = useState(null);
-
-  const handleContextMenu = (event) => {
-    event.preventDefault();
-    setContextMenu({
-      x: event.clientX,
-      y: event.clientY,
-    });
-  };
-
-  const handleClose = () => {
-    setContextMenu(null);
-  };
-
-  return (
-    <>
-      <div onContextMenu={handleContextMenu}>{children}</div>
-
-      {contextMenu && (
-        <Menu.Root open={!!contextMenu} onOpenChange={handleClose}>
-          <Menu.Content
-            style={{
-              position: "fixed",
-              left: contextMenu.x,
-              top: contextMenu.y,
-            }}
-          >
-            <Menu.Button onClick={handleClose}>Copy</Menu.Button>
-            <Menu.Button onClick={handleClose}>Paste</Menu.Button>
-            <Menu.Button onClick={handleClose}>Delete</Menu.Button>
-          </Menu.Content>
-        </Menu.Root>
-      )}
-    </>
-  );
-};
-```
-
 ### Menu with Loading States
 
 ```tsx
@@ -620,16 +575,21 @@ The menu component uses Telegraph design tokens for consistent styling:
 | `Escape`          | Close menu                                    |
 | `Arrow Down`      | Navigate to next item                         |
 | `Arrow Up`        | Navigate to previous item                     |
+| `Arrow Right`     | Open submenu (when focused on a `SubTrigger`) |
+| `Arrow Left`      | Close submenu and return to its trigger       |
 | `Home`            | Navigate to first item                        |
 | `End`             | Navigate to last item                         |
 | `Tab`             | Close menu and move to next focusable element |
 
+Typeahead is also supported: type the first characters of an item to focus it.
+
 ### ARIA Attributes
 
-- `role="menu"` on menu content
-- `role="menuitem"` on menu buttons
-- `aria-expanded` on trigger
-- `aria-haspopup="menu"` on trigger
+- `role="menu"` on menu (and submenu) content
+- `role="menuitem"` on menu buttons and submenu triggers
+- `aria-expanded` on the trigger and on each `Menu.SubTrigger`
+- `aria-haspopup="menu"` on the trigger and on each `Menu.SubTrigger`
+- `aria-controls` linking a `SubTrigger` to its `SubContent`
 - `aria-disabled` on disabled items
 - `aria-checked` on selectable items
 

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -50,6 +50,7 @@ export const Default: Story = {
           <TelegraphMenu.Trigger>
             <Button
               variant="outline"
+              aria-label="Workflow actions"
               leadingIcon={{ icon: Ellipsis, "aria-hidden": true }}
             />
           </TelegraphMenu.Trigger>
@@ -92,6 +93,7 @@ export const WithSubmenu: Story = {
           <TelegraphMenu.Trigger>
             <Button
               variant="outline"
+              aria-label="Workflow actions"
               leadingIcon={{ icon: Ellipsis, "aria-hidden": true }}
             />
           </TelegraphMenu.Trigger>

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -2,7 +2,15 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
 import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
-import { Archive, Cog, CornerUpLeft, Ellipsis, Pencil } from "lucide-react";
+import {
+  Archive,
+  Cog,
+  CornerUpLeft,
+  Ellipsis,
+  FileText,
+  Pencil,
+  Share2,
+} from "lucide-react";
 
 import { Menu as TelegraphMenu } from "./Menu";
 
@@ -68,6 +76,65 @@ export const Default: Story = {
               disabled={true}
             >
               Reset all uncomitted changes
+            </TelegraphMenu.Button>
+          </TelegraphMenu.Content>
+        </TelegraphMenu.Root>
+      </Stack>
+    );
+  },
+};
+
+export const WithSubmenu: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack m="20" align="center" justify="center">
+        <TelegraphMenu.Root {...args}>
+          <TelegraphMenu.Trigger>
+            <Button
+              variant="outline"
+              leadingIcon={{ icon: Ellipsis, "aria-hidden": true }}
+            />
+          </TelegraphMenu.Trigger>
+          <TelegraphMenu.Content {...args}>
+            <TelegraphMenu.Button
+              leadingIcon={{ icon: Pencil, "aria-hidden": true }}
+            >
+              Edit workflow steps
+            </TelegraphMenu.Button>
+
+            {/* Hover this item to open the submenu to the side */}
+            <TelegraphMenu.Sub>
+              <TelegraphMenu.SubTrigger
+                leadingIcon={{ icon: Share2, "aria-hidden": true }}
+              >
+                Share
+              </TelegraphMenu.SubTrigger>
+              <TelegraphMenu.SubContent>
+                <TelegraphMenu.Button>Copy link</TelegraphMenu.Button>
+                <TelegraphMenu.Button>Invite teammate</TelegraphMenu.Button>
+
+                {/* Submenus can nest arbitrarily */}
+                <TelegraphMenu.Sub>
+                  <TelegraphMenu.SubTrigger
+                    leadingIcon={{ icon: FileText, "aria-hidden": true }}
+                  >
+                    Export as
+                  </TelegraphMenu.SubTrigger>
+                  <TelegraphMenu.SubContent>
+                    <TelegraphMenu.Button>PDF</TelegraphMenu.Button>
+                    <TelegraphMenu.Button>CSV</TelegraphMenu.Button>
+                    <TelegraphMenu.Button>JSON</TelegraphMenu.Button>
+                  </TelegraphMenu.SubContent>
+                </TelegraphMenu.Sub>
+              </TelegraphMenu.SubContent>
+            </TelegraphMenu.Sub>
+
+            <TelegraphMenu.Divider />
+            <TelegraphMenu.Button
+              color="red"
+              leadingIcon={{ icon: Archive, "aria-hidden": true }}
+            >
+              Archive workflow
             </TelegraphMenu.Button>
           </TelegraphMenu.Content>
         </TelegraphMenu.Root>

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -43,9 +43,14 @@ describe("Menu", () => {
       void validProps;
     });
 
-    it("rejects defaultOpen (not supported by Radix Sub)", () => {
-      // @ts-expect-error Sub is controlled-only; defaultOpen is not supported
-      const invalidProps: MenuSubProps = { defaultOpen: true };
+    it("accepts defaultOpen for uncontrolled use", () => {
+      const validProps: MenuSubProps = { defaultOpen: true };
+      void validProps;
+    });
+
+    it("rejects mistyped known props", () => {
+      // @ts-expect-error open must be a boolean, not a string
+      const invalidProps: MenuSubProps = { open: "yes" };
       void invalidProps;
     });
   });

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1,6 +1,12 @@
+import { ChevronRight } from "lucide-react";
 import { describe, it } from "vitest";
 
-import type { MenuContentProps } from "./index";
+import type {
+  MenuContentProps,
+  MenuSubContentProps,
+  MenuSubProps,
+  MenuSubTriggerProps,
+} from "./index";
 
 describe("Menu", () => {
   describe("type inheritance", () => {
@@ -24,6 +30,58 @@ describe("Menu", () => {
     it("rejects unknown props on type level", () => {
       // @ts-expect-error unknown prop rejected on MenuContentProps
       const invalidProp: MenuContentProps = { invalidProp: "invalid" };
+      void invalidProp;
+    });
+  });
+
+  describe("Sub type inheritance", () => {
+    it("accepts controlled open props", () => {
+      const validProps: MenuSubProps = {
+        open: true,
+        onOpenChange: () => {},
+      };
+      void validProps;
+    });
+
+    it("rejects defaultOpen (not supported by Radix Sub)", () => {
+      // @ts-expect-error Sub is controlled-only; defaultOpen is not supported
+      const invalidProps: MenuSubProps = { defaultOpen: true };
+      void invalidProps;
+    });
+  });
+
+  describe("SubTrigger type inheritance", () => {
+    it("accepts menu-item props (icon, disabled, children)", () => {
+      const validProps: MenuSubTriggerProps = {
+        leadingIcon: { icon: ChevronRight, "aria-hidden": true },
+        trailingIcon: { icon: ChevronRight, "aria-hidden": true },
+        disabled: true,
+        children: "Recent files",
+      };
+      void validProps;
+    });
+
+    it("rejects mistyped known props", () => {
+      // @ts-expect-error disabled must be a boolean, not a string
+      const invalidProp: MenuSubTriggerProps = { disabled: "yes" };
+      void invalidProp;
+    });
+  });
+
+  describe("SubContent type inheritance", () => {
+    it("accepts positioning and stack/layout props", () => {
+      const validProps: MenuSubContentProps = {
+        sideOffset: 0,
+        alignOffset: -4,
+        gap: "2",
+        rounded: "4",
+      };
+      void validProps;
+    });
+
+    it("rejects mistyped known props", () => {
+      // @ts-expect-error sideOffset must be a number, not a string
+      const invalidProp: MenuSubContentProps = { sideOffset: "4" };
       void invalidProp;
     });
   });

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -10,7 +10,7 @@ import { ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import React from "react";
 
-import { MenuItem } from "../MenuItem";
+import { MenuItem, type MenuItemProps } from "../MenuItem";
 
 export type RootProps = React.ComponentProps<typeof RadixMenu.Root> & {
   defaultOpen?: boolean;
@@ -210,8 +210,7 @@ const Sub = ({
 };
 
 export type SubTriggerProps<T extends TgphElement = "button"> =
-  TgphComponentProps<typeof MenuItem<T>> &
-    React.ComponentProps<typeof RadixMenu.SubTrigger>;
+  MenuItemProps<T> & React.ComponentProps<typeof RadixMenu.SubTrigger>;
 
 const SubTrigger = <T extends TgphElement = "button">({
   mx = "1",

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -177,16 +177,36 @@ const Button = <T extends TgphElement = "button">({
   );
 };
 
-export type SubProps = React.ComponentProps<typeof RadixMenu.Sub>;
+export type SubProps = React.ComponentProps<typeof RadixMenu.Sub> & {
+  defaultOpen?: boolean;
+};
 
 /**
  * Groups a `SubTrigger` with its `SubContent` to form a nested submenu that
- * opens on hover/focus. Thin pass-through to Radix's `Sub`, which manages its
- * own open state (use `open`/`onOpenChange` to control it). Note: Radix's `Sub`
- * does not support `defaultOpen`.
+ * opens on hover/focus. Works uncontrolled by default; pass `open`/`onOpenChange`
+ * to control it, or `defaultOpen` to set the initial state.
+ *
+ * Note: the underlying `RadixMenu.Sub` is controlled-only (it has no internal
+ * uncontrolled state), so we manage open state here via `useControllableState`,
+ * mirroring `Menu.Root`. Without this the submenu would never open on hover.
  */
-const Sub = ({ children, ...props }: SubProps) => {
-  return <RadixMenu.Sub {...props}>{children}</RadixMenu.Sub>;
+const Sub = ({
+  open: openProp,
+  onOpenChange: onOpenChangeProp,
+  defaultOpen: defaultOpenProp,
+  children,
+  ...props
+}: SubProps) => {
+  const [open = false, setOpen] = useControllableState({
+    prop: openProp,
+    defaultProp: defaultOpenProp ?? false,
+    onChange: onOpenChangeProp,
+  });
+  return (
+    <RadixMenu.Sub open={open} onOpenChange={setOpen} {...props}>
+      {children}
+    </RadixMenu.Sub>
+  );
 };
 
 export type SubTriggerProps<T extends TgphElement = "button"> =

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -6,6 +6,7 @@ import {
   type TgphElement,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
+import { ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import React from "react";
 
@@ -106,6 +107,7 @@ const Content = <T extends TgphElement = "div">({
         ref={tgphRef as React.LegacyRef<HTMLDivElement>}
       >
         <RefToTgphRef>
+          {/* Keep this Stack surface in sync with `SubContent` below. */}
           <Stack
             bg="surface-1"
             // Add tgph class so that this always works in portals
@@ -175,6 +177,120 @@ const Button = <T extends TgphElement = "button">({
   );
 };
 
+export type SubProps = React.ComponentProps<typeof RadixMenu.Sub>;
+
+/**
+ * Groups a `SubTrigger` with its `SubContent` to form a nested submenu that
+ * opens on hover/focus. Thin pass-through to Radix's `Sub`, which manages its
+ * own open state (use `open`/`onOpenChange` to control it). Note: Radix's `Sub`
+ * does not support `defaultOpen`.
+ */
+const Sub = ({ children, ...props }: SubProps) => {
+  return <RadixMenu.Sub {...props}>{children}</RadixMenu.Sub>;
+};
+
+export type SubTriggerProps<T extends TgphElement = "button"> =
+  TgphComponentProps<typeof MenuItem<T>> &
+    React.ComponentProps<typeof RadixMenu.SubTrigger>;
+
+const SubTrigger = <T extends TgphElement = "button">({
+  mx = "1",
+  asChild = true,
+  icon,
+  leadingIcon,
+  trailingIcon,
+  leadingComponent,
+  trailingComponent,
+  tgphRef,
+  ...props
+}: SubTriggerProps<T>) => {
+  const combinedLeadingIcon = leadingIcon || icon;
+  // Default to a chevron so the item reads as "opens a submenu", but allow
+  // callers to override it (or pass `trailingIcon={undefined}` to remove it).
+  // Annotating with `typeof trailingIcon` keeps `aria-hidden` as the literal
+  // `true` the icon type requires instead of widening it to `boolean`.
+  const combinedTrailingIcon: typeof trailingIcon = trailingIcon ?? {
+    icon: ChevronRight,
+    "aria-hidden": true,
+  };
+  return (
+    <RadixMenu.SubTrigger
+      {...props}
+      asChild={asChild}
+      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+    >
+      <RefToTgphRef>
+        <MenuItem
+          leadingIcon={combinedLeadingIcon}
+          trailingIcon={combinedTrailingIcon}
+          leadingComponent={leadingComponent}
+          trailingComponent={trailingComponent}
+          data-tgph-menu-button
+          mx={mx}
+          style={{
+            flexShrink: 0,
+          }}
+          {...props}
+        />
+      </RefToTgphRef>
+    </RadixMenu.SubTrigger>
+  );
+};
+
+export type SubContentProps<T extends TgphElement = "div"> =
+  React.ComponentProps<typeof RadixMenu.SubContent> &
+    Omit<TgphComponentProps<typeof Stack<T>>, "align">;
+
+const SubContent = <T extends TgphElement = "div">({
+  direction = "column",
+  gap = "1",
+  rounded = "4",
+  py = "1",
+  shadow = "2",
+  // Submenus open to the side with no gap by default; `side`/`align` are
+  // managed by Radix and intentionally not accepted here.
+  sideOffset = 0,
+  children,
+  onInteractOutside,
+  onKeyDown,
+  tgphRef,
+  ...props
+}: SubContentProps<T>) => {
+  return (
+    <RadixMenu.Portal>
+      <RadixMenu.SubContent
+        onInteractOutside={onInteractOutside}
+        onKeyDown={onKeyDown}
+        asChild
+        sideOffset={sideOffset}
+        {...props}
+        // Need to cast this type since RadixMenu.SubContent doesn't accept tgphRef
+        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+      >
+        <RefToTgphRef>
+          {/* Keep this Stack surface in sync with `Content` above. */}
+          <Stack
+            bg="surface-1"
+            // Add tgph class so that this always works in portals
+            className="tgph"
+            direction={direction}
+            gap={gap}
+            rounded={rounded}
+            py={py}
+            shadow={shadow}
+            style={{
+              overflowY: "auto",
+            }}
+            zIndex="popover"
+          >
+            <LazyMotion features={domAnimation}>{children}</LazyMotion>
+          </Stack>
+        </RefToTgphRef>
+      </RadixMenu.SubContent>
+    </RadixMenu.Portal>
+  );
+};
+
 export type DividerProps = TgphComponentProps<typeof Box>;
 
 const Divider = ({
@@ -190,6 +306,9 @@ const Menu = {} as {
   Trigger: typeof Trigger;
   Content: typeof Content;
   Button: typeof Button;
+  Sub: typeof Sub;
+  SubTrigger: typeof SubTrigger;
+  SubContent: typeof SubContent;
   Divider: typeof Divider;
 };
 
@@ -198,6 +317,9 @@ Object.assign(Menu, {
   Trigger,
   Content,
   Button,
+  Sub,
+  SubTrigger,
+  SubContent,
   Divider,
 });
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -222,17 +222,21 @@ const SubTrigger = <T extends TgphElement = "button">({
   leadingComponent,
   trailingComponent,
   tgphRef,
+  onClick,
   ...props
 }: SubTriggerProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
-  // Default to a chevron so the item reads as "opens a submenu", but allow
-  // callers to override it (or pass `trailingIcon={undefined}` to remove it).
-  // Annotating with `typeof trailingIcon` keeps `aria-hidden` as the literal
-  // `true` the icon type requires instead of widening it to `boolean`.
-  const combinedTrailingIcon: typeof trailingIcon = trailingIcon ?? {
-    icon: ChevronRight,
-    "aria-hidden": true,
-  };
+  // Default to a chevron so the item reads as "opens a submenu". Only apply it
+  // when the caller supplies neither a trailing icon nor a trailing component —
+  // `MenuItemTrailing` renders `trailingIcon` in preference to
+  // `trailingComponent`, so an unconditional default would hide a caller's
+  // `trailingComponent`. Annotating with `typeof trailingIcon` keeps
+  // `aria-hidden` as the literal `true` the icon type requires instead of
+  // widening it to `boolean`.
+  const combinedTrailingIcon: typeof trailingIcon =
+    trailingIcon === undefined && trailingComponent === undefined
+      ? { icon: ChevronRight, "aria-hidden": true }
+      : trailingIcon;
   return (
     <RadixMenu.SubTrigger
       {...props}
@@ -241,6 +245,12 @@ const SubTrigger = <T extends TgphElement = "button">({
     >
       <RefToTgphRef>
         <MenuItem
+          // Pass onClick only to MenuItem (not also via {...props} to
+          // RadixMenu.SubTrigger) so RefToTgphRef doesn't compose a
+          // caller-supplied handler twice. Mirrors Menu.Button.
+          onClick={
+            onClick as React.MouseEventHandler<HTMLButtonElement> | undefined
+          }
           leadingIcon={combinedLeadingIcon}
           trailingIcon={combinedTrailingIcon}
           leadingComponent={leadingComponent}

--- a/packages/menu/src/Menu/index.ts
+++ b/packages/menu/src/Menu/index.ts
@@ -3,5 +3,8 @@ export type {
   RootProps as MenuRootProps,
   ContentProps as MenuContentProps,
   ButtonProps as MenuButtonProps,
+  SubProps as MenuSubProps,
+  SubTriggerProps as MenuSubTriggerProps,
+  SubContentProps as MenuSubContentProps,
   DividerProps as MenuDividerProps,
 } from "./Menu";

--- a/packages/menu/src/default.css
+++ b/packages/menu/src/default.css
@@ -2,3 +2,11 @@
 [data-tgph-menu-button]:focus-visible {
   outline: none;
 }
+
+/* Keep a submenu trigger highlighted while its submenu is open, so it stays
+   clear which parent item the open submenu belongs to. Radix sets
+   data-state="open" on the active SubTrigger; we reuse the button's own hover
+   background so the highlight matches its color/variant automatically. */
+[data-tgph-menu-button][data-state="open"] {
+  background-color: var(--hover--background-color, var(--background-color));
+}

--- a/packages/menu/src/index.ts
+++ b/packages/menu/src/index.ts
@@ -3,6 +3,9 @@ export type {
   MenuRootProps,
   MenuContentProps,
   MenuButtonProps,
+  MenuSubProps,
+  MenuSubTriggerProps,
+  MenuSubContentProps,
   MenuDividerProps,
 } from "./Menu";
 export { MenuItem } from "./MenuItem";


### PR DESCRIPTION
## What changed?

Added `Menu.Sub`, `Menu.SubTrigger`, and `Menu.SubContent` (thin wrappers over Radix's submenu primitives) for real hover-to-open nested menus. `SubTrigger` defaults to a trailing chevron and `SubContent` positions to the side automatically. Downstream consumers (`combobox`, `select`, `filter`, `tabs`) get patch bumps so they ship against the new Menu.

## Why?

Menus only supported one level of nesting. The old approach nested a whole `Menu.Root`, which opened on click and ran a separate state machine, losing keyboard navigation, focus management, and Radix's "safe triangle" pointer tracking. The `Sub` primitives give proper hover-to-open submenus, matching Radix's own context/dropdown menus.

<img width="487" height="387" alt="Screenshot 2026-06-03 at 14-59-11" src="https://github.com/user-attachments/assets/6807b6bf-728d-4705-96fc-0c41458eac30" />