### PR TITLE
fix(vite-config): externalize Node built-in modules so style-engine's PostCSS plugin works

### DIFF
--- a/.changeset/kno-13579-vite-config-externalize-node-builtins.md
+++ b/.changeset/kno-13579-vite-config-externalize-node-builtins.md
@@ -1,0 +1,16 @@
+---
+"@telegraph/vite-config": patch
+"@telegraph/style-engine": patch
+---
+
+fix(vite-config): externalize Node built-in modules in the Rolldown bundle
+
+The shared Vite build config only externalized each package's declared
+dependencies, never Node built-ins. Under Vite 8 / Rolldown, runtime
+`require("node:path")` / `require("node:fs")` calls were inlined as empty-object
+stubs, so `@telegraph/style-engine`'s PostCSS plugin threw
+`TypeError: t.dirname is not a function` and broke every consumer build.
+
+Add `builtinModules` (bare and `node:`-prefixed) to the Rolldown `external`
+list. Republishes `@telegraph/style-engine` (0.3.5) so its `dist/cjs/postcss.js`
+emits real `require("node:path")` / `require("node:fs")` again.

--- a/packages/vite-config/src/vite-config.ts
+++ b/packages/vite-config/src/vite-config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react";
-import { createRequire } from "node:module";
+import { builtinModules, createRequire } from "node:module";
 import { resolve } from "path";
 import { type Rollup } from "vite";
 import dts from "vite-plugin-dts";
@@ -22,6 +22,14 @@ const allDependencies = [
   // Need to declare these as external as well since they're
   // not explicitly listed in the package.json
   "react/jsx-runtime",
+];
+
+// Externalize Node built-ins (both bare and `node:`-prefixed). Rolldown does not
+// auto-externalize these, so without this a runtime `require("node:path")` /
+// `require("node:fs")` gets inlined as an empty-object stub. See KNO-13579.
+const nodeBuiltins = [
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
 ];
 
 const buildTimeInfo = {
@@ -51,7 +59,7 @@ export default {
       },
     },
     rolldownOptions: {
-      external: [...allDependencies],
+      external: [...allDependencies, ...nodeBuiltins],
       output: {
         assetFileNames: (assetInfo: Rollup.PreRenderedAsset) => {
           if (assetInfo?.name?.endsWith(".css")) {


### PR DESCRIPTION
## Summary

`@telegraph/style-engine`'s PostCSS plugin loads Node built-ins via `require("node:path")` / `require("node:fs")`. The shared Vite build config (`packages/vite-config`) only externalized each package's declared dependencies — never Node built-ins.

Under Vite 7 / Rollup these were auto-externalized, so `style-engine@0.3.2` shipped correctly. [#759](https://github.com/knocklabs/telegraph/pull/759) upgraded to Vite 8 / Rolldown, which does **not** auto-externalize `node:` built-ins here — it inlined the requires as empty-object stubs. At runtime `path`/`fs` were `{}`, so `path.dirname` was `undefined` and the plugin threw:

```
TypeError: t.dirname is not a function
  at .../node_modules/@telegraph/style-engine/dist/cjs/postcss.js
```

`0.3.3` and `0.3.4` were the first releases rebuilt under the new config, so the break first appeared there. This is currently blocking [control#9558](https://github.com/knocklabs/control/pull/9558) (telegraph dependabot group bump).

## Fix

Externalize Node built-ins (bare and `node:`-prefixed) in `packages/vite-config/src/vite-config.ts` by adding `builtinModules` to the Rolldown `external` list. This is the correct general fix; in practice `style-engine` is the only package that ships built-in `require`s in its runtime output, so it is the one that needs republishing.

The changeset bumps both `@telegraph/vite-config` (the fix) and `@telegraph/style-engine` → `0.3.5` (forcing a republish under the fixed config, since `vite-config` is only a devDependency and would not otherwise cascade).

Once `0.3.5` publishes, control#9558 picks it up and Vercel goes green — no control-side change needed.

## Verification

After rebuilding under the fixed config, `packages/style-engine/dist/cjs/postcss.js` emits real `require("node:path")` / `require("node:fs")` with no empty-object stub:

```js
var e=require(`node:path`),t=require(`node:fs`),n=require(`postcss`);
```

Resolves [KNO-13579](https://linear.app/knock/issue/KNO-13579).
