### PR TITLE
fix(vite-config): emit declaration files to a consistent dist/types root

### DIFF
--- a/.changeset/fix-types-entrypoint-kno-13604.md
+++ b/.changeset/fix-types-entrypoint-kno-13604.md
@@ -1,0 +1,18 @@
+---
+"@telegraph/vite-config": patch
+"@telegraph/compose-refs": patch
+"@telegraph/helpers": patch
+"@telegraph/input": patch
+"@telegraph/modal": patch
+"@telegraph/nextjs": patch
+"@telegraph/tokens": patch
+---
+
+fix(vite-config): emit declaration files to a consistent `dist/types` root
+
+Pin the TypeScript declaration root to `src` in the shared dts plugin config so
+every package emits its types to `dist/types/index.d.ts`. Previously, packages
+whose tsconfig omitted `rootDir` emitted to `dist/types/src/index.d.ts`, which
+did not match the `types` entrypoint declared in their `package.json`, so
+consumers received no type definitions. Also corrects the stale top-level
+`types` field in `@telegraph/tokens`.

--- a/.changeset/fix-types-entrypoint-kno-13604.md
+++ b/.changeset/fix-types-entrypoint-kno-13604.md
@@ -6,6 +6,8 @@
 "@telegraph/modal": patch
 "@telegraph/nextjs": patch
 "@telegraph/tokens": patch
+"@telegraph/tabs": patch
+"@telegraph/layout": patch
 ---
 
 fix(vite-config): emit declaration files to a consistent `dist/types` root
@@ -14,5 +16,13 @@ Pin the TypeScript declaration root to `src` in the shared dts plugin config so
 every package emits its types to `dist/types/index.d.ts`. Previously, packages
 whose tsconfig omitted `rootDir` emitted to `dist/types/src/index.d.ts`, which
 did not match the `types` entrypoint declared in their `package.json`, so
-consumers received no type definitions. Also corrects the stale top-level
-`types` field in `@telegraph/tokens`.
+consumers received no type definitions (`@telegraph/compose-refs`, `helpers`,
+`input`, `modal`, `nextjs`, `tokens`).
+
+Pinning the declaration root also repairs degraded type emission that depended
+on the inferred root: `@telegraph/tabs` previously emitted a dangling
+`TgphElement` reference (`error TS2304: Cannot find name 'TgphElement'` for
+consumers), and `@telegraph/modal`'s `Content` prop type was widened to `any`.
+Both now emit correct, fully-resolved types.
+
+Also corrects the stale top-level `types` field in `@telegraph/tokens`.

--- a/packages/compose-refs/tsconfig.json
+++ b/packages/compose-refs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@knocklabs/typescript-config/react-library.json",
-  "display": "@telegraph/button",
+  "display": "@telegraph/compose-refs",
   "compilerOptions": {
     "outDir": "dist",
   },

--- a/packages/input/tsconfig.json
+++ b/packages/input/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@knocklabs/typescript-config/react-library.json",
-  "display": "@telegraph/button",
+  "display": "@telegraph/input",
   "compilerOptions": {
     "outDir": "dist",
   },

--- a/packages/tag/tsconfig.json
+++ b/packages/tag/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@knocklabs/typescript-config/react-library.json",
-  "display": "@telegraph/icon",
+  "display": "@telegraph/tag",
   "compilerOptions": {
     "outDir": "dist",
     "paths": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -4,7 +4,7 @@
   "author": "@knocklabs",
   "license": "MIT",
   "repository": "https://github.com/knocklabs/telegraph/tree/main/packages/tokens",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",

--- a/packages/tokens/tsconfig.json
+++ b/packages/tokens/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@knocklabs/typescript-config/base.json",
-  "display": "@telegraph/postcss-config",
+  "display": "@telegraph/tokens",
   "compilerOptions": {
     "outDir": "dist",
     "allowJs": true,

--- a/packages/vite-config/src/vite-config.ts
+++ b/packages/vite-config/src/vite-config.ts
@@ -86,6 +86,12 @@ export default {
         "src/**/*.test.tsx",
         "src/**/*.test.ts",
       ],
+      // Pin the declaration root to src so every package emits to
+      // dist/types/index.d.ts. The emitted layout follows the TypeScript
+      // compiler's rootDir; packages whose tsconfig omits `rootDir` otherwise
+      // emit to dist/types/src/..., breaking the `types` entrypoint declared in
+      // package.json. Forcing it here keeps all packages consistent.
+      compilerOptions: { rootDir: resolve(process.cwd(), "src") },
       outDirs: "dist/types",
     }),
     react(),


### PR DESCRIPTION
## What

Pins the TypeScript declaration root to `src` in the shared `@telegraph/vite-config` dts plugin so every package emits its types to `dist/types/index.d.ts`.

Fixes [KNO-13604](https://linear.app/knock/issue/KNO-13604/fix-mismatched-types-entrypoint-in-several-telegraph-packages).

## Why

The emitted `.d.ts` layout follows the TypeScript compiler's `rootDir`. Packages whose `tsconfig.json` set `"rootDir": "src"` emitted to `dist/types/index.d.ts`, but packages that omitted it emitted to `dist/types/`**`src`**`/index.d.ts`. The latter did **not** match the `types` entrypoint declared in their `package.json`, so consumers of those packages received **no type definitions**:

- `@telegraph/compose-refs`, `@telegraph/helpers`, `@telegraph/input`, `@telegraph/modal`, `@telegraph/nextjs`, `@telegraph/tokens`

Pinning the declaration root also repairs degraded type emission that depended on the inferred root:

- **`@telegraph/tabs`** previously emitted a dangling `TgphElement` reference — consumers got `error TS2304: Cannot find name 'TgphElement'`. Now emits `import('@telegraph/helpers').TgphElement`.
- **`@telegraph/modal`**'s `Content` prop type was widened to `any`. Now emits the fully-resolved props type.

This was pre-existing and unrelated to the recent `vite-plugin-dts` v4 → v5 bump ([#824](https://github.com/knocklabs/telegraph/pull/824)) — it reproduces on `main`.

## How

- Set `compilerOptions: { rootDir: <pkg>/src }` on the shared `dts()` plugin config in `packages/vite-config/src/vite-config.ts` so all packages emit consistently, regardless of their individual tsconfig. (`entryRoot` alone does not override the compiler-derived layout.)
- Fix the stale top-level `types` field in `@telegraph/tokens` (`dist/index.d.ts` → `dist/types/index.d.ts`) to match its `exports` map.

## Verification (audited against `main`, end to end)

- Clean `yarn build:packages` → **31/31 packages build**.
- **JS output is byte-identical to `main`** across all 31 packages — this change only affects declaration emit, no runtime change.
- Every package's `types` / `typings` / `exports[*].types` field resolves to a real emitted file: **54 root + 28 subpath entrypoints, 0 broken** (was 5 broken).
- Relocated `.d.ts` content is byte-identical to `main`'s (valid) output — pure relocation, except the intentional `tabs`/`modal` repairs.
- **Before/after consumer `tsc` (skipLibCheck: false), importing all 27 type-bearing packages:** `main` → exit 2 (`TS2304` in `tabs`); this branch → **exit 0, zero errors**.
- Changeset covers exactly the 8 packages whose published output changes, plus `vite-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)