### PR TITLE
chore(KNO-13661): Fix toggle styling

### DIFF
--- a/.changeset/full-poets-deny.md
+++ b/.changeset/full-poets-deny.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/toggle": minor
+---
+
+Adjust spacing and size of Toggle to vertically center align elements

--- a/packages/toggle/src/Toggle/Toggle.constants.ts
+++ b/packages/toggle/src/Toggle/Toggle.constants.ts
@@ -1,14 +1,14 @@
 // Size mappings for the toggle component
 export const TOGGLE_SIZE_MAP = {
   "1": {
-    w: "7",
-    h: "4",
-    iconSize: "1",
+    w: "9",
+    h: "5",
+    iconSize: "3",
   },
   "2": {
-    w: "8",
-    h: "5",
-    iconSize: "2",
+    w: "10",
+    h: "6",
+    iconSize: "4",
   },
 } as const;
 

--- a/packages/toggle/src/Toggle/Toggle.styles.css
+++ b/packages/toggle/src/Toggle/Toggle.styles.css
@@ -1,7 +1,7 @@
 [data-tgph-toggle-switch] {
   position: relative;
   cursor: pointer;
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition: background-color 180ms cubic-bezier(0.16, 1, 0.3, 1);
   flex-shrink: 0;
 }
 

--- a/packages/toggle/src/Toggle/Toggle.styles.css
+++ b/packages/toggle/src/Toggle/Toggle.styles.css
@@ -1,7 +1,7 @@
 [data-tgph-toggle-switch] {
   position: relative;
   cursor: pointer;
-  transition: background-color 0.2s ease-in-out;
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
   flex-shrink: 0;
 }
 
@@ -13,13 +13,14 @@
 
 /* Icon inside the knob */
 [data-tgph-toggle-icon] {
-  transition: transform 0.2s ease-in-out;
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Move icon with knob when checked */
 [data-tgph-toggle-switch][data-tgph-toggle-checked="true"]
   [data-tgph-toggle-icon] {
   transform: translateX(calc(100% - var(--tgph-spacing-0_5)));
+  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Label styling */

--- a/packages/toggle/src/Toggle/Toggle.styles.css
+++ b/packages/toggle/src/Toggle/Toggle.styles.css
@@ -20,7 +20,6 @@
 [data-tgph-toggle-switch][data-tgph-toggle-checked="true"]
   [data-tgph-toggle-icon] {
   transform: translateX(calc(100% - var(--tgph-spacing-0_5)));
-  transition: transform 180ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Label styling */

--- a/packages/toggle/src/Toggle/Toggle.styles.css
+++ b/packages/toggle/src/Toggle/Toggle.styles.css
@@ -19,7 +19,7 @@
 /* Move icon with knob when checked */
 [data-tgph-toggle-switch][data-tgph-toggle-checked="true"]
   [data-tgph-toggle-icon] {
-  transform: translateX(calc(100% - var(--tgph-spacing-1)));
+  transform: translateX(calc(100% - var(--tgph-spacing-0_5)));
 }
 
 /* Label styling */

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -7,7 +7,7 @@ import type {
   TgphElement,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
-import { Box, Stack } from "@telegraph/layout";
+import { Stack } from "@telegraph/layout";
 import { Tag } from "@telegraph/tag";
 import { Text } from "@telegraph/typography";
 import { CheckCircle2, Circle } from "lucide-react";
@@ -130,7 +130,7 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
   const { iconSize, ...sizeConfig } = TOGGLE_SIZE_MAP[context.size];
 
   return (
-    <Box position="relative">
+    <Stack position="relative" align="center">
       {/* Hidden native checkbox for accessibility */}
       <VisuallyHidden.Root>
         <input
@@ -182,12 +182,12 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
           }
           bg="white"
           rounded="full"
-          mx="px"
+          ml="px"
           data-tgph-toggle-icon
           aria-hidden
         />
       </Button.Root>
-    </Box>
+    </Stack>
   );
 };
 

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -182,7 +182,7 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
           }
           bg="white"
           rounded="full"
-          mx="0_5"
+          mx="px"
           data-tgph-toggle-icon
           aria-hidden
         />


### PR DESCRIPTION
## Toggle vertical alignment & styling

- **Fixed vertical centering** with its labels/indicator: switch wrapper changed from `Box` (block) to `Stack` (flex, `align="center"`), removing the line-box descender gap that pushed the control above the tag's center.
- **Matched toggle height to its paired tag** at each size (size-1 → 20px, size-2 → 24px), scaling width and knob `iconSize` proportionally.
- **Retuned knob position** (`mx:"0_5"` → `ml:"px"`) and checked-state travel for the new dimensions.
- **Smoothed the on/off transition**: `0.2s ease-in-out` → `180ms cubic-bezier(0.16, 1, 0.3, 1)`.