### PR TITLE
refactor(base-ui): migrate Telegraph components off Radix

### DIFF
--- a/.changeset/base-popovers-move.md
+++ b/.changeset/base-popovers-move.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/popover": minor
+---
+
+Migrate Popover internals from Radix UI to Base UI while preserving Telegraph styling, `tgphRef`, dismissal callbacks, focus callbacks, `avoidCollisions`, and `hideWhenDetached` compatibility. Also add shared Base UI compatibility helpers for migrated floating components.

--- a/.changeset/base-tooltips-shift.md
+++ b/.changeset/base-tooltips-shift.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/tooltip": minor
+"@telegraph/truncate": patch
+"@telegraph/vite-config": patch
+---
+
+Migrate Tooltip internals from Radix UI to Base UI while preserving Telegraph trigger state attributes, dismissal callbacks, collision props, hidden-when-detached behavior, and `tgphRef` support. The portaled tooltip surface keeps a dark Telegraph appearance attribute without reintroducing the removed public `appearance` prop. Keep dependency subpath imports external in shared Vite library builds so Base UI-backed packages publish browser-safe ESM output.

--- a/.changeset/bright-tabs-shift.md
+++ b/.changeset/bright-tabs-shift.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/tabs": minor
+---
+
+Migrate Tabs from Radix primitives to Base UI while preserving Telegraph styling hooks and `tgphRef` support. `onValueChange` now honestly types the Base UI cleared-selection case as `string | null`, and list activation behavior is configured through `Tabs.List` props.

--- a/.changeset/bright-tokens-travel.md
+++ b/.changeset/bright-tokens-travel.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/style-engine": patch
+"@telegraph/tokens": patch
+---
+
+Publish JavaScript wrappers for token CSS variable map exports so ESM consumers can import them without JSON import attributes.

--- a/.changeset/curvy-comboboxes-grin.md
+++ b/.changeset/curvy-comboboxes-grin.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": minor
+---
+
+Migrate Combobox off direct Radix runtime dependencies while preserving Telegraph menu layering, focus restoration, CSS compatibility variables, legacy option objects, and controlled/uncontrolled value behavior. Adds Base UI-backed dismissal handling, including `onEscapeKeyDown`, and documents that stay-open multi-select keeps focus on the selected option.

--- a/.changeset/early-helpers-bridge.md
+++ b/.changeset/early-helpers-bridge.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/helpers": minor
+---
+
+Add the Base UI render bridge used by the migration while preserving Telegraph `tgphRef` behavior and React 18 compatibility. This also adds `@base-ui/react` as a runtime dependency for shared helper primitives.

--- a/.changeset/fresh-radios-shift.md
+++ b/.changeset/fresh-radios-shift.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/radio": minor
+---
+
+Migrate RadioCards from Radix Radio Group to Base UI Radio primitives while preserving Telegraph visual states, `tgphRef` support, orientation, looping, and RTL keyboard behavior. The documented option title and description types now reflect ReactNode support.

--- a/.changeset/gentle-toggles-hide.md
+++ b/.changeset/gentle-toggles-hide.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/toggle": patch
+---
+
+refactor(toggle): remove Radix utility dependencies

--- a/.changeset/green-segments-press.md
+++ b/.changeset/green-segments-press.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/segmented-control": minor
+---
+
+Migrate SegmentedControl to Base UI ToggleGroup primitives while preserving Telegraph value shapes, empty-string values, scroll controls, `tgphRef`, and disabled option styling. Group-level `disabled` now propagates to every rendered option button so visual disabled state matches blocked interaction.

--- a/.changeset/quiet-docs-validate.md
+++ b/.changeset/quiet-docs-validate.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/button": patch
+"@telegraph/layout": patch
+"@telegraph/style-engine": patch
+"@telegraph/textarea": patch
+---
+
+Preserve compatibility for consumer apps that pass inferred click handlers, textarea `as="textarea"`, Box `direction`, and raw size values.

--- a/.changeset/sharp-tooltips-sip.md
+++ b/.changeset/sharp-tooltips-sip.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/data-list": patch
+"@telegraph/tag": patch
+"@telegraph/tooltip": minor
+"@telegraph/truncate": patch
+---
+
+Verify published Tooltip consumers against the Base UI-backed implementation and preserve their trigger refs, optional tooltip labels, and Radix-compatible trigger state attributes. TooltipIfTruncated now documents and tests that an explicit `label` takes precedence over child text when both are provided.

--- a/.changeset/silver-slots-merge.md
+++ b/.changeset/silver-slots-merge.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/appearance": patch
+"@telegraph/helpers": minor
+"@telegraph/input": patch
+---
+
+Replace Radix Slot usage in Appearance and Input with Telegraph helpers, and add shared `TgphSlot`, `VisuallyHidden`, and `useControllableState` exports for migrated components. Explicit appearance overrides now remain pinned instead of being overwritten by document-level appearance observer updates.

--- a/.changeset/slow-modals-dream.md
+++ b/.changeset/slow-modals-dream.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/modal": minor
+---
+
+Migrate Modal to Base UI Dialog primitives while preserving Telegraph stacking, dismissal callbacks, autofocus callbacks, `tgphRef`, and portal styling. `trapped={false}` continues to disable focus trapping without opting out of Telegraph's modal overlay or document scroll lock behavior.

--- a/.changeset/soft-menus-rhyme.md
+++ b/.changeset/soft-menus-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/menu": minor
+---
+
+Migrate Menu internals to Base UI while preserving Telegraph dismissal callbacks, focus callbacks, `avoidCollisions`, `hideWhenDetached`, trigger refs, submenu state attributes, and portal styling. Combobox trigger aria labels now fall back to option values when labels are rendered as React nodes so assistive text remains string-safe.

--- a/.changeset/sour-selects-dance.md
+++ b/.changeset/sour-selects-dance.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/select": patch
+---
+
+Verify Select against the migrated Combobox implementation, including single-select, multi-select, prop pass-through, portalled accessibility scans, keyboard selection, Escape dismissal, and focus return.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "turbo lint --filter=\"./packages/**\" --filter=\"!@telegraph/prettier-config\"",
     "format": "turbo format",
     "format:check": "turbo format:check",
-    "dev:storybook": "storybook dev --port 3005",
+    "dev:storybook": "storybook dev --port 3005 --no-open --exact-port",
     "build:storybook": "storybook build",
     "release": "yarn release:publish && yarn changeset tag",
     "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@telegraph/*' npm publish --access public --tolerate-republish",

--- a/packages/appearance/README.md
+++ b/packages/appearance/README.md
@@ -82,11 +82,19 @@ import { Appearance } from "@telegraph/appearance";
 </Appearance>;
 ```
 
-| Prop         | Type                | Default                   | Description                                    |
-| ------------ | ------------------- | ------------------------- | ---------------------------------------------- |
-| `appearance` | `"light" \| "dark"` | `undefined`               | Specific appearance to apply (uses current global appearance when omitted) |
-| `inverted`   | `boolean`           | `false`                   | Whether to invert the current appearance       |
-| `asChild`    | `boolean`           | `false`                   | Render as child element instead of div wrapper |
+| Prop         | Type                | Default     | Description                                                                           |
+| ------------ | ------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `appearance` | `"light" \| "dark"` | `undefined` | Specific appearance to apply (uses current global appearance when omitted)            |
+| `inverted`   | `boolean`           | `false`     | Whether to invert the current appearance                                              |
+| `asChild`    | `boolean`           | `false`     | Merge appearance props into a single child element instead of rendering a div wrapper |
+
+```tsx
+import { Appearance } from "@telegraph/appearance";
+
+<Appearance appearance="dark" asChild>
+  <section>This section receives data-tgph-appearance directly</section>
+</Appearance>;
+```
 
 #### `<InvertedAppearance>`
 

--- a/packages/appearance/package.json
+++ b/packages/appearance/package.json
@@ -32,7 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4"
+    "@telegraph/helpers": "workspace:^"
   },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.5",

--- a/packages/appearance/src/useAppearance.test.tsx
+++ b/packages/appearance/src/useAppearance.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Appearance,
+  InvertedAppearance,
+  OverrideAppearance,
+} from "./useAppearance";
+
+describe("Appearance", () => {
+  it("applies appearance data attributes to the default wrapper", () => {
+    render(
+      <Appearance appearance="dark" data-testid="appearance">
+        Content
+      </Appearance>,
+    );
+
+    expect(screen.getByTestId("appearance")).toHaveAttribute(
+      "data-tgph-appearance",
+      "dark",
+    );
+  });
+
+  it("merges props into the child when asChild is true", async () => {
+    const childClick = vi.fn();
+    const slotClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Appearance
+        appearance="dark"
+        asChild
+        className="appearance"
+        data-testid="appearance-button"
+        onClick={slotClick}
+      >
+        <button className="child" onClick={childClick} type="button">
+          Toggle
+        </button>
+      </Appearance>,
+    );
+
+    const button = screen.getByTestId("appearance-button");
+    await user.click(button);
+
+    expect(button).toHaveClass("appearance");
+    expect(button).toHaveClass("child");
+    expect(button).toHaveAttribute("data-tgph-appearance", "dark");
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(slotClick).toHaveBeenCalledOnce();
+  });
+
+  it("applies explicit and inverted appearance data attributes", () => {
+    render(
+      <>
+        <OverrideAppearance appearance="light" data-testid="override" />
+        <InvertedAppearance appearance="light" data-testid="inverted" />
+      </>,
+    );
+
+    expect(screen.getByTestId("override")).toHaveAttribute(
+      "data-tgph-appearance",
+      "light",
+    );
+    expect(screen.getByTestId("inverted")).toHaveAttribute(
+      "data-tgph-appearance",
+      "dark",
+    );
+  });
+});

--- a/packages/appearance/src/useAppearance.tsx
+++ b/packages/appearance/src/useAppearance.tsx
@@ -1,5 +1,10 @@
-import { Slot } from "@radix-ui/react-slot";
-import React from "react";
+import { TgphSlot } from "@telegraph/helpers";
+import {
+  type ComponentPropsWithoutRef,
+  type PropsWithChildren,
+  useEffect,
+  useState,
+} from "react";
 
 type Appearance = "light" | "dark";
 
@@ -7,9 +12,9 @@ type UseAppearanceParams = {
   appearanceOverride?: Appearance;
 };
 
-const useAppearance = (params: UseAppearanceParams = {}) => {
-  const [appearance, setAppearance] = React.useState<Appearance>(
-    params?.appearanceOverride || "light",
+const useAppearance = ({ appearanceOverride }: UseAppearanceParams = {}) => {
+  const [appearance, setAppearance] = useState<Appearance>(
+    appearanceOverride || "light",
   );
 
   // Collection of helper props to apply to elements to set their appearance
@@ -22,7 +27,7 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
   const darkAppearanceProps = { "data-tgph-appearance": "dark" };
 
   const handleAppearanceChange = (newAppearance: Appearance) => {
-    if (document) {
+    if (typeof document !== "undefined") {
       setAppearance(newAppearance);
       document.documentElement.setAttribute(
         "data-tgph-appearance",
@@ -33,21 +38,28 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
 
   // Observer for the `html` element to detect changes in the data-tgph-appearance
   // and update the appearance state accordingly
-  React.useEffect(() => {
-    if (!document) return;
+  useEffect(() => {
+    if (appearanceOverride) {
+      setAppearance(appearanceOverride);
+      return;
+    }
+
+    if (typeof document === "undefined") return;
 
     const mutationsCallback = (mutations: MutationRecord[]) => {
-      for (const mutation of mutations) {
-        if (
+      const appearanceMutation = mutations.find((mutation) => {
+        return (
           mutation.type === "attributes" &&
           mutation.attributeName === "data-tgph-appearance"
-        ) {
-          setAppearance(
-            document.documentElement.getAttribute(
-              "data-tgph-appearance",
-            ) as Appearance,
-          );
-        }
+        );
+      });
+
+      if (appearanceMutation) {
+        setAppearance(
+          document.documentElement.getAttribute(
+            "data-tgph-appearance",
+          ) as Appearance,
+        );
       }
     };
 
@@ -66,7 +78,7 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
         observer.disconnect();
       }
     };
-  }, []);
+  }, [appearanceOverride]);
 
   const toggleAppearance = () => {
     const newAppearance = appearance === "light" ? "dark" : "light";
@@ -85,11 +97,13 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
   };
 };
 
-type AppearanceProps = React.PropsWithChildren<{
-  appearance?: Appearance;
-  inverted?: boolean;
-  asChild?: boolean;
-}>;
+type AppearanceProps = PropsWithChildren<
+  ComponentPropsWithoutRef<"div"> & {
+    appearance?: Appearance;
+    inverted?: boolean;
+    asChild?: boolean;
+  }
+>;
 
 // Applies the data attribute to the element to set the appearance
 // of its children
@@ -107,7 +121,7 @@ const Appearance = ({
     ? invertedAppearanceProps
     : appearanceProps;
 
-  const Component = asChild ? Slot : "div";
+  const Component = asChild ? TgphSlot : "div";
 
   return <Component {...derivedAppearanceProps} {...props} />;
 };
@@ -124,7 +138,7 @@ const OverrideAppearance = ({
   const derivedAppearanceProps =
     appearance === "light" ? lightAppearanceProps : darkAppearanceProps;
 
-  const Component = asChild ? Slot : "div";
+  const Component = asChild ? TgphSlot : "div";
   return <Component {...derivedAppearanceProps} {...props} />;
 };
 

--- a/packages/appearance/vitest.config.mts
+++ b/packages/appearance/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "appearance",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/button/src/Button/Button.test.tsx
+++ b/packages/button/src/Button/Button.test.tsx
@@ -289,14 +289,21 @@ describe("Button", () => {
         void event;
       };
       const noArgHandler = () => {};
+      const inferredTupleCallback = (): boolean | (() => void) => {
+        return noArgHandler;
+      };
 
       const withKeyboard = <Button onClick={keyboardHandler}>Click</Button>;
       const withNoArg = <Button onClick={noArgHandler}>Click</Button>;
+      const withInferredTupleCallback = (
+        <Button onClick={inferredTupleCallback()}>Click</Button>
+      );
       const withInline = (
         <Button onClick={() => console.log("clicked")}>Click</Button>
       );
       void withKeyboard;
       void withNoArg;
+      void withInferredTupleCallback;
       void withInline;
     });
 

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,5 +1,4 @@
 import {
-  type PolymorphicProps,
   type PolymorphicPropsWithTgphRef,
   RemappedOmit,
   type Required,
@@ -42,13 +41,19 @@ type InternalProps = {
   state: Required<RootBaseProps>["state"] | "disabled" | "active";
 };
 
+type ButtonClickHandler = {
+  bivarianceHack(event: React.SyntheticEvent | Event): void;
+}["bivarianceHack"];
+
+type ButtonOnClick = ButtonClickHandler | boolean;
+
 export type RootProps<T extends TgphElement = "button"> = Omit<
   TgphComponentProps<typeof Stack>,
   "tgphRef" | "as" | "onClick"
 > &
   Omit<PolymorphicPropsWithTgphRef<T, HTMLButtonElement>, "onClick"> &
   RootBaseProps & {
-    onClick?(event: React.SyntheticEvent | Event): void;
+    onClick?: ButtonClickHandler;
   };
 
 const ButtonContext = React.createContext<
@@ -85,6 +90,7 @@ const Root = <T extends TgphElement = "button">({
   active = false,
   type = "button",
   disabled,
+  onClick,
   className,
   children,
   style,
@@ -150,6 +156,7 @@ const Root = <T extends TgphElement = "button">({
         {...(derivedAs === "button" && { type })} // Only pass in type if we are a button
         {...otherProps}
         {...props}
+        {...(typeof onClick === "function" && { onClick })}
       >
         {state === "loading" && (
           <Spinner
@@ -270,24 +277,26 @@ type BaseDefaultProps =
       trailingIcon?: never;
     };
 export type DefaultProps<T extends TgphElement = "button"> = Omit<
-  PolymorphicProps<T>,
+  RootProps<T>,
   "onClick"
 > &
-  TgphComponentProps<typeof Root> &
   BaseDefaultProps & {
-    onClick?(event: React.SyntheticEvent | Event): void;
+    onClick?: ButtonOnClick;
   };
 
 const Default = <T extends TgphElement = "button">({
   leadingIcon,
   trailingIcon,
   icon,
+  onClick,
   children,
   ...props
 }: DefaultProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
+  const rootProps = props as RootProps<T>;
+
   return (
-    <Root {...props}>
+    <Root<T> {...rootProps} {...(typeof onClick === "function" && { onClick })}>
       {combinedLeadingIcon && (
         <Icon {...combinedLeadingIcon} internal_iconType="leading" />
       )}

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -59,6 +59,21 @@ export const SingleSelectExample = () => {
 
 ## API Reference
 
+## Implementation Notes
+
+Combobox keeps the existing Telegraph compound API while using the Base UI-backed
+Telegraph Menu primitives for popup positioning, portal rendering, dismissal,
+and focus restoration. The package no longer depends on Radix directly.
+
+The public value contracts remain unchanged: string values are the recommended
+mode, `legacyBehavior` still supports `{ value, label }` objects for backwards
+compatibility, and single- vs multi-select behavior is still inferred from the
+shape of `value` / `defaultValue`.
+
+When `closeOnSelect={false}`, the dropdown stays open after selection and focus
+remains on the selected option so keyboard users can continue through the list
+without returning to the trigger first.
+
 ### `<Combobox.Root>`
 
 The root component that manages the state and context for the combobox.
@@ -83,11 +98,11 @@ The root component that manages the state and context for the combobox.
 
 The button that triggers the combobox dropdown.
 
-| Prop          | Type                | Default     | Description            |
-| ------------- | ------------------- | ----------- | ---------------------- |
-| `size`        | `"0" \| "1" \| "2" \| "3"` | `"1"` | Size of the trigger    |
-| `placeholder` | `string`            | `undefined` | Placeholder text       |
-| `children`    | `ReactNode`         | `undefined` | Custom trigger content |
+| Prop          | Type                       | Default     | Description            |
+| ------------- | -------------------------- | ----------- | ---------------------- |
+| `size`        | `"0" \| "1" \| "2" \| "3"` | `"1"`       | Size of the trigger    |
+| `placeholder` | `string`                   | `undefined` | Placeholder text       |
+| `children`    | `ReactNode`                | `undefined` | Custom trigger content |
 
 ### Other Components
 
@@ -325,9 +340,9 @@ export const CustomTrigger = () => (
 
 Individual selectable option item.
 
-| Prop       | Type      | Default     | Description          |
-| ---------- | --------- | ----------- | -------------------- |
-| `value`    | `string`  | required    | Option value         |
+| Prop       | Type                  | Default     | Description          |
+| ---------- | --------------------- | ----------- | -------------------- |
+| `value`    | `string`              | required    | Option value         |
 | `label`    | `string \| ReactNode` | `undefined` | Display label        |
 | `selected` | `boolean \| null`     | `undefined` | Force selected state |
 
@@ -410,6 +425,7 @@ const [value, setValue] = useState<{ value: string; label?: string }>();
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/combobox)
+- [Base UI Menu](https://base-ui.com/react/components/menu/)
 - [ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 
 ## Contributing

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -32,11 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-dismissable-layer": "^1.1.11",
-    "@radix-ui/react-menu": "^2.1.16",
-    "@radix-ui/react-portal": "^1.1.10",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@telegraph/button": "workspace:^",
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -2,6 +2,10 @@ import React from "react";
 
 import type { DefinedOption, Option } from "./Combobox.types";
 
+export const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
+export const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
+export const SELECT_KEYS = ["Enter", " "];
+
 export const isMultiSelect = (
   value: Option | Array<Option> | undefined,
 ): value is Array<Option> => {
@@ -23,16 +27,18 @@ export const getOptions = (children: React.ReactNode): Array<DefinedOption> => {
     children: React.ReactNode,
     options: Array<React.ReactNode> = [],
   ) => {
+    // Options can be wrapped in grouping/layout components, so walk the child
+    // tree instead of assuming direct Combobox.Option children.
     const childrenArray = React.Children.toArray(children);
 
     childrenArray.forEach((child) => {
       if (React.isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
         if (childProps.value) {
-          // If it has a value prop, it's an option
+          // Combobox.Option is identified by its public value prop.
           options.push(child);
         } else if (childProps.children) {
-          // If it has children, recursively search them
+          // Non-option wrappers may still contain options further down.
           recursivelyFindOptionElements(
             childProps.children as React.ReactNode,
             options,
@@ -69,10 +75,29 @@ export const getValueFromOption = (
   if (!option) return undefined;
 
   if (legacyBehavior === true) {
+    // Legacy callers store selected values as { value, label } objects.
     return (option as DefinedOption)?.value;
   }
 
+  // Newer callers store the selected value directly as a string.
   return option as string;
+};
+
+export const getOptionAccessibleLabel = (option?: DefinedOption) => {
+  if (!option) {
+    return undefined;
+  }
+
+  if (typeof option.label === "string" && option.label !== "") {
+    return option.label;
+  }
+
+  if (typeof option.label === "number" || typeof option.label === "bigint") {
+    // aria-label needs text; React labels fall back to value below.
+    return String(option.label);
+  }
+
+  return option.value;
 };
 
 export const getCurrentOption = (
@@ -103,6 +128,8 @@ export const doesOptionMatchSearchQuery = ({
   value,
   searchQuery,
 }: DoesOptionMatchSearchQueryProps) => {
+  // Search both the option value and any rendered text because labels can be
+  // supplied through nested React children.
   const childStrings = findStringNodes(children);
 
   return (

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -20,15 +20,15 @@ export default meta;
 
 type Story = StoryObj<TgphComponentProps<typeof TelegraphCombobox>>;
 
-const labels = ["Email", "SMS", "Push", "In-App", "Webhook"];
+const LABELS = ["Email", "SMS", "Push", "In-App", "Webhook"];
 
-const values = ["email", "sms", "push", "inapp", "webhook"];
-const firstValue = values[0] as string;
+const VALUES = ["email", "sms", "push", "inapp", "webhook"];
+const FIRST_VALUE = VALUES[0] as string;
 
 export const SingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -42,9 +42,9 @@ export const SingleSelect: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -58,7 +58,7 @@ export const SingleSelect: Story = {
 export const SingleSelectWithSearch: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -72,9 +72,9 @@ export const SingleSelectWithSearch: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -89,7 +89,7 @@ export const SingleSelectWithSearch: Story = {
 export const SingleSelectWithLongLabel: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
     return (
       <Box w="80">
         <TelegraphCombobox.Root
@@ -104,9 +104,9 @@ export const SingleSelectWithLongLabel: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]} with more content to make the label longer
+                  {LABELS[index]} with more content to make the label longer
                   than the trigger width
                 </TelegraphCombobox.Option>
               ))}
@@ -122,7 +122,7 @@ export const SingleSelectWithLongLabel: Story = {
 export const MultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -141,9 +141,9 @@ export const MultiSelect: Story = {
           >
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -158,7 +158,7 @@ export const MultiSelect: Story = {
 export const MultiSelectWithWrapLayout: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -174,9 +174,9 @@ export const MultiSelectWithWrapLayout: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -206,15 +206,15 @@ export const SingleSelectWithCreate: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create<"div", false>
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
-                  values.push(createdValue);
+                  VALUES.push(createdValue);
                   setValue(createdValue);
                 }}
               />
@@ -229,7 +229,7 @@ export const SingleSelectWithCreate: Story = {
 export const MultiSelectWithCreate: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<Array<string>>([firstValue]);
+    const [value, setValue] = React.useState<Array<string>>([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -245,15 +245,15 @@ export const MultiSelectWithCreate: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
-                  values.push(createdValue);
+                  VALUES.push(createdValue);
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
               />
@@ -268,7 +268,7 @@ export const MultiSelectWithCreate: Story = {
 export const MultiSelectWithClear: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -285,13 +285,13 @@ export const MultiSelectWithClear: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
@@ -309,7 +309,7 @@ export const ComboboxInModal: Story = {
     // eslint-disable-next-line
     const [open, setOpen] = React.useState(false);
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
     return (
       <>
         <Button size="1" variant="outline" onClick={() => setOpen(true)}>
@@ -339,15 +339,15 @@ export const ComboboxInModal: Story = {
                 <TelegraphCombobox.Content>
                   <TelegraphCombobox.Search />
                   <TelegraphCombobox.Options>
-                    {values.map((v, index) => (
+                    {VALUES.map((v, index) => (
                       <TelegraphCombobox.Option value={v}>
-                        {labels[index]}
+                        {LABELS[index]}
                       </TelegraphCombobox.Option>
                     ))}
                     <TelegraphCombobox.Create
-                      values={values}
+                      values={VALUES}
                       onCreate={(createdValue) => {
-                        values.push(createdValue);
+                        VALUES.push(createdValue);
                         setValue((prevValue) => [createdValue, ...prevValue]);
                       }}
                     />
@@ -363,7 +363,7 @@ export const ComboboxInModal: Story = {
 };
 
 type Option = { value: string; label?: string };
-const legacyValues = [
+const LEGACY_VALUES = [
   { value: "email", label: "Email" },
   { value: "sms", label: "SMS" },
   { value: "push", label: "Push" },
@@ -371,12 +371,12 @@ const legacyValues = [
   { value: "webhook", label: "Webhook" },
 ] as Array<Option>;
 
-const firstLegacyValue = legacyValues[0] as Option;
+const FIRST_LEGACY_VALUE = LEGACY_VALUES[0] as Option;
 
 export const LegacyComboboxSingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstLegacyValue);
+    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -391,7 +391,7 @@ export const LegacyComboboxSingleSelect: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
             </TelegraphCombobox.Options>
@@ -406,7 +406,7 @@ export const LegacyComboboxSingleSelect: Story = {
 export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstLegacyValue);
+    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -425,7 +425,7 @@ export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
             </TelegraphCombobox.Options>
@@ -440,7 +440,7 @@ export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
 export const LegacyComboboxMultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstLegacyValue]);
+    const [value, setValue] = React.useState([FIRST_LEGACY_VALUE]);
 
     return (
       <Box w="80">
@@ -458,14 +458,14 @@ export const LegacyComboboxMultiSelect: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
               <TelegraphCombobox.Create
                 legacyBehavior={true}
-                values={legacyValues}
+                values={LEGACY_VALUES}
                 onCreate={(createdValue) => {
-                  legacyValues.push(createdValue);
+                  LEGACY_VALUES.push(createdValue);
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
               />
@@ -480,7 +480,7 @@ export const LegacyComboboxMultiSelect: Story = {
 export const SingleSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -500,9 +500,9 @@ export const SingleSelectWithCustomTrigger: Story = {
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -517,7 +517,7 @@ export const SingleSelectWithCustomTrigger: Story = {
 export const MultiSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -537,9 +537,9 @@ export const MultiSelectWithCustomTrigger: Story = {
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -552,7 +552,7 @@ export const MultiSelectWithCustomTrigger: Story = {
 };
 
 // Generate years from 1960 to 2060
-const years = Array.from({ length: 101 }, (_, i) => String(1960 + i));
+const YEARS = Array.from({ length: 101 }, (_, i) => String(1960 + i));
 
 export const YearPicker: Story = {
   render: ({ ...args }) => {
@@ -567,7 +567,7 @@ export const YearPicker: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options maxHeight="64">
-              {years.map((year) => (
+              {YEARS.map((year) => (
                 <TelegraphCombobox.Option key={year} value={year}>
                   {year}
                 </TelegraphCombobox.Option>
@@ -599,7 +599,7 @@ export const YearPickerWithScrollToValue: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options maxHeight="64">
-              {years.map((year) => (
+              {YEARS.map((year) => (
                 <TelegraphCombobox.Option key={year} value={year}>
                   {year}
                 </TelegraphCombobox.Option>

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -1,12 +1,16 @@
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+import { useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
-import { Combobox, getOptionAccessibleLabel } from "./Combobox";
-import { findStringNodes } from "./Combobox.helpers";
-import type { ComboboxContentProps, ComboboxOptionsProps } from "./index";
+import { Combobox } from "./Combobox";
+import { findStringNodes, getOptionAccessibleLabel } from "./Combobox.helpers";
+import type {
+  ComboboxContentProps,
+  ComboboxOptionProps,
+  ComboboxOptionsProps,
+} from "./index";
 
 type Option = { value: string; label?: string };
 
@@ -19,8 +23,8 @@ beforeAll(() => {
   };
 });
 
-const values = ["email", "sms", "push", "inapp", "webhook"];
-const labels = ["Email", "SMS", "Push", "In-App", "Webhook"];
+const VALUES = ["email", "sms", "push", "inapp", "webhook"];
+const LABELS = ["Email", "SMS", "Push", "In-App", "Webhook"];
 
 // Utility to query elements rendered in a portal
 const queryPortalElement = (selector: string) =>
@@ -29,15 +33,15 @@ const queryPortalElements = (selector: string) =>
   document.querySelectorAll(selector);
 
 const ComboboxSingleSelect = ({ ...props }) => {
-  const [value, setValue] = React.useState<string>(values[0]!);
+  const [value, setValue] = useState<string>(VALUES[0]!);
   return (
     <Combobox.Root value={value} onValueChange={setValue} {...props}>
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -48,19 +52,16 @@ const ComboboxSingleSelect = ({ ...props }) => {
 };
 
 const ComboboxMultiSelect = () => {
-  const [value, setValue] = React.useState<Array<string>>([
-    values[0]!,
-    values[1]!,
-  ]);
+  const [value, setValue] = useState<Array<string>>([VALUES[0]!, VALUES[1]!]);
   return (
     <Combobox.Root value={value} onValueChange={setValue}>
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Search />
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -71,7 +72,7 @@ const ComboboxMultiSelect = () => {
 };
 
 const CustomTriggerCombobox = () => {
-  const [value, setValue] = React.useState<Option>(valuesLegacy[0]!);
+  const [value, setValue] = useState<Option>(valuesLegacy[0]!);
   return (
     <Combobox.Root value={value} onValueChange={setValue} legacyBehavior={true}>
       <Combobox.Trigger>
@@ -90,6 +91,40 @@ const CustomTriggerCombobox = () => {
     </Combobox.Root>
   );
 };
+
+const ControlledOpenCombobox = ({
+  onOpenChange,
+}: {
+  onOpenChange?: (open: boolean) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
+  return (
+    <div>
+      <button data-testid="open-combobox" onClick={() => setOpen(true)}>
+        Open combobox
+      </button>
+      <Combobox.Root open={open} onOpenChange={handleOpenChange}>
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </div>
+  );
+};
+
 describe("Combobox", () => {
   describe("Single Select", () => {
     it("combobox is accessible", async () => {
@@ -334,6 +369,53 @@ describe("Combobox", () => {
       expect(options.length).toBe(1);
     });
 
+    it("keeps focus on the selected option when closeOnSelect is false", async () => {
+      const user = userEvent.setup();
+
+      const StayOpenMultiSelect = () => {
+        const [value, setValue] = useState<Array<string>>([VALUES[0]!]);
+
+        return (
+          <Combobox.Root
+            closeOnSelect={false}
+            value={value}
+            onValueChange={setValue}
+          >
+            <Combobox.Trigger />
+            <Combobox.Content>
+              <Combobox.Search />
+              <Combobox.Options>
+                {VALUES.map((option, index) => (
+                  <Combobox.Option key={option} value={option}>
+                    {LABELS[index]}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+
+      const { container } = render(<StayOpenMultiSelect />);
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      const getSmsOption = () =>
+        Array.from(queryPortalElements("[data-tgph-combobox-option]")).find(
+          (option) => option.textContent === "SMS",
+        ) as HTMLElement | undefined;
+
+      await user.click(getSmsOption()!);
+
+      await waitFor(() => expect(trigger?.textContent).toBe("EmailSMS"));
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(getSmsOption()).toHaveFocus();
+    });
+
     it("empty state should show when there are no results", async () => {
       const user = userEvent.setup();
       const { container } = render(<ComboboxMultiSelect />);
@@ -439,6 +521,128 @@ describe("Combobox", () => {
       expect(isOpen).toBe(wasOpen);
     });
   });
+
+  describe("open state", () => {
+    it("supports controlled open state", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      const { container, getByTestId } = render(
+        <ControlledOpenCombobox onOpenChange={onOpenChange} />,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+      await user.click(getByTestId("open-combobox"));
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("false"),
+      );
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it("keeps the combobox open when escape dismissal is prevented", async () => {
+      const user = userEvent.setup();
+      const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+        event.preventDefault();
+      });
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content onEscapeKeyDown={onEscapeKeyDown}>
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.keyboard("[Escape]");
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("keeps the combobox open when search escape dismissal is prevented", async () => {
+      const user = userEvent.setup();
+      const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+        event.preventDefault();
+      });
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content onEscapeKeyDown={onEscapeKeyDown}>
+            <Combobox.Search />
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.keyboard("[Escape]");
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("closes the combobox when Escape is pressed from search input", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content>
+            <Combobox.Search />
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      expect(queryPortalElement("[data-tgph-combobox-search]")).toHaveFocus();
+
+      await user.keyboard("[Escape]");
+
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("false"),
+      );
+    });
+  });
 });
 
 const valuesLegacy: Array<Option> = [
@@ -450,7 +654,7 @@ const valuesLegacy: Array<Option> = [
 ];
 
 const ComboboxSingleSelectLegacy = ({ ...props }) => {
-  const [value, setValue] = React.useState<Option>(valuesLegacy[0]!);
+  const [value, setValue] = useState<Option>(valuesLegacy[0]!);
   return (
     <Combobox.Root
       value={value}
@@ -471,7 +675,7 @@ const ComboboxSingleSelectLegacy = ({ ...props }) => {
   );
 };
 const ComboboxMultiSelectLegacy = () => {
-  const [value, setValue] = React.useState<Array<Option>>([
+  const [value, setValue] = useState<Array<Option>>([
     valuesLegacy[0]!,
     valuesLegacy[1]!,
   ]);
@@ -717,6 +921,26 @@ describe("findStringNodes", () => {
 });
 
 describe("getOptionAccessibleLabel", () => {
+  it("returns undefined when no option is provided", () => {
+    expect(getOptionAccessibleLabel()).toBeUndefined();
+  });
+
+  it("uses text-like LABELS as the accessible label", () => {
+    expect(getOptionAccessibleLabel({ value: "email", label: "Email" })).toBe(
+      "Email",
+    );
+    expect(getOptionAccessibleLabel({ value: "sms", label: 123 })).toBe("123");
+  });
+
+  it("falls back to the option value for non-text LABELS", () => {
+    expect(
+      getOptionAccessibleLabel({
+        value: "push",
+        label: <span>Push</span>,
+      }),
+    ).toBe("push");
+  });
+
   it("falls back to the option value when the label is an empty string", () => {
     expect(getOptionAccessibleLabel({ value: "email", label: "" })).toBe(
       "email",
@@ -800,9 +1024,9 @@ const ComboboxWithDefaultValue = ({
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -873,9 +1097,9 @@ describe("defaultValue", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -897,9 +1121,9 @@ describe("defaultValue", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -955,7 +1179,7 @@ describe("scroll to selected", () => {
     // - Double quotes: Option "A"
     // - Brackets: Option [B]
     // - Backslashes: Option \C
-    const specialValues = [
+    const SPECIAL_VALUES = [
       'Option "A"',
       "Option [B]",
       "Option \\C",
@@ -968,7 +1192,7 @@ describe("scroll to selected", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {specialValues.map((val) => (
+            {SPECIAL_VALUES.map((val) => (
               <Combobox.Option key={val} value={val}>
                 {val}
               </Combobox.Option>
@@ -1007,7 +1231,7 @@ const ComboboxWithDefaultScrollToValue = ({
   defaultScrollToValue: string;
 }) => {
   const years = Array.from({ length: 101 }, (_, i) => String(1960 + i));
-  const [value, setValue] = React.useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string | undefined>(undefined);
 
   return (
     <Combobox.Root
@@ -1114,7 +1338,7 @@ const ControlledComboboxWrapper = ({
   initialValue: string;
   onValueChange?: (value: string) => void;
 }) => {
-  const [value, setValue] = React.useState(initialValue);
+  const [value, setValue] = useState(initialValue);
 
   const handleValueChange = (newValue: string) => {
     setValue(newValue);
@@ -1143,9 +1367,9 @@ const ControlledComboboxWrapper = ({
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -1278,6 +1502,14 @@ describe("Combobox type inheritance", () => {
     const validProps: ComboboxOptionsProps = {
       gap: "2",
       padding: "1",
+    };
+    void validProps;
+  });
+
+  it("accepts React node labels on Option", () => {
+    const validProps: ComboboxOptionProps = {
+      value: "email",
+      label: <span>Email</span>,
     };
     void validProps;
   });

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
-import { Combobox } from "./Combobox";
+import { Combobox, getOptionAccessibleLabel } from "./Combobox";
 import { findStringNodes } from "./Combobox.helpers";
 import type { ComboboxContentProps, ComboboxOptionsProps } from "./index";
 
@@ -713,6 +713,14 @@ describe("findStringNodes", () => {
       </p>
     );
     expect(findStringNodes(node)).toStrictEqual(["Lorem", "ipsum", "dolor"]);
+  });
+});
+
+describe("getOptionAccessibleLabel", () => {
+  it("falls back to the option value when the label is an empty string", () => {
+    expect(getOptionAccessibleLabel({ value: "email", label: "" })).toBe(
+      "email",
+    );
   });
 });
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -14,7 +14,23 @@ import { Box, Stack } from "@telegraph/layout";
 import { Menu as TelegraphMenu } from "@telegraph/menu";
 import { Text } from "@telegraph/typography";
 import { Plus, Search as SearchIcon, X } from "lucide-react";
-import React from "react";
+import {
+  type CSSProperties,
+  type ChangeEvent,
+  type MouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type KeyboardEventHandler as ReactKeyboardEventHandler,
+  type ReactNode,
+  type RefObject,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { TRIGGER_MIN_HEIGHT } from "./Combobox.constants";
 import {
@@ -36,6 +52,22 @@ import type {
 const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
 const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
 const SELECT_KEYS = ["Enter", " "];
+
+export const getOptionAccessibleLabel = (option?: DefinedOption) => {
+  if (!option) {
+    return undefined;
+  }
+
+  if (typeof option.label === "string" && option.label !== "") {
+    return option.label;
+  }
+
+  if (typeof option.label === "number" || typeof option.label === "bigint") {
+    return String(option.label);
+  }
+
+  return option.value;
+};
 
 type LayoutValue<O> = O extends DefinedOption | string | undefined
   ? never
@@ -64,10 +96,10 @@ export type RootProps<
    * Useful for long lists where you want to start at a specific position.
    */
   defaultScrollToValue?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
-export const ComboboxContext = React.createContext<
+export const ComboboxContext = createContext<
   Omit<
     RootProps<(Option | Array<Option>) | (string | Array<string>), boolean>,
     "children"
@@ -79,9 +111,9 @@ export const ComboboxContext = React.createContext<
     onOpenToggle: () => void;
     searchQuery?: string;
     setSearchQuery?: (query: string) => void;
-    triggerRef?: React.RefObject<HTMLDivElement>;
-    searchRef?: React.RefObject<HTMLInputElement>;
-    contentRef?: React.RefObject<HTMLDivElement>;
+    triggerRef?: RefObject<HTMLButtonElement>;
+    searchRef?: RefObject<HTMLInputElement>;
+    contentRef?: RefObject<HTMLDivElement>;
     options: Array<DefinedOption>;
     legacyBehavior: boolean;
     defaultScrollToValue?: string;
@@ -122,17 +154,17 @@ const Root = <
   children,
   ...props
 }: RootProps<O, LB>) => {
-  const contentId = React.useId();
-  const triggerId = React.useId();
-  const triggerRef = React.useRef<HTMLDivElement>(null);
-  const searchRef = React.useRef<HTMLInputElement>(null);
-  const contentRef = React.useRef<HTMLDivElement>(null);
+  const contentId = useId();
+  const triggerId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
-  const options = React.useMemo(() => {
+  const options = useMemo(() => {
     return getOptions(children);
   }, [children]);
 
-  const [searchQuery, setSearchQuery] = React.useState<string>("");
+  const [searchQuery, setSearchQuery] = useState<string>("");
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpenProp ?? false,
@@ -145,13 +177,11 @@ const Root = <
     onChange: onValueChangeProp as (value: O) => void,
   });
 
-  const onOpenToggle = React.useCallback(() => {
+  const onOpenToggle = useCallback(() => {
     setOpen((prevOpen) => !prevOpen);
   }, [setOpen]);
 
-  React.useEffect(() => {
-    // If the combobox is closed clear
-    // the search query
+  useEffect(() => {
     if (!open) {
       setSearchQuery("");
     }
@@ -176,9 +206,9 @@ const Root = <
         disabled,
         searchQuery,
         setSearchQuery,
-        triggerRef: triggerRef as React.RefObject<HTMLDivElement>,
-        searchRef: searchRef as React.RefObject<HTMLInputElement>,
-        contentRef: contentRef as React.RefObject<HTMLDivElement>,
+        triggerRef: triggerRef as RefObject<HTMLButtonElement>,
+        searchRef: searchRef as RefObject<HTMLInputElement>,
+        contentRef: contentRef as RefObject<HTMLDivElement>,
         errored,
         layout,
         options,
@@ -217,9 +247,7 @@ type TriggerBaseProps = RemappedOmit<
 
 export type TriggerProps<V extends ChildrenValue> = TriggerBaseProps & {
   placeholder?: string;
-  children?:
-    | React.ReactNode
-    | ((props: { value: ChildrenFnValue<V> }) => React.ReactNode);
+  children?: ReactNode | ((props: { value: ChildrenFnValue<V> }) => ReactNode);
 };
 
 const Trigger = <V extends ChildrenValue>({
@@ -227,10 +255,10 @@ const Trigger = <V extends ChildrenValue>({
   children,
   ...props
 }: TriggerProps<V>) => {
-  const context = React.useContext(ComboboxContext);
+  const context = useContext(ComboboxContext);
   const hasTags = isMultiSelect(context.value) && context.value.length > 0;
 
-  const currentValue = React.useMemo<
+  const currentValue = useMemo<
     DefinedOption | Array<DefinedOption | undefined> | undefined
   >(() => {
     if (!context.value) return undefined;
@@ -249,15 +277,17 @@ const Trigger = <V extends ChildrenValue>({
     return undefined;
   }, [context.value, context.options, context.legacyBehavior]);
 
-  const getAriaLabelString = React.useCallback(() => {
+  const getAriaLabelString = useCallback(() => {
     if (!currentValue) return context.placeholder;
     if (isSingleSelect(currentValue)) {
-      return currentValue?.label || currentValue?.value || context.placeholder;
+      return getOptionAccessibleLabel(currentValue) || context.placeholder;
     }
     if (isMultiSelect(currentValue)) {
       return (
-        currentValue.map((v) => v?.label || v?.value).join(", ") ||
-        context.placeholder
+        currentValue
+          .map((option) => getOptionAccessibleLabel(option))
+          .filter(Boolean)
+          .join(", ") || context.placeholder
       );
     }
 
@@ -267,12 +297,12 @@ const Trigger = <V extends ChildrenValue>({
     <TelegraphMenu.Trigger
       {...props}
       asChild
-      onClick={(event: React.MouseEvent) => {
+      onClick={(event: MouseEvent) => {
         event.preventDefault();
         context.onOpenToggle();
         context.triggerRef?.current?.focus();
       }}
-      onKeyDown={(event: React.KeyboardEvent) => {
+      onKeyDown={(event: ReactKeyboardEvent) => {
         // If the event target isn't exactly the trigger we don't want anything to
         // happen within this event handler. For example, if the `X` icon on a trigger
         // tag is focused and the user presses `Enter`, this keydown event will trigger.
@@ -352,17 +382,17 @@ const Content = <T extends TgphElement = "div">({
   tgphRef,
   ...props
 }: ContentProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const hasInteractedOutside = React.useRef(false);
+  const context = useContext(ComboboxContext);
+  const hasInteractedOutside = useRef(false);
   const composedRef = useComposedRefs<unknown>(tgphRef, context.contentRef);
 
-  const internalContentRef = React.useRef(null);
+  const internalContentRef = useRef(null);
 
-  const [height, setHeight] = React.useState(0);
+  const [height, setHeight] = useState(0);
   const [initialAnimationComplete, setInitialAnimationComplete] =
-    React.useState(false);
+    useState(false);
 
-  const setHeightFromContent = React.useCallback(
+  const setHeightFromContent = useCallback(
     (element: Element) => {
       // Set the initial height of the content after the animation completes
       const rect = element?.getBoundingClientRect();
@@ -377,7 +407,7 @@ const Content = <T extends TgphElement = "div">({
     [initialAnimationComplete],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const element = entry.target;
@@ -394,7 +424,7 @@ const Content = <T extends TgphElement = "div">({
   }, [initialAnimationComplete, setHeightFromContent]);
 
   // Reset the animation complete state when the combobox is closed
-  React.useEffect(() => {
+  useEffect(() => {
     if (initialAnimationComplete === true && context.open === false) {
       setInitialAnimationComplete(false);
     }
@@ -403,7 +433,7 @@ const Content = <T extends TgphElement = "div">({
   // On open, set the height of the content after the animation completes
   // we add a timeout here to ensure that the DOM element has responded to
   // the state changes first
-  React.useEffect(() => {
+  useEffect(() => {
     let timeout: NodeJS.Timeout;
     if (context.open) {
       timeout = setTimeout(() => {
@@ -462,7 +492,7 @@ const Content = <T extends TgphElement = "div">({
         // Cancel out accessibility attirbutes related to aria menu
         role={undefined}
         aria-orientation={undefined}
-        onKeyDown={(event: React.KeyboardEvent) => {
+        onKeyDown={(event: ReactKeyboardEvent) => {
           // Don't allow the event to bubble up outside of the menu
           event.stopPropagation();
 
@@ -496,12 +526,12 @@ const Options = <T extends TgphElement = "div">({
   tgphRef,
   ...props
 }: OptionsProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const optionsRef = React.useRef<HTMLDivElement>(null);
+  const context = useContext(ComboboxContext);
+  const optionsRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs<unknown>(tgphRef, optionsRef);
 
   // Scroll to the selected option (or defaultScrollToValue) when the combobox opens
-  React.useEffect(() => {
+  useEffect(() => {
     if (context.open && optionsRef.current) {
       // Small delay to ensure the DOM has rendered
       requestAnimationFrame(() => {
@@ -556,7 +586,7 @@ const Options = <T extends TgphElement = "div">({
           "--max-height": !props.maxHeight
             ? "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))"
             : undefined,
-        } as React.CSSProperties
+        } as CSSProperties
       }
       // Accessibility attributes
       role="listbox"
@@ -580,10 +610,11 @@ const Option = <T extends TgphElement>({
   selected,
   onSelect,
   children,
+  closeOnClick,
   ...props
 }: OptionProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const [isFocused, setIsFocused] = React.useState(false);
+  const context = useContext(ComboboxContext);
+  const [isFocused, setIsFocused] = useState(false);
   const contextValue = context.value;
 
   const isVisible =
@@ -600,12 +631,12 @@ const Option = <T extends TgphElement>({
       )
     : getValueFromOption(contextValue, context.legacyBehavior) === value;
 
-  const handleSelection = (event: Event | React.KeyboardEvent) => {
+  const handleSelection = (event: Event | ReactKeyboardEvent) => {
     // Don't allow the event to bubble up outside of the menu
     event.stopPropagation();
 
     // Don't do anything if the key isn't a selection key
-    const keyboardEvent = event as React.KeyboardEvent;
+    const keyboardEvent = event as ReactKeyboardEvent;
     if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) return;
 
     // Don't bubble up the event
@@ -659,7 +690,8 @@ const Option = <T extends TgphElement>({
       <TelegraphMenu.Button
         type="button"
         onSelect={handleSelection as (event: Event) => void}
-        onKeyDown={handleSelection as React.KeyboardEventHandler}
+        onKeyDown={handleSelection as ReactKeyboardEventHandler}
+        closeOnClick={closeOnClick ?? context.closeOnSelect}
         // Force null if selected equals null so we
         // can override the icon of the button
         selected={selected === null ? null : (selected ?? isSelected)}
@@ -693,14 +725,14 @@ const Search = ({
   onValueChange: onValueChangeProp,
   ...props
 }: SearchProps) => {
-  const id = React.useId();
-  const context = React.useContext(ComboboxContext);
+  const id = useId();
+  const context = useContext(ComboboxContext);
   const composedRef = useComposedRefs(tgphRef, context.searchRef);
 
   const value = controlledValueProp ?? context.searchQuery;
   const onValueChange = onValueChangeProp ?? context.setSearchQuery;
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleSearchKeyDown = (event: KeyboardEvent) => {
       if (FIRST_KEYS.includes(event.key)) {
         context.contentRef?.current?.focus({ preventScroll: true });
@@ -735,7 +767,7 @@ const Search = ({
         variant="ghost"
         placeholder={placeholder}
         value={value}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
           onValueChange(event.target.value);
         }}
         LeadingComponent={<Icon icon={SearchIcon} alt="Search Icon" />}
@@ -772,10 +804,10 @@ const Empty = <T extends TgphElement>({
   children,
   ...props
 }: EmptyProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const [isVisible, setIsVisible] = React.useState(false);
+  const context = useContext(ComboboxContext);
+  const [isVisible, setIsVisible] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const options = context.contentRef?.current?.querySelectorAll(
       "[data-tgph-combobox-option]",
     );
@@ -830,9 +862,9 @@ const Create = <T extends TgphElement, LB extends boolean>({
   legacyBehavior = false as LB,
   ...props
 }: CreateProps<T, LB>) => {
-  const context = React.useContext(ComboboxContext);
+  const context = useContext(ComboboxContext);
 
-  const variableAlreadyExists = React.useCallback(
+  const variableAlreadyExists = useCallback(
     (searchQuery: string | undefined) => {
       if (!values || values?.length === 0) return false;
       return values.some(

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1,12 +1,11 @@
-import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button as TelegraphButton } from "@telegraph/button";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type RemappedOmit,
   type TgphComponentProps,
   type TgphElement,
+  VisuallyHidden,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
 import { Input as TelegraphInput } from "@telegraph/input";
@@ -21,6 +20,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type KeyboardEventHandler as ReactKeyboardEventHandler,
   type ReactNode,
+  type Ref,
   type RefObject,
   createContext,
   useCallback,
@@ -34,8 +34,12 @@ import {
 
 import { TRIGGER_MIN_HEIGHT } from "./Combobox.constants";
 import {
+  FIRST_KEYS,
+  LAST_KEYS,
+  SELECT_KEYS,
   doesOptionMatchSearchQuery,
   getCurrentOption,
+  getOptionAccessibleLabel,
   getOptions,
   getValueFromOption,
   isMultiSelect,
@@ -48,26 +52,6 @@ import type {
   Option,
   SingleSelect,
 } from "./Combobox.types";
-
-const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
-const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
-const SELECT_KEYS = ["Enter", " "];
-
-export const getOptionAccessibleLabel = (option?: DefinedOption) => {
-  if (!option) {
-    return undefined;
-  }
-
-  if (typeof option.label === "string" && option.label !== "") {
-    return option.label;
-  }
-
-  if (typeof option.label === "number" || typeof option.label === "bigint") {
-    return String(option.label);
-  }
-
-  return option.value;
-};
 
 type LayoutValue<O> = O extends DefinedOption | string | undefined
   ? never
@@ -91,10 +75,8 @@ export type RootProps<
   clearable?: boolean;
   disabled?: boolean;
   legacyBehavior?: LB;
-  /**
-   * The value to scroll to when the combobox opens, if no value is selected.
-   * Useful for long lists where you want to start at a specific position.
-   */
+  // The value to scroll to when the combobox opens if no value is selected.
+  // Useful for long lists where you want to start at a specific position.
   defaultScrollToValue?: string;
   children?: ReactNode;
 };
@@ -114,6 +96,7 @@ export const ComboboxContext = createContext<
     triggerRef?: RefObject<HTMLButtonElement>;
     searchRef?: RefObject<HTMLInputElement>;
     contentRef?: RefObject<HTMLDivElement>;
+    onEscapeKeyDown?: (event: KeyboardEvent) => void;
     options: Array<DefinedOption>;
     legacyBehavior: boolean;
     defaultScrollToValue?: string;
@@ -165,12 +148,16 @@ const Root = <
   }, [children]);
 
   const [searchQuery, setSearchQuery] = useState<string>("");
+  // Keep open state controllable like the old menu-backed implementation while
+  // still allowing uncontrolled usage through defaultOpen.
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpenProp ?? false,
     onChange: onOpenChangeProp,
   });
 
+  // The selected value can be a string, legacy option object, or array of
+  // either; this shared helper preserves that public contract.
   const [value, setValue] = useControllableState({
     prop: valueProp,
     defaultProp: defaultValueProp as O,
@@ -193,9 +180,8 @@ const Root = <
         contentId,
         triggerId,
         value,
-        // Need to cast this to avoid type errors
-        // because the type of onValueChange is not
-        // consistent with the value type
+        // Context consumers handle the runtime single/multi branches below, so
+        // expose one setter shape here and narrow it at the selection site.
         onValueChange: setValue as (value: Option | Array<Option>) => void,
         placeholder,
         open,
@@ -263,6 +249,8 @@ const Trigger = <V extends ChildrenValue>({
   >(() => {
     if (!context.value) return undefined;
     if (isSingleSelect(context.value)) {
+      // Convert the public selected value back to the option object so custom
+      // trigger render functions receive the same shape as before the rewrite.
       return getCurrentOption(
         context.value,
         context.options,
@@ -270,6 +258,8 @@ const Trigger = <V extends ChildrenValue>({
       );
     }
     if (isMultiSelect(context.value)) {
+      // Preserve array order from the selected value while resolving each entry
+      // against the current option list.
       return context.value.map((v) =>
         getCurrentOption(v, context.options, context.legacyBehavior),
       );
@@ -280,9 +270,13 @@ const Trigger = <V extends ChildrenValue>({
   const getAriaLabelString = useCallback(() => {
     if (!currentValue) return context.placeholder;
     if (isSingleSelect(currentValue)) {
+      // The visible option label may be a React node, so derive a text-only
+      // fallback before assigning it to aria-label.
       return getOptionAccessibleLabel(currentValue) || context.placeholder;
     }
     if (isMultiSelect(currentValue)) {
+      // Multi-select trigger text is rendered as tags; expose the same selected
+      // values as a comma-separated text label for assistive tech.
       return (
         currentValue
           .map((option) => getOptionAccessibleLabel(option))
@@ -311,6 +305,14 @@ const Trigger = <V extends ChildrenValue>({
         // Lets the user tab in and out of the combobox as usual
         if (event.key === "Tab") {
           event.stopPropagation();
+          return;
+        }
+
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          event.preventDefault();
+          context.setOpen(false);
+          context.triggerRef?.current?.focus();
           return;
         }
 
@@ -379,11 +381,15 @@ export type ContentProps<T extends TgphElement = "div"> = TgphComponentProps<
 const Content = <T extends TgphElement = "div">({
   style,
   children,
+  onEscapeKeyDown,
   tgphRef,
   ...props
 }: ContentProps<T>) => {
   const context = useContext(ComboboxContext);
+  const { open, setOpen, triggerRef } = context;
   const hasInteractedOutside = useRef(false);
+  const handledEscapeKeyDownRef = useRef(false);
+  const handledEscapeKeyDownTimeoutRef = useRef<number | undefined>(undefined);
   const composedRef = useComposedRefs<unknown>(tgphRef, context.contentRef);
 
   const internalContentRef = useRef(null);
@@ -391,6 +397,53 @@ const Content = <T extends TgphElement = "div">({
   const [height, setHeight] = useState(0);
   const [initialAnimationComplete, setInitialAnimationComplete] =
     useState(false);
+
+  const markEscapeKeyDownHandled = useCallback(() => {
+    handledEscapeKeyDownRef.current = true;
+    window.clearTimeout(handledEscapeKeyDownTimeoutRef.current);
+    handledEscapeKeyDownTimeoutRef.current = window.setTimeout(() => {
+      handledEscapeKeyDownRef.current = false;
+    }, 0);
+  }, []);
+
+  const handleEscapeKeyDownEvent = useCallback(
+    (event: KeyboardEvent) => {
+      markEscapeKeyDownHandled();
+      event.stopPropagation();
+      onEscapeKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return true;
+      }
+
+      if (open) {
+        event.preventDefault();
+        setOpen(false);
+        triggerRef?.current?.focus();
+      }
+
+      return true;
+    },
+    [markEscapeKeyDownHandled, onEscapeKeyDown, open, setOpen, triggerRef],
+  );
+
+  const handleEscapeKeyDown = (event: ReactKeyboardEvent) => {
+    if (event.key !== "Escape") {
+      return false;
+    }
+
+    const baseUIEvent = event as ReactKeyboardEvent & {
+      preventBaseUIHandler?: () => void;
+    };
+
+    baseUIEvent.preventBaseUIHandler?.();
+
+    if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+      return true;
+    }
+
+    return handleEscapeKeyDownEvent(event.nativeEvent);
+  };
 
   const setHeightFromContent = useCallback(
     (element: Element) => {
@@ -414,7 +467,7 @@ const Content = <T extends TgphElement = "div">({
         setHeightFromContent(element);
       }
     });
-    // Attatch the observer once the initial animation completes
+    // Attach the observer once the initial animation completes
     // and the content ref is available
     if (internalContentRef.current && initialAnimationComplete) {
       observer.observe(internalContentRef.current);
@@ -434,32 +487,57 @@ const Content = <T extends TgphElement = "div">({
   // we add a timeout here to ensure that the DOM element has responded to
   // the state changes first
   useEffect(() => {
-    let timeout: NodeJS.Timeout;
-    if (context.open) {
-      timeout = setTimeout(() => {
-        setHeightFromContent(internalContentRef.current as unknown as Element);
-      }, 10);
+    if (!context.open) {
+      return undefined;
     }
 
-    return () => timeout && clearTimeout(timeout);
+    const timeout = window.setTimeout(() => {
+      setHeightFromContent(internalContentRef.current as unknown as Element);
+    }, 10);
+
+    return () => window.clearTimeout(timeout);
   }, [context.open, setHeightFromContent]);
 
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(handledEscapeKeyDownTimeoutRef.current);
+    };
+  }, []);
+
+  const contentContext = {
+    ...context,
+    onEscapeKeyDown,
+  };
+
   return (
-    <DismissableLayer
-      onEscapeKeyDown={(event) => {
-        if (context.open) {
-          // Don't allow the event to bubble up outside of the menu
-          event.stopPropagation();
-          event.preventDefault();
-          context.setOpen(false);
-        }
-      }}
-    >
+    <ComboboxContext.Provider value={contentContext}>
       <TelegraphMenu.Content
         className="tgph"
         mt="1"
+        onEscapeKeyDown={(event: KeyboardEvent) => {
+          if (handledEscapeKeyDownRef.current) {
+            handledEscapeKeyDownRef.current = false;
+            return;
+          }
+
+          onEscapeKeyDown?.(event);
+
+          if (event.defaultPrevented) {
+            // Consumer escape handlers can keep the popup open.
+            return;
+          }
+
+          if (context.open) {
+            // Don't allow the event to bubble up outside of the menu
+            event.stopPropagation();
+            event.preventDefault();
+            context.setOpen(false);
+          }
+        }}
         onCloseAutoFocus={(event: Event) => {
           if (!hasInteractedOutside.current) {
+            // Menu close autofocus would otherwise move focus away from the
+            // combobox trigger after keyboard selection or Escape close.
             context.triggerRef?.current?.focus();
           }
 
@@ -489,10 +567,14 @@ const Content = <T extends TgphElement = "div">({
         tgphRef={composedRef}
         data-tgph-combobox-content
         data-tgph-combobox-content-open={context.open}
-        // Cancel out accessibility attirbutes related to aria menu
+        // Cancel out accessibility attributes related to aria menu
         role={undefined}
         aria-orientation={undefined}
         onKeyDown={(event: ReactKeyboardEvent) => {
+          if (handleEscapeKeyDown(event)) {
+            return;
+          }
+
           // Don't allow the event to bubble up outside of the menu
           event.stopPropagation();
 
@@ -506,6 +588,8 @@ const Content = <T extends TgphElement = "div">({
             document.activeElement === options?.[0] &&
             LAST_KEYS.includes(event.key)
           ) {
+            // Moving backward from the first option should return focus to search,
+            // matching the previous keyboard loop inside the combobox popup.
             context.searchRef?.current?.focus();
           }
         }}
@@ -514,7 +598,7 @@ const Content = <T extends TgphElement = "div">({
           {children}
         </Stack>
       </TelegraphMenu.Content>
-    </DismissableLayer>
+    </ComboboxContext.Provider>
   );
 };
 
@@ -530,7 +614,7 @@ const Options = <T extends TgphElement = "div">({
   const optionsRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs<unknown>(tgphRef, optionsRef);
 
-  // Scroll to the selected option (or defaultScrollToValue) when the combobox opens
+  // Scroll to the selected option or defaultScrollToValue when the combobox opens.
   useEffect(() => {
     if (context.open && optionsRef.current) {
       // Small delay to ensure the DOM has rendered
@@ -541,7 +625,8 @@ const Options = <T extends TgphElement = "div">({
             ? getValueFromOption(context.value[0], context.legacyBehavior)
             : null;
 
-        // Use selected value if available, otherwise fall back to defaultScrollToValue
+        // Prefer the current selection, then fall back to the explicit initial
+        // scroll target for long lists.
         const valueToScrollTo = selectedValue ?? context.defaultScrollToValue;
 
         if (valueToScrollTo) {
@@ -596,8 +681,9 @@ const Options = <T extends TgphElement = "div">({
   );
 };
 
-export type OptionProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof TelegraphMenu.Button<T>
+export type OptionProps<T extends TgphElement = "button"> = Omit<
+  TgphComponentProps<typeof TelegraphMenu.Button<T>>,
+  "label"
 > & {
   value: DefinedOption["value"];
   label?: DefinedOption["label"];
@@ -611,11 +697,18 @@ const Option = <T extends TgphElement>({
   onSelect,
   children,
   closeOnClick,
+  tgphRef,
   ...props
 }: OptionProps<T>) => {
   const context = useContext(ComboboxContext);
+  const { onEscapeKeyDown, setOpen, triggerRef } = context;
   const [isFocused, setIsFocused] = useState(false);
   const contextValue = context.value;
+  const optionRef = useRef<HTMLElement>(null);
+  const composedRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    optionRef,
+  );
 
   const isVisible =
     !context.searchQuery ||
@@ -631,25 +724,76 @@ const Option = <T extends TgphElement>({
       )
     : getValueFromOption(contextValue, context.legacyBehavior) === value;
 
-  const handleSelection = (event: Event | ReactKeyboardEvent) => {
-    // Don't allow the event to bubble up outside of the menu
-    event.stopPropagation();
+  useEffect(() => {
+    const option = optionRef.current;
+    if (!option) {
+      return undefined;
+    }
 
-    // Don't do anything if the key isn't a selection key
+    const handleOptionKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.stopPropagation();
+      onEscapeKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      event.preventDefault();
+      setOpen(false);
+      triggerRef?.current?.focus();
+    };
+
+    option.addEventListener("keydown", handleOptionKeyDown);
+
+    return () => {
+      option.removeEventListener("keydown", handleOptionKeyDown);
+    };
+  }, [onEscapeKeyDown, setOpen, triggerRef]);
+
+  const handleSelection = (event: Event | ReactKeyboardEvent) => {
     const keyboardEvent = event as ReactKeyboardEvent;
-    if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) return;
+    if (keyboardEvent.key === "Escape") {
+      event.stopPropagation();
+      context.onEscapeKeyDown?.(keyboardEvent.nativeEvent);
+
+      if (
+        event.defaultPrevented ||
+        keyboardEvent.nativeEvent.defaultPrevented
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      context.setOpen(false);
+      context.triggerRef?.current?.focus();
+      return;
+    }
+
+    if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) {
+      // Let non-selection keys bubble to the content layer so Escape dismissal
+      // and popup-level navigation shims still run from focused options.
+      return;
+    }
+
+    // Don't allow selection events to bubble up outside of the menu.
+    event.stopPropagation();
 
     // Don't bubble up the event
     event.preventDefault();
 
     if (context.closeOnSelect === true) {
+      // Close before emitting value changes so controlled callers see the old
+      // menu-backed ordering of open/value updates.
       context.setOpen(false);
     }
 
     if (onSelect) {
-      // Need to convert to non keyboard type event
-      // since onSelect is expecting a mouse event
-      // and we've handled the keyboard event already
+      // Menu onSelect receives an Event; keyboard selection is already handled
+      // here, so bridge the event shape for the public override callback.
       const onSelectEvent = event as unknown as Event;
       return onSelect(onSelectEvent);
     }
@@ -660,6 +804,7 @@ const Option = <T extends TgphElement>({
 
       // TODO: Remove this once { value, label } option is deprecated
       if (context.legacyBehavior === true) {
+        // Legacy single select still emits the option object shape.
         onValueChange?.({ value, label });
       } else {
         onValueChange?.(value);
@@ -676,13 +821,16 @@ const Option = <T extends TgphElement>({
         : [
             ...contextValue,
             // TODO: Remove this once { value, label } option is deprecated
+            // Preserve the legacy array item shape when that mode is enabled.
             context.legacyBehavior === true ? { value, label } : value,
           ];
 
       onValueChange?.(newValue);
     }
 
-    context.triggerRef?.current?.focus();
+    if (context.closeOnSelect === true) {
+      context.triggerRef?.current?.focus();
+    }
   };
 
   if (isVisible) {
@@ -705,6 +853,11 @@ const Option = <T extends TgphElement>({
         data-tgph-combobox-option-focused={isFocused}
         data-tgph-combobox-option-value={value}
         data-tgph-combobox-option-label={label}
+        tgphRef={
+          composedRef as TgphComponentProps<
+            typeof TelegraphMenu.Button<T>
+          >["tgphRef"]
+        }
         {...props}
       >
         {label || children || value}
@@ -735,11 +888,13 @@ const Search = ({
   useEffect(() => {
     const handleSearchKeyDown = (event: KeyboardEvent) => {
       if (FIRST_KEYS.includes(event.key)) {
+        // Arrowing down from the search input should transfer focus into the
+        // options list without scrolling the popup.
         context.contentRef?.current?.focus({ preventScroll: true });
       }
 
       if (event.key === "Escape") {
-        context.setOpen(false);
+        return;
       }
 
       event.stopPropagation();
@@ -757,11 +912,11 @@ const Search = ({
 
   return (
     <Box borderBottom="px" px="1" pb="1">
-      <VisuallyHidden.Root>
+      <VisuallyHidden>
         <Text as="label" htmlFor={id}>
           {label}
         </Text>
-      </VisuallyHidden.Root>
+      </VisuallyHidden>
       <TelegraphInput
         id={id}
         variant="ghost"
@@ -867,6 +1022,8 @@ const Create = <T extends TgphElement, LB extends boolean>({
   const variableAlreadyExists = useCallback(
     (searchQuery: string | undefined) => {
       if (!values || values?.length === 0) return false;
+      // Compare through getValueFromOption so create works for both string
+      // values and legacy { value, label } options.
       return values.some(
         (v) => getValueFromOption(v, legacyBehavior) === searchQuery,
       );
@@ -891,6 +1048,8 @@ const Create = <T extends TgphElement, LB extends boolean>({
 
             const create = onCreate as CreateProps<T, LB>["onCreate"];
 
+            // The conditional prop type keeps public APIs precise, but runtime
+            // creation narrows through the legacyBehavior branch above.
             create(value);
 
             context.setSearchQuery?.("");

--- a/packages/data-list/README.md
+++ b/packages/data-list/README.md
@@ -41,11 +41,11 @@ export const UserProfile = () => (
 
 Container component that wraps data list items.
 
-| Prop          | Type                   | Default    | Description                           |
-| ------------- | ---------------------- | ---------- | ------------------------------------- |
-| `direction`   | `"column" \| "row"`    | `"column"` | Layout direction of list items        |
-| `gap`         | `keyof tokens.spacing` | `"4"`      | Gap between list items                |
-| All Stack props | -                    | -          | Inherits all Stack component properties |
+| Prop            | Type                   | Default    | Description                             |
+| --------------- | ---------------------- | ---------- | --------------------------------------- |
+| `direction`     | `"column" \| "row"`    | `"column"` | Layout direction of list items          |
+| `gap`           | `keyof tokens.spacing` | `"4"`      | Gap between list items                  |
+| All Stack props | -                      | -          | Inherits all Stack component properties |
 
 ### `<DataList.Item>`
 
@@ -72,13 +72,17 @@ Row container for composing custom label-value layouts.
 
 Label component for displaying field names.
 
-| Prop        | Type                   | Default  | Description                     |
-| ----------- | ---------------------- | -------- | ------------------------------- |
-| `maxW`      | `keyof tokens.spacing` | `"36"`   | Maximum width of label          |
-| `maxH`      | `keyof tokens.spacing` | `"6"`    | Maximum height of label         |
-| `w`         | `keyof tokens.spacing` | `"full"` | Width of label                  |
-| `icon`      | `IconProps`            | -        | Optional icon to display        |
-| `textProps` | `TextProps`            | -        | Props to pass to Text component |
+| Prop           | Type                                          | Default     | Description                                          |
+| -------------- | --------------------------------------------- | ----------- | ---------------------------------------------------- |
+| `maxW`         | `keyof tokens.spacing`                        | `"36"`      | Maximum width of label                               |
+| `maxH`         | `keyof tokens.spacing`                        | `"6"`       | Maximum height of label                              |
+| `w`            | `keyof tokens.spacing`                        | `"full"`    | Width of label                                       |
+| `icon`         | `IconProps`                                   | -           | Optional icon to display                             |
+| `description`  | `React.ReactNode`                             | `undefined` | Tooltip content shown for label descriptions         |
+| `tooltipProps` | `Partial<TgphComponentProps<typeof Tooltip>>` | `undefined` | Props passed to the Base UI-backed Telegraph Tooltip |
+| `textProps`    | `TextProps`                                   | -           | Props to pass to Text component                      |
+
+`DataList.Label` uses the Base UI-backed `@telegraph/tooltip` package when `description` is provided. `tooltipProps` pass through to Tooltip, except `enabled` and `label`, which are controlled by DataList so labels without descriptions do not render tooltips.
 
 ### `<DataList.Value>`
 

--- a/packages/data-list/src/DataList/DataList.test.tsx
+++ b/packages/data-list/src/DataList/DataList.test.tsx
@@ -1,0 +1,58 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataList } from "./DataList";
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DataList", () => {
+  it("shows label descriptions through the migrated Tooltip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DataList.Label
+        description="The unique identifier for this user"
+        tooltipProps={{ delayDuration: 0, skipAnimation: true }}
+      >
+        User ID
+      </DataList.Label>,
+    );
+
+    await user.hover(screen.getByText("User ID"));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "The unique identifier for this user",
+    );
+  });
+
+  it("keeps the label tooltip disabled without a description", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DataList.Label tooltipProps={{ delayDuration: 0, skipAnimation: true }}>
+        User ID
+      </DataList.Label>,
+    );
+
+    await user.hover(screen.getByText("User ID"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -24,7 +24,10 @@ import {
   PolymorphicProps,
   RefToTgphRef,
   TgphElement,
+  TgphSlot,
+  VisuallyHidden,
   createTgphBaseUIRender,
+  useControllableState,
   useDeterminateState,
 } from "@telegraph/helpers";
 
@@ -42,6 +45,13 @@ const state = useDeterminateState({
 
 // Base UI render bridge for Telegraph components
 const renderTrigger = createTgphBaseUIRender(<Button>Open</Button>);
+
+// Controlled/uncontrolled state bridge for component primitives
+const [open, setOpen] = useControllableState({
+  prop: openProp,
+  defaultProp: false,
+  onChange: onOpenChange,
+});
 ```
 
 ## API Reference
@@ -222,39 +232,38 @@ const CustomButton = ({
 
 ### `RefToTgphRef`
 
-Component for handling ref forwarding between external libraries (like Radix) and Telegraph components.
+Component for handling ref forwarding between external libraries and Telegraph
+components.
 
 ```tsx
-import * as Popover from "@radix-ui/react-popover";
 import { Button } from "@telegraph/button";
 import { RefToTgphRef } from "@telegraph/helpers";
 
-// Radix expects a `ref` prop, but Telegraph uses `tgphRef`
-<Popover.Trigger asChild>
-  <RefToTgphRef>
-    <Button>Open Popover</Button>
-  </RefToTgphRef>
-</Popover.Trigger>;
+// Use when an external primitive passes a React `ref` to a single child,
+// but the Telegraph child expects `tgphRef`.
+<RefToTgphRef>
+  <Button>Open</Button>
+</RefToTgphRef>;
 ```
 
 #### Use Cases
 
-**With Radix UI Primitives:**
+**With Base UI render props:**
 
 ```tsx
-import * as Dialog from "@radix-ui/react-dialog";
+import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
-import { RefToTgphRef } from "@telegraph/helpers";
+import { createTgphBaseUIRender } from "@telegraph/helpers";
 
-const DialogExample = () => (
-  <Dialog.Root>
-    <Dialog.Trigger asChild>
-      <RefToTgphRef>
-        <Button>Open Dialog</Button>
-      </RefToTgphRef>
-    </Dialog.Trigger>
-    <Dialog.Content>{/* Dialog content */}</Dialog.Content>
-  </Dialog.Root>
+const PopoverExample = () => (
+  <Popover.Root>
+    <Popover.Trigger render={createTgphBaseUIRender(<Button>Open</Button>)} />
+    <Popover.Portal>
+      <Popover.Positioner>
+        <Popover.Popup>{/* Popover content */}</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
 );
 ```
 
@@ -280,6 +289,44 @@ const FormExample = () => {
     />
   );
 };
+```
+
+### `TgphSlot`
+
+Component for merging wrapper props into a single child element while preserving
+native refs, custom `forwardRef` children, and Telegraph `tgphRef` children.
+
+```tsx
+import { TgphSlot } from "@telegraph/helpers";
+
+<TgphSlot data-state="open" className="trigger">
+  <button type="button">Open</button>
+</TgphSlot>;
+```
+
+### `VisuallyHidden`
+
+Component for rendering accessible text that should remain available to assistive
+technology without being visible in the UI.
+
+```tsx
+import { VisuallyHidden } from "@telegraph/helpers";
+import { Text } from "@telegraph/typography";
+
+<VisuallyHidden>
+  <Text as="label" htmlFor="search">
+    Search
+  </Text>
+</VisuallyHidden>;
+```
+
+Use `asChild` when the hidden styles need to be applied directly to a specific
+element.
+
+```tsx
+<VisuallyHidden asChild>
+  <label htmlFor="email">Email</label>
+</VisuallyHidden>
 ```
 
 ### `createTgphBaseUIRender`
@@ -326,6 +373,28 @@ import type { ComponentProps } from "react";
 ```
 
 ## React Hooks
+
+### `useControllableState`
+
+Hook for component primitives that support both controlled and uncontrolled
+usage.
+
+```tsx
+import { useControllableState } from "@telegraph/helpers";
+
+const [open, setOpen] = useControllableState({
+  prop: openProp,
+  defaultProp: false,
+  onChange: onOpenChange,
+});
+```
+
+The hook mirrors Telegraph's controlled prop conventions:
+
+- `prop` controls the state when it is not `undefined`.
+- `defaultProp` seeds uncontrolled state.
+- `onChange` is called only when the next value differs from the current value.
+- Updater functions are supported, matching React's `setState` ergonomics.
 
 ### `useDeterminateState`
 
@@ -511,32 +580,6 @@ const Card = ({ variant, children, ...props }: CardProps) => {
 ### Integration with External Libraries
 
 ```tsx
-import * as RadixPopover from "@radix-ui/react-popover";
-import { Button } from "@telegraph/button";
-import { PolymorphicProps, RefToTgphRef } from "@telegraph/helpers";
-
-type PopoverProps = PolymorphicProps<"div"> & {
-  trigger: React.ReactNode;
-  content: React.ReactNode;
-};
-
-const Popover = ({ trigger, content, ...props }: PopoverProps) => (
-  <RadixPopover.Root>
-    <RadixPopover.Trigger asChild>
-      <RefToTgphRef>{trigger}</RefToTgphRef>
-    </RadixPopover.Trigger>
-    <RadixPopover.Content {...props}>{content}</RadixPopover.Content>
-  </RadixPopover.Root>
-);
-
-// Usage:
-<Popover
-  trigger={<Button>Open Menu</Button>}
-  content={<div>Popover content</div>}
-/>;
-```
-
-```tsx
 import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
 import { PolymorphicProps, createTgphBaseUIRender } from "@telegraph/helpers";
@@ -638,10 +681,11 @@ type ConditionalProps<T extends TgphElement> = PolymorphicProps<T> &
 ### Component Development
 
 1. **Use `createTgphBaseUIRender` with Base UI `render` props**: Preserves Base UI props while forwarding refs to Telegraph `tgphRef`
-2. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
-3. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
-4. **Type polymorphic components properly**: Use appropriate helper types
-5. **Test type constraints**: Verify TypeScript catches errors correctly
+2. **Use `TgphSlot` for single-child prop composition**: Preserves native refs and `tgphRef`
+3. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
+4. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
+5. **Type polymorphic components properly**: Use appropriate helper types
+6. **Test type constraints**: Verify TypeScript catches errors correctly
 
 ## References
 

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -355,7 +355,9 @@ const PopoverExample = () => (
 
 The helper accepts a React element or a state callback. It preserves Base UI
 props, event handlers, class names, styles, native refs, custom `forwardRef`
-children, and Telegraph `tgphRef` children.
+children, and Telegraph `tgphRef` children. When the child already has its own
+`tgphRef`, the helper composes it with the Base UI ref so both refs receive the
+same rendered element.
 
 ```tsx
 import { Popover } from "@base-ui/react/popover";

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -19,9 +19,12 @@ npm install @telegraph/helpers
 ## Quick Start
 
 ```tsx
+import { Button } from "@telegraph/button";
 import {
   PolymorphicProps,
   RefToTgphRef,
+  TgphElement,
+  createTgphBaseUIRender,
   useDeterminateState,
 } from "@telegraph/helpers";
 
@@ -31,11 +34,14 @@ type ButtonProps<T extends TgphElement> = PolymorphicProps<T> & {
 };
 
 // Hook for loading states with minimum duration
-const { state } = useDeterminateState({
+const state = useDeterminateState({
   value: isLoading ? "loading" : "idle",
   determinateValue: "loading",
   minDurationMs: 1000,
 });
+
+// Base UI render bridge for Telegraph components
+const renderTrigger = createTgphBaseUIRender(<Button>Open</Button>);
 ```
 
 ## API Reference
@@ -276,6 +282,49 @@ const FormExample = () => {
 };
 ```
 
+### `createTgphBaseUIRender`
+
+Helper for adapting Base UI `render` callbacks to Telegraph components that
+use `tgphRef`.
+
+```tsx
+import { Popover } from "@base-ui/react/popover";
+import { Button } from "@telegraph/button";
+import { createTgphBaseUIRender } from "@telegraph/helpers";
+
+const PopoverExample = () => (
+  <Popover.Root>
+    <Popover.Trigger
+      render={createTgphBaseUIRender(<Button>Open Popover</Button>)}
+    />
+    <Popover.Portal>
+      <Popover.Positioner>
+        <Popover.Popup>{/* Popover content */}</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
+);
+```
+
+The helper accepts a React element or a state callback. It preserves Base UI
+props, event handlers, class names, styles, native refs, custom `forwardRef`
+children, and Telegraph `tgphRef` children.
+
+```tsx
+import { Popover } from "@base-ui/react/popover";
+import { Button } from "@telegraph/button";
+import { createTgphBaseUIRender } from "@telegraph/helpers";
+import type { ComponentProps } from "react";
+
+<Popover.Trigger
+  render={createTgphBaseUIRender<ComponentProps<"button">, { open: boolean }>(
+    (state) => (
+      <Button>{state.open ? "Close" : "Open"}</Button>
+    ),
+  )}
+/>;
+```
+
 ## React Hooks
 
 ### `useDeterminateState`
@@ -487,6 +536,30 @@ const Popover = ({ trigger, content, ...props }: PopoverProps) => (
 />;
 ```
 
+```tsx
+import { Popover } from "@base-ui/react/popover";
+import { Button } from "@telegraph/button";
+import { PolymorphicProps, createTgphBaseUIRender } from "@telegraph/helpers";
+import type { ReactNode } from "react";
+
+type BasePopoverProps = PolymorphicProps<"div"> & {
+  content: ReactNode;
+};
+
+const BasePopover = ({ children, content, ...props }: BasePopoverProps) => (
+  <Popover.Root>
+    <Popover.Trigger
+      render={createTgphBaseUIRender(<Button>{children}</Button>)}
+    />
+    <Popover.Portal>
+      <Popover.Positioner>
+        <Popover.Popup {...props}>{content}</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
+);
+```
+
 ## TypeScript
 
 ### Utility Type Examples
@@ -522,6 +595,7 @@ type PublicUser = RemappedOmit<User, "email">;
 ```tsx
 import {
   PolymorphicProps,
+  PolymorphicPropsWithTgphRef,
   TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
@@ -563,10 +637,11 @@ type ConditionalProps<T extends TgphElement> = PolymorphicProps<T> &
 
 ### Component Development
 
-1. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
-2. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
-3. **Type polymorphic components properly**: Use appropriate helper types
-4. **Test type constraints**: Verify TypeScript catches errors correctly
+1. **Use `createTgphBaseUIRender` with Base UI `render` props**: Preserves Base UI props while forwarding refs to Telegraph `tgphRef`
+2. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
+3. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
+4. **Type polymorphic components properly**: Use appropriate helper types
+5. **Test type constraints**: Verify TypeScript catches errors correctly
 
 ## References
 

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -21,6 +21,8 @@ npm install @telegraph/helpers
 ```tsx
 import { Button } from "@telegraph/button";
 import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
   PolymorphicProps,
   RefToTgphRef,
   TgphElement,
@@ -52,6 +54,12 @@ const [open, setOpen] = useControllableState({
   defaultProp: false,
   onChange: onOpenChange,
 });
+
+// Legacy Radix-style dismissal and animation compatibility for Base UI wrappers
+const shouldCancelDismiss = callLegacyDismissHandlers(eventDetails, {
+  onEscapeKeyDown,
+});
+const initial = { opacity: 0, ...getBaseUIMotionOffset(side) };
 ```
 
 ## API Reference
@@ -372,6 +380,35 @@ import type { ComponentProps } from "react";
     ),
   )}
 />;
+```
+
+### Base UI Compatibility Utilities
+
+Small helpers for preserving legacy Radix-style Telegraph behavior while
+wrapping Base UI primitives.
+
+```tsx
+import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+} from "@telegraph/helpers";
+
+const shouldCancelDismiss = callLegacyDismissHandlers(eventDetails, {
+  onEscapeKeyDown,
+  onPointerDownOutside,
+});
+
+const initial = {
+  opacity: 0,
+  ...getBaseUIMotionOffset(side),
+};
+
+const positionerStyle = getBaseUIPositionerVisibilityStyle({
+  anchorHidden,
+  hideWhenDetached,
+  zIndex: "var(--tgph-zIndex-tooltip)",
+});
 ```
 
 ## React Hooks

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -43,5 +43,8 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.5.0"
   }
 }

--- a/packages/helpers/src/base-ui/compatibility.test.ts
+++ b/packages/helpers/src/base-ui/compatibility.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+} from "./compatibility";
+
+describe("callLegacyDismissHandlers", () => {
+  it("calls escape handlers and returns whether they prevented dismissal", () => {
+    const event = new KeyboardEvent("keydown", { cancelable: true });
+    const onEscapeKeyDown = vi.fn((dismissEvent: KeyboardEvent) => {
+      dismissEvent.preventDefault();
+    });
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "escape-key" },
+      { onEscapeKeyDown },
+    );
+
+    expect(onEscapeKeyDown).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(true);
+  });
+
+  it("calls pointer and interact handlers for outside press dismissal", () => {
+    const event = new MouseEvent("mousedown", { cancelable: true });
+    const onPointerDownOutside = vi.fn();
+    const onInteractOutside = vi.fn((dismissEvent: Event) => {
+      dismissEvent.preventDefault();
+    });
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "outside-press" },
+      { onInteractOutside, onPointerDownOutside },
+    );
+
+    expect(onPointerDownOutside).toHaveBeenCalledWith(event);
+    expect(onInteractOutside).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(true);
+  });
+
+  it("calls focus and interact handlers for focus-out dismissal", () => {
+    const event = new FocusEvent("focusout", { cancelable: true });
+    const onFocusOutside = vi.fn();
+    const onInteractOutside = vi.fn();
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "focus-out" },
+      { onFocusOutside, onInteractOutside },
+    );
+
+    expect(onFocusOutside).toHaveBeenCalledWith(event);
+    expect(onInteractOutside).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(false);
+  });
+});
+
+describe("getBaseUIMotionOffset", () => {
+  it("returns directional motion offsets", () => {
+    expect(getBaseUIMotionOffset("top")).toEqual({ y: -5 });
+    expect(getBaseUIMotionOffset("bottom", 8)).toEqual({ y: 8 });
+    expect(getBaseUIMotionOffset("left")).toEqual({ x: -5 });
+    expect(getBaseUIMotionOffset("right", 8)).toEqual({ x: 8 });
+    expect(getBaseUIMotionOffset("inline-start")).toEqual({});
+  });
+});
+
+describe("getBaseUIPositionerVisibilityStyle", () => {
+  it("only hides detached positioners when requested", () => {
+    expect(
+      getBaseUIPositionerVisibilityStyle({
+        anchorHidden: true,
+        hideWhenDetached: true,
+        zIndex: "var(--tgph-zIndex-tooltip)",
+      }),
+    ).toEqual({
+      visibility: "hidden",
+      zIndex: "var(--tgph-zIndex-tooltip)",
+    });
+
+    expect(
+      getBaseUIPositionerVisibilityStyle({
+        anchorHidden: true,
+        hideWhenDetached: false,
+      }),
+    ).toEqual({
+      visibility: undefined,
+      zIndex: undefined,
+    });
+  });
+});

--- a/packages/helpers/src/base-ui/compatibility.ts
+++ b/packages/helpers/src/base-ui/compatibility.ts
@@ -1,0 +1,155 @@
+import type { CSSProperties } from "react";
+
+const ANIMATION_OFFSET = 5;
+const BASE_UI_DISMISS_REASONS = {
+  escapeKey: "escape-key",
+  focusOut: "focus-out",
+  outsidePress: "outside-press",
+} as const;
+
+type BaseUIChangeDetails = {
+  event: Event;
+  reason?: string;
+};
+
+type BaseUIFloatingSide =
+  | "top"
+  | "bottom"
+  | "left"
+  | "right"
+  | "inline-start"
+  | "inline-end";
+
+type LegacyDismissEventHandler<TEvent extends Event = Event> = (
+  event: TEvent,
+) => void;
+
+type LegacyDismissHandlers = {
+  onEscapeKeyDown?: LegacyDismissEventHandler<KeyboardEvent>;
+  onFocusOutside?: LegacyDismissEventHandler<FocusEvent | KeyboardEvent>;
+  onInteractOutside?: LegacyDismissEventHandler;
+  onPointerDownOutside?: LegacyDismissEventHandler<
+    MouseEvent | PointerEvent | TouchEvent
+  >;
+};
+
+type BaseUIPositionerVisibilityStyleParams = {
+  anchorHidden: boolean;
+  hideWhenDetached?: boolean;
+  zIndex?: CSSProperties["zIndex"];
+};
+
+const callLegacyEventHandler = <TEvent extends Event>(
+  handler: LegacyDismissEventHandler<TEvent> | undefined,
+  event: TEvent,
+) => {
+  handler?.(event);
+  return event.defaultPrevented;
+};
+
+const callLegacyDismissHandlers = (
+  eventDetails: BaseUIChangeDetails,
+  callbacks: LegacyDismissHandlers,
+) => {
+  const { event, reason } = eventDetails;
+
+  if (reason === BASE_UI_DISMISS_REASONS.escapeKey) {
+    // Radix exposed escape as a typed keyboard callback, so preserve that event
+    // shape even though Base UI sends all dismiss reasons through one details object.
+    return callLegacyEventHandler(
+      callbacks.onEscapeKeyDown,
+      event as KeyboardEvent,
+    );
+  }
+
+  if (reason === BASE_UI_DISMISS_REASONS.outsidePress) {
+    // Radix fired both pointer-specific and generic outside-interaction hooks;
+    // cancellation from either one should block Base UI's dismiss.
+    const pointerDismissPrevented = callLegacyEventHandler(
+      callbacks.onPointerDownOutside,
+      event as MouseEvent | PointerEvent | TouchEvent,
+    );
+    const interactDismissPrevented = callLegacyEventHandler(
+      callbacks.onInteractOutside,
+      event,
+    );
+
+    return pointerDismissPrevented || interactDismissPrevented;
+  }
+
+  if (reason === BASE_UI_DISMISS_REASONS.focusOut) {
+    // Focus-out maps to Radix's focus-specific hook and the broader
+    // interaction hook, matching the previous callback cascade.
+    const focusDismissPrevented = callLegacyEventHandler(
+      callbacks.onFocusOutside,
+      event as FocusEvent | KeyboardEvent,
+    );
+    const interactDismissPrevented = callLegacyEventHandler(
+      callbacks.onInteractOutside,
+      event,
+    );
+
+    return focusDismissPrevented || interactDismissPrevented;
+  }
+
+  return false;
+};
+
+const getBaseUIMotionOffset = (
+  side: BaseUIFloatingSide | undefined,
+  offset = ANIMATION_OFFSET,
+) => {
+  // Base UI includes logical sides, but Telegraph's existing animation only
+  // offsets physical sides; logical sides intentionally fall through to no offset.
+  if (side === "top") {
+    return {
+      y: -offset,
+    };
+  }
+
+  if (side === "bottom") {
+    return {
+      y: offset,
+    };
+  }
+
+  if (side === "left") {
+    return {
+      x: -offset,
+    };
+  }
+
+  if (side === "right") {
+    return {
+      x: offset,
+    };
+  }
+
+  return {};
+};
+
+const getBaseUIPositionerVisibilityStyle = ({
+  anchorHidden,
+  hideWhenDetached,
+  zIndex,
+}: BaseUIPositionerVisibilityStyleParams): CSSProperties => {
+  return {
+    // Radix's `hideWhenDetached` hid content without unmounting it; Base UI
+    // reports anchor visibility through render state instead.
+    visibility: hideWhenDetached && anchorHidden ? "hidden" : undefined,
+    zIndex,
+  };
+};
+
+export {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+};
+export type {
+  BaseUIChangeDetails,
+  BaseUIFloatingSide,
+  BaseUIPositionerVisibilityStyleParams,
+  LegacyDismissEventHandler,
+  LegacyDismissHandlers,
+};

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  forwardRef,
+} from "react";
+import { describe, expect, it } from "vitest";
+
+import { createTgphBaseUIRender } from "./createTgphBaseUIRender";
+
+type BaseUIRenderProps = ComponentPropsWithoutRef<"button"> & {
+  ref?: Ref<HTMLButtonElement>;
+};
+
+type TelegraphButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TelegraphButton = ({ tgphRef, ...props }: TelegraphButtonProps) => {
+  return <button ref={tgphRef} type="button" {...props} />;
+};
+
+const ForwardRefButton = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button">
+>((props, ref) => {
+  return <button ref={ref} type="button" {...props} />;
+});
+
+describe("createTgphBaseUIRender", () => {
+  it("forwards Base UI render props to a native element", () => {
+    const ref = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <button className="child" type="button">
+        Open
+      </button>,
+    );
+
+    render(
+      renderButton(
+        {
+          "aria-expanded": true,
+          className: "base-ui",
+          "data-testid": "native-button",
+          ref,
+        },
+        {},
+      ),
+    );
+
+    const button = screen.getByTestId("native-button");
+
+    expect(button).toHaveClass("child");
+    expect(button).toHaveClass("base-ui");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(ref.current).toBe(button);
+  });
+
+  it("maps Base UI refs to tgphRef for Telegraph-style children", () => {
+    const ref = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <TelegraphButton>Open</TelegraphButton>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "telegraph-button",
+          ref,
+        },
+        {},
+      ),
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("telegraph-button"));
+  });
+
+  it("composes Base UI refs with existing native element refs", () => {
+    const baseUIRef = createRef<HTMLButtonElement>();
+    const childRef = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <button ref={childRef} type="button">
+        Open
+      </button>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "native-button",
+          ref: baseUIRef,
+        },
+        {},
+      ),
+    );
+
+    const button = screen.getByTestId("native-button");
+
+    expect(baseUIRef.current).toBe(button);
+    expect(childRef.current).toBe(button);
+  });
+
+  it("preserves ref support for custom forwardRef children", () => {
+    const ref = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <ForwardRefButton>Open</ForwardRefButton>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "forward-ref-button",
+          ref,
+        },
+        {},
+      ),
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("forward-ref-button"));
+  });
+
+  it("merges child and Base UI event handlers", () => {
+    const childClick = vi.fn();
+    const baseUIClick = vi.fn();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <button onClick={childClick} type="button">
+        Open
+      </button>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "merged-button",
+          onClick: baseUIClick,
+        },
+        {},
+      ),
+    );
+
+    screen.getByTestId("merged-button").click();
+
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(baseUIClick).toHaveBeenCalledOnce();
+  });
+
+  it("supports render callbacks that receive Base UI state", () => {
+    const renderButton = createTgphBaseUIRender<
+      BaseUIRenderProps,
+      { open: boolean }
+    >((state) => {
+      return <TelegraphButton>{state.open ? "Close" : "Open"}</TelegraphButton>;
+    });
+
+    render(
+      renderButton(
+        {
+          "data-testid": "state-button",
+        },
+        { open: true },
+      ),
+    );
+
+    expect(screen.getByTestId("state-button")).toHaveTextContent("Close");
+  });
+});

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
@@ -5,7 +5,7 @@ import {
   createRef,
   forwardRef,
 } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createTgphBaseUIRender } from "./createTgphBaseUIRender";
 
@@ -96,6 +96,29 @@ describe("createTgphBaseUIRender", () => {
     );
 
     const button = screen.getByTestId("native-button");
+
+    expect(baseUIRef.current).toBe(button);
+    expect(childRef.current).toBe(button);
+  });
+
+  it("composes Base UI refs with existing tgphRef props", () => {
+    const baseUIRef = createRef<HTMLButtonElement>();
+    const childRef = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <TelegraphButton tgphRef={childRef}>Open</TelegraphButton>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "telegraph-button",
+          ref: baseUIRef,
+        },
+        {},
+      ),
+    );
+
+    const button = screen.getByTestId("telegraph-button");
 
     expect(baseUIRef.current).toBe(button);
     expect(childRef.current).toBe(button);

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
@@ -1,31 +1,10 @@
-import { mergeProps } from "@base-ui/react/merge-props";
 import type { ComponentRenderFn, HTMLProps } from "@base-ui/react/use-render";
-import {
-  type ComponentPropsWithRef,
-  type MutableRefObject,
-  type ReactElement,
-  type Ref,
-  type RefAttributes,
-  cloneElement,
-  isValidElement,
-} from "react";
+import { type ReactElement, type Ref, isValidElement } from "react";
 
-import { RefToTgphRef } from "../components/RefToTgphRef";
+import { TgphSlot } from "../components/TgphSlot";
 
 type PropsWithRef = HTMLProps & {
   ref?: Ref<unknown>;
-};
-
-type CloneableProps = Record<string, unknown> & RefAttributes<unknown>;
-
-type IntrinsicMergeProps = ComponentPropsWithRef<"button">;
-
-type ElementWithRef = ReactElement<CloneableProps> & {
-  ref?: Ref<unknown>;
-};
-
-type WarningGetter = (() => unknown) & {
-  isReactWarning?: boolean;
 };
 
 type TgphBaseUIRenderElement<State = Record<string, unknown>> =
@@ -37,62 +16,9 @@ type GetRenderElementParams<State> = {
   state: State;
 };
 
-type RenderNativeElementParams = {
+type RenderWithTgphSlotParams = {
   props: PropsWithRef;
   renderElement: ReactElement;
-};
-
-const isIntrinsicElement = (element: ReactElement) => {
-  return typeof element.type === "string";
-};
-
-const isReactWarningGetter = (
-  getter: (() => unknown) | undefined,
-): getter is WarningGetter => {
-  return Boolean(getter && "isReactWarning" in getter && getter.isReactWarning);
-};
-
-const getElementRef = (element: ReactElement<CloneableProps>) => {
-  const propsRefGetter = Object.getOwnPropertyDescriptor(
-    element.props,
-    "ref",
-  )?.get;
-
-  if (isReactWarningGetter(propsRefGetter)) {
-    // React 18 can hide the real ref on the element when props.ref is only the
-    // dev warning getter, so read the element field in that case.
-    return (element as ElementWithRef).ref;
-  }
-
-  const elementRefGetter = Object.getOwnPropertyDescriptor(element, "ref")?.get;
-
-  if (isReactWarningGetter(elementRefGetter)) {
-    // React 19 moves refs into props; if element.ref is the warning getter,
-    // prefer the props ref so we do not trip the warning while composing refs.
-    return element.props.ref;
-  }
-
-  return element.props.ref ?? (element as ElementWithRef).ref;
-};
-
-const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
-  if (typeof ref === "function") {
-    ref(value);
-  } else if (ref !== null && ref !== undefined) {
-    (ref as MutableRefObject<T | null>).current = value;
-  }
-};
-
-const composeRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
-  const definedRefs = refs.filter((ref): ref is Ref<T> => Boolean(ref));
-
-  if (definedRefs.length === 0) {
-    return undefined;
-  }
-
-  return (node: T | null) => {
-    definedRefs.forEach((ref) => setRef(ref, node));
-  };
 };
 
 const getRenderElement = <State = Record<string, unknown>,>({
@@ -106,26 +32,19 @@ const getRenderElement = <State = Record<string, unknown>,>({
   return element;
 };
 
-const renderNativeElement = ({
+const renderWithTgphSlot = ({
   props,
   renderElement,
-}: RenderNativeElementParams) => {
-  // React treats refs specially when cloning, so pull Base UI's forwarded ref
-  // out before merging the rest of the props into the rendered element.
-  const { ref, ...baseUIProps } = props;
-  const cloneableElement = renderElement as ReactElement<CloneableProps>;
-  const childRef = getElementRef(cloneableElement);
-  const composedRef = composeRefs(childRef, ref);
+}: RenderWithTgphSlotParams) => {
+  // Base UI gives render targets a standard React ref; TgphSlot decides whether
+  // that ref should stay on `ref` or be bridged onto Telegraph's `tgphRef`.
+  const { ref } = props;
 
-  return cloneElement(cloneableElement, {
-    // Keep Base UI's injected event handlers and data attributes composed with
-    // the caller's element props instead of replacing one side wholesale.
-    ...mergeProps(
-      baseUIProps as IntrinsicMergeProps,
-      renderElement.props as IntrinsicMergeProps,
-    ),
-    ...(composedRef ? { ref: composedRef } : {}),
-  });
+  return (
+    <TgphSlot {...props} ref={ref as Ref<HTMLElement>}>
+      {renderElement}
+    </TgphSlot>
+  );
 };
 
 const createTgphBaseUIRender = <
@@ -136,24 +55,19 @@ const createTgphBaseUIRender = <
 ): ComponentRenderFn<Props, State> => {
   return (props, state) => {
     // Base UI may call `render` with live state, so resolve function children
-    // before choosing the native-element path or Telegraph ref bridge.
+    // before asking TgphSlot to merge props into the concrete element.
     const renderElement = getRenderElement({ element, state });
 
     if (!isValidElement(renderElement)) {
       return renderElement;
     }
 
-    if (isIntrinsicElement(renderElement)) {
-      // Native elements can receive Base UI's merged props and React ref
-      // directly, so keep Base UI's merge behavior intact here.
-      return renderNativeElement({
-        props: props as PropsWithRef,
-        renderElement,
-      });
-    }
-
-    // Telegraph components need Base UI's standard `ref` bridged to `tgphRef`.
-    return <RefToTgphRef {...props}>{renderElement}</RefToTgphRef>;
+    // Keep native elements, forwardRef components, and tgphRef-only components
+    // on the same prop/ref composition path.
+    return renderWithTgphSlot({
+      props: props as PropsWithRef,
+      renderElement,
+    });
   };
 };
 

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
@@ -1,0 +1,161 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import type { ComponentRenderFn, HTMLProps } from "@base-ui/react/use-render";
+import {
+  type ComponentPropsWithRef,
+  type MutableRefObject,
+  type ReactElement,
+  type Ref,
+  type RefAttributes,
+  cloneElement,
+  isValidElement,
+} from "react";
+
+import { RefToTgphRef } from "../components/RefToTgphRef";
+
+type PropsWithRef = HTMLProps & {
+  ref?: Ref<unknown>;
+};
+
+type CloneableProps = Record<string, unknown> & RefAttributes<unknown>;
+
+type IntrinsicMergeProps = ComponentPropsWithRef<"button">;
+
+type ElementWithRef = ReactElement<CloneableProps> & {
+  ref?: Ref<unknown>;
+};
+
+type WarningGetter = (() => unknown) & {
+  isReactWarning?: boolean;
+};
+
+type TgphBaseUIRenderElement<State = Record<string, unknown>> =
+  | ReactElement
+  | ((state: State) => ReactElement);
+
+type GetRenderElementParams<State> = {
+  element: TgphBaseUIRenderElement<State>;
+  state: State;
+};
+
+type RenderNativeElementParams = {
+  props: PropsWithRef;
+  renderElement: ReactElement;
+};
+
+const isIntrinsicElement = (element: ReactElement) => {
+  return typeof element.type === "string";
+};
+
+const isReactWarningGetter = (
+  getter: (() => unknown) | undefined,
+): getter is WarningGetter => {
+  return Boolean(getter && "isReactWarning" in getter && getter.isReactWarning);
+};
+
+const getElementRef = (element: ReactElement<CloneableProps>) => {
+  const propsRefGetter = Object.getOwnPropertyDescriptor(
+    element.props,
+    "ref",
+  )?.get;
+
+  if (isReactWarningGetter(propsRefGetter)) {
+    // React 18 can hide the real ref on the element when props.ref is only the
+    // dev warning getter, so read the element field in that case.
+    return (element as ElementWithRef).ref;
+  }
+
+  const elementRefGetter = Object.getOwnPropertyDescriptor(element, "ref")?.get;
+
+  if (isReactWarningGetter(elementRefGetter)) {
+    // React 19 moves refs into props; if element.ref is the warning getter,
+    // prefer the props ref so we do not trip the warning while composing refs.
+    return element.props.ref;
+  }
+
+  return element.props.ref ?? (element as ElementWithRef).ref;
+};
+
+const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref !== null && ref !== undefined) {
+    (ref as MutableRefObject<T | null>).current = value;
+  }
+};
+
+const composeRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
+  const definedRefs = refs.filter((ref): ref is Ref<T> => Boolean(ref));
+
+  if (definedRefs.length === 0) {
+    return undefined;
+  }
+
+  return (node: T | null) => {
+    definedRefs.forEach((ref) => setRef(ref, node));
+  };
+};
+
+const getRenderElement = <State = Record<string, unknown>,>({
+  element,
+  state,
+}: GetRenderElementParams<State>) => {
+  if (typeof element === "function") {
+    return element(state);
+  }
+
+  return element;
+};
+
+const renderNativeElement = ({
+  props,
+  renderElement,
+}: RenderNativeElementParams) => {
+  // React treats refs specially when cloning, so pull Base UI's forwarded ref
+  // out before merging the rest of the props into the rendered element.
+  const { ref, ...baseUIProps } = props;
+  const cloneableElement = renderElement as ReactElement<CloneableProps>;
+  const childRef = getElementRef(cloneableElement);
+  const composedRef = composeRefs(childRef, ref);
+
+  return cloneElement(cloneableElement, {
+    // Keep Base UI's injected event handlers and data attributes composed with
+    // the caller's element props instead of replacing one side wholesale.
+    ...mergeProps(
+      baseUIProps as IntrinsicMergeProps,
+      renderElement.props as IntrinsicMergeProps,
+    ),
+    ...(composedRef ? { ref: composedRef } : {}),
+  });
+};
+
+const createTgphBaseUIRender = <
+  Props extends HTMLProps = HTMLProps,
+  State = Record<string, unknown>,
+>(
+  element: TgphBaseUIRenderElement<State>,
+): ComponentRenderFn<Props, State> => {
+  return (props, state) => {
+    // Base UI may call `render` with live state, so resolve function children
+    // before choosing the native-element path or Telegraph ref bridge.
+    const renderElement = getRenderElement({ element, state });
+
+    if (!isValidElement(renderElement)) {
+      return renderElement;
+    }
+
+    if (isIntrinsicElement(renderElement)) {
+      // Native elements can receive Base UI's merged props and React ref
+      // directly, so keep Base UI's merge behavior intact here.
+      return renderNativeElement({
+        props: props as PropsWithRef,
+        renderElement,
+      });
+    }
+
+    // Telegraph components need Base UI's standard `ref` bridged to `tgphRef`.
+    return <RefToTgphRef {...props}>{renderElement}</RefToTgphRef>;
+  };
+};
+
+export { createTgphBaseUIRender };
+export type { TgphBaseUIRenderElement };

--- a/packages/helpers/src/base-ui/index.ts
+++ b/packages/helpers/src/base-ui/index.ts
@@ -1,0 +1,4 @@
+export {
+  createTgphBaseUIRender,
+  type TgphBaseUIRenderElement,
+} from "./createTgphBaseUIRender";

--- a/packages/helpers/src/base-ui/index.ts
+++ b/packages/helpers/src/base-ui/index.ts
@@ -2,3 +2,14 @@ export {
   createTgphBaseUIRender,
   type TgphBaseUIRenderElement,
 } from "./createTgphBaseUIRender";
+
+export {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+  type BaseUIChangeDetails,
+  type BaseUIFloatingSide,
+  type BaseUIPositionerVisibilityStyleParams,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
+} from "./compatibility";

--- a/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
+++ b/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
@@ -1,50 +1,3 @@
-/**
- * RefToTgphRef Component
- *
- * PURPOSE:
- * ========
- * This component bridges the gap between third-party libraries (like Radix UI) and
- * Telegraph components. Third-party libraries expect components to accept a standard
- * React `ref` prop, but Telegraph components use a custom `tgphRef` prop instead.
- *
- * Without this adapter, using Telegraph components with libraries like Radix would fail
- * because Radix would try to pass a `ref` that Telegraph components wouldn't receive.
- *
- * EXAMPLE USAGE:
- * ==============
- * ```tsx
- * <RadixTooltip.Trigger asChild>
- *   <RefToTgphRef>
- *     <Button>Hover me</Button>  // Button uses tgphRef internally
- *   </RefToTgphRef>
- * </RadixTooltip.Trigger>
- * ```
- *
- * WHAT IT DOES:
- * =============
- * 1. Receives a `ref` from the parent (e.g., Radix)
- * 2. Forwards it as both `ref` AND `tgphRef` to Telegraph children
- * 3. Merges any additional props from the parent with child props
- * 4. Handles both forwardRef components and regular components appropriately
- *
- * THE INFINITE LOOP PROBLEM:
- * ==========================
- * Radix and other libraries often pass ref callbacks that are recreated on every render
- * (new function references). When we pass these unstable refs to children via
- * React.cloneElement, it causes the child to re-render with "new" props even though
- * the ref functionality hasn't actually changed. This can trigger infinite render loops.
- *
- * THE SOLUTION:
- * =============
- * We create a STABLE ref callback using useCallback with an empty dependency array,
- * so the function reference never changes. We store the actual (unstable) ref in a
- * mutable ref (refStorage) and update it on every render. When our stable callback
- * is invoked, it reads from refStorage to get the latest ref and calls it.
- *
- * We also track the DOM node so that if the ref callback itself changes (rare but
- * possible), we can properly cleanup the old ref by calling it with null, and then
- * call the new ref with the current node. This matches React's standard ref behavior.
- */
 import React from "react";
 
 const FORWARD_REF_SYMBOL = Symbol.for("react.forward_ref");
@@ -58,27 +11,13 @@ type Child = React.ReactElement & {
   type: { $$typeof: symbol };
 };
 
-/**
- * mergeProps
- *
- * Merges props from the slot (parent/wrapper) with props from the child component.
- * This follows the same approach as Radix's Slot component to ensure compatibility.
- *
- * MERGE STRATEGY:
- * - Event handlers (onX): Compose them so both parent and child handlers run
- * - style: Merge objects (child styles override parent styles with same keys)
- * - className: Concatenate both class strings
- * - Other props: Child props override parent props
- *
- * @see https://github.com/radix-ui/primitives/blob/main/packages/react/slot/src/Slot.tsx
- */
 const mergeProps = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   slotProps: Record<string, any>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   childProps: Record<string, any>,
 ) => {
-  // all child props should override
+  // Match Slot-style precedence: child props win unless a prop needs composition.
   const overrideProps = { ...childProps };
 
   for (const propName in childProps) {
@@ -87,20 +26,21 @@ const mergeProps = (
 
     const isHandler = /^on[A-Z]/.test(propName);
     if (isHandler) {
-      // if the handler exists on both, we compose them
       if (slotPropValue && childPropValue) {
         overrideProps[propName] = (...args: unknown[]) => {
+          // Child handlers run first so they can observe their original event
+          // before the wrapper primitive reacts to it.
           childPropValue(...args);
           slotPropValue(...args);
         };
-      }
-      // but if it exists only on the slot, we use only this one
-      else if (slotPropValue) {
+      } else if (slotPropValue) {
+        // Slot-only handlers still need to be forwarded when the child did not
+        // define that interaction prop itself.
         overrideProps[propName] = slotPropValue;
       }
-    }
-    // if it's `style`, we merge them
-    else if (propName === "style") {
+    } else if (propName === "style") {
+      // Keep both style objects while preserving child override behavior for
+      // conflicting keys.
       overrideProps[propName] = { ...slotPropValue, ...childPropValue };
     } else if (propName === "className") {
       overrideProps[propName] = [slotPropValue, childPropValue]
@@ -112,32 +52,6 @@ const mergeProps = (
   return { ...slotProps, ...overrideProps };
 };
 
-/**
- * applyRefProps
- *
- * Clones child elements and applies the forwarded ref and any merged props to them.
- *
- * KEY DECISIONS:
- *
- * 1. ForwardRef Detection:
- *    We check if a child is a forwardRef component by inspecting its $$typeof symbol.
- *    This is necessary because forwardRef components EXPECT a `ref` prop, while
- *    regular function components would throw a warning if given one.
- *
- * 2. Dual Ref Forwarding (forwardRef components):
- *    For forwardRef components, we pass BOTH `ref` and `tgphRef` because:
- *    - They might be third-party components that only understand `ref`
- *    - They might be Telegraph components that need `tgphRef`
- *    - Passing both ensures compatibility with all cases
- *
- * 3. Single Ref Forwarding (regular components):
- *    For non-forwardRef components, we only pass `tgphRef` to avoid React warnings
- *    about function components receiving refs.
- *
- * 4. Ref Priority:
- *    If a child already has a `tgphRef`, we use that instead of the forwarded ref.
- *    This allows child components to override ref behavior if needed.
- */
 const applyRefProps = (
   { children, ...props }: ApplyRefPropsProps,
   ref: React.Ref<unknown>,
@@ -152,100 +66,58 @@ const applyRefProps = (
       const childProps = validChild.props as Record<string, unknown>;
       const tgphRef = childProps.tgphRef;
 
-      // CASE 1: ForwardRef Component
-      // Pass both `ref` and `tgphRef` to ensure compatibility with both
-      // Telegraph components and third-party forwardRef components.
       if (
         $$typeof === FORWARD_REF_SYMBOL ||
         $$typeofType === FORWARD_REF_SYMBOL
       ) {
         return React.cloneElement(validChild, {
           ...mergeProps(props, childProps as Record<string, unknown>),
+          // ForwardRef children may be third-party components that only read
+          // `ref` or Telegraph components that still expect `tgphRef`.
           tgphRef: tgphRef || ref,
           ref: tgphRef || ref,
         } as Record<string, unknown>);
       }
 
-      // CASE 2: Regular Component
-      // Only pass `tgphRef` to avoid React warnings about function components
-      // receiving refs (which would happen if we passed `ref`).
       return React.cloneElement(validChild, {
         ...mergeProps(props, childProps as Record<string, unknown>),
+        // Plain function children cannot receive a React ref without warnings,
+        // so bridge through Telegraph's custom ref prop only.
         tgphRef: tgphRef || ref,
       } as Record<string, unknown>);
     }
 
-    // CASE 3: Non-element children (strings, numbers, etc.)
-    // Return as-is since they can't receive refs or props.
     return child;
   });
 };
 
-/**
- * RefToTgphRef Component Implementation
- *
- * TYPE CONSTRAINTS:
- * We use `any` for the ref type because this component must accept refs of any type
- * (HTMLButtonElement, HTMLDivElement, custom component refs, etc.). Since we're
- * forwarding refs generically, there's no way to statically type this without
- * making the API cumbersome.
- */
+// This adapter accepts refs for many element types, so keeping the forwarded ref
+// generic avoids forcing every caller into one DOM element shape.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const RefToTgphRef = React.forwardRef<any, any>(
   ({ children: childrenProp, ...props }, ref) => {
-    /**
-     * REF STABILIZATION ARCHITECTURE
-     *
-     * PROBLEM:
-     * Libraries like Radix create new ref callback functions on every render.
-     * If we pass these unstable refs directly to children via React.cloneElement,
-     * React sees the props object as changed (new function reference), causing
-     * unnecessary re-renders and potential infinite loops.
-     *
-     * SOLUTION OVERVIEW:
-     * Create a stable callback (stableRef) that never changes (empty deps array),
-     * but internally reads from a mutable storage to get the latest ref. This way:
-     * - Children receive the same function reference every render (no infinite loops)
-     * - The function still forwards to the latest ref (functionality preserved)
-     *
-     */
-
-    // Storage for the latest ref callback/object from parent (e.g., Radix)
-    // This gets updated on every render but doesn't cause re-renders since it's
-    // a mutable ref, not state.
+    // Parent primitives can recreate ref callbacks every render; store the
+    // latest one behind a stable callback so cloned children do not see a new
+    // ref prop and loop.
     const refStorage = React.useRef(ref);
 
-    // Storage for the current DOM node/component instance
-    // We need this to handle ref changes properly (cleanup old, set new)
+    // Track the currently mounted node so a ref identity change can be replayed
+    // without waiting for the child to remount.
     const nodeStorage = React.useRef<unknown>(null);
 
-    /**
-     * REF CHANGE HANDLING
-     *
-     * When the parent ref changes (rare, but possible), we need to:
-     * 1. Call the OLD ref with null (cleanup - standard React behavior)
-     * 2. Call the NEW ref with the current node (re-attach)
-     *
-     * This matches React's native behavior when a ref prop changes.
-     *
-     * WHY IN useEffect:
-     * We use useEffect (not direct assignment) because we need to detect when
-     * the ref has actually changed between renders and perform cleanup/setup.
-     */
     React.useEffect(() => {
       const prevRef = refStorage.current;
       const currentNode = nodeStorage.current;
 
-      // Detect ref change
       if (prevRef !== ref && currentNode) {
-        // Step 1: Cleanup old ref (call with null)
+        // Mirror React's native ref replacement behavior by clearing the old
+        // ref before attaching the latest ref to the already-mounted node.
         if (typeof prevRef === "function") {
           prevRef(null);
         } else if (prevRef) {
           (prevRef as React.MutableRefObject<unknown>).current = null;
         }
 
-        // Step 2: Set new ref with current node
         if (typeof ref === "function") {
           ref(currentNode);
         } else if (ref) {
@@ -253,40 +125,25 @@ const RefToTgphRef = React.forwardRef<any, any>(
         }
       }
 
-      // Update storage with latest ref for next render
       refStorage.current = ref;
     });
 
-    /**
-     * STABLE REF CALLBACK
-     *
-     * This is the key to preventing infinite loops. The function reference
-     * returned by useCallback with an empty dependency array NEVER changes.
-     *
-     * When called (by React when attaching/detaching from DOM):
-     * 1. Store the node so we can handle ref changes
-     * 2. Read the LATEST ref from refStorage
-     * 3. Forward the call to that ref
-     *
-     * This indirection gives us stability (no infinite loops) while maintaining
-     * correctness (always calls the latest ref).
-     */
     const stableRef = React.useCallback((node: unknown) => {
-      // Store node for ref change handling
+      // Keep the node available for the effect above if the parent swaps refs
+      // after this callback was attached.
       nodeStorage.current = node;
 
-      // Get the current ref (might have been updated since last call)
       const currentRef = refStorage.current;
 
-      // Forward to the actual ref (handle both callback refs and ref objects)
+      // The callback identity is stable, but the target ref it forwards to is
+      // always the latest parent ref from storage.
       if (typeof currentRef === "function") {
         currentRef(node);
       } else if (currentRef) {
         (currentRef as React.MutableRefObject<unknown>).current = node;
       }
-    }, []); // Empty deps = stable function reference forever
+    }, []);
 
-    // Apply the stable ref and merged props to children
     return applyRefProps({ children: childrenProp, ...props }, stableRef);
   },
 );

--- a/packages/helpers/src/components/TgphSlot/TgphSlot.test.tsx
+++ b/packages/helpers/src/components/TgphSlot/TgphSlot.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  forwardRef,
+} from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TgphSlot } from "./TgphSlot";
+
+type TelegraphButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TelegraphButton = ({ tgphRef, ...props }: TelegraphButtonProps) => {
+  return <button ref={tgphRef} type="button" {...props} />;
+};
+
+type TrackingTelegraphButtonProps = TelegraphButtonProps & {
+  onTgphRefChange: (tgphRef: TelegraphButtonProps["tgphRef"]) => void;
+};
+
+const TrackingTelegraphButton = ({
+  tgphRef,
+  onTgphRefChange,
+  ...props
+}: TrackingTelegraphButtonProps) => {
+  onTgphRefChange(tgphRef);
+
+  return <button ref={tgphRef} type="button" {...props} />;
+};
+
+const ForwardRefButton = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button">
+>((props, ref) => {
+  return <button ref={ref} type="button" {...props} />;
+});
+
+describe("TgphSlot", () => {
+  it("merges props and refs into native children", async () => {
+    const childClick = vi.fn();
+    const slotClick = vi.fn();
+    const ref = createRef<HTMLButtonElement>();
+    const user = userEvent.setup();
+
+    render(
+      <TgphSlot
+        aria-expanded
+        className="slot"
+        data-testid="native-button"
+        onClick={slotClick}
+        ref={ref}
+      >
+        <button className="child" onClick={childClick} type="button">
+          Open
+        </button>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByTestId("native-button");
+    await user.click(button);
+
+    expect(button).toHaveClass("child");
+    expect(button).toHaveClass("slot");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(slotClick).toHaveBeenCalledOnce();
+    expect(ref.current).toBe(button);
+  });
+
+  it("maps refs to tgphRef for Telegraph-style children", () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    render(
+      <TgphSlot data-testid="telegraph-button" ref={ref}>
+        <TelegraphButton>Open</TelegraphButton>
+      </TgphSlot>,
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("telegraph-button"));
+  });
+
+  it("keeps child tgphRef stable when parent refs change", () => {
+    const firstRef = vi.fn();
+    const secondRef = vi.fn();
+    const seenTgphRefs: TelegraphButtonProps["tgphRef"][] = [];
+
+    const { rerender } = render(
+      <TgphSlot ref={firstRef}>
+        <TrackingTelegraphButton
+          onTgphRefChange={(tgphRef) => seenTgphRefs.push(tgphRef)}
+        >
+          Open
+        </TrackingTelegraphButton>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByRole("button", { name: "Open" });
+    const stableTgphRef = seenTgphRefs.at(-1);
+
+    rerender(
+      <TgphSlot ref={secondRef}>
+        <TrackingTelegraphButton
+          onTgphRefChange={(tgphRef) => seenTgphRefs.push(tgphRef)}
+        >
+          Open
+        </TrackingTelegraphButton>
+      </TgphSlot>,
+    );
+
+    expect(seenTgphRefs.at(-1)).toBe(stableTgphRef);
+    expect(firstRef).toHaveBeenCalledWith(button);
+    expect(firstRef).toHaveBeenLastCalledWith(null);
+    expect(secondRef).toHaveBeenCalledWith(button);
+  });
+
+  it("composes refs with existing tgphRef props on Telegraph-style children", () => {
+    const childRef = createRef<HTMLButtonElement>();
+    const slotRef = createRef<HTMLButtonElement>();
+
+    render(
+      <TgphSlot ref={slotRef}>
+        <TelegraphButton tgphRef={childRef}>Open</TelegraphButton>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByRole("button", { name: "Open" });
+
+    expect(childRef.current).toBe(button);
+    expect(slotRef.current).toBe(button);
+  });
+
+  it("preserves ref support for custom forwardRef children without leaking tgphRef", () => {
+    const childRef = createRef<HTMLButtonElement>();
+    const slotRef = createRef<HTMLButtonElement>();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      render(
+        <TgphSlot data-testid="forward-ref-button" ref={slotRef}>
+          <ForwardRefButton ref={childRef}>Open</ForwardRefButton>
+        </TgphSlot>,
+      );
+
+      const button = screen.getByTestId("forward-ref-button");
+
+      expect(slotRef.current).toBe(button);
+      expect(childRef.current).toBe(button);
+      expect(button).not.toHaveAttribute("tgphRef");
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("does not recognize the `tgphRef` prop"),
+        expect.anything(),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/helpers/src/components/TgphSlot/TgphSlot.tsx
+++ b/packages/helpers/src/components/TgphSlot/TgphSlot.tsx
@@ -1,0 +1,225 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import {
+  Children,
+  type ComponentPropsWithRef,
+  type MutableRefObject,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefAttributes,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+
+// React marks forwardRef components with this symbol in the element metadata.
+// Checking it lets us decide whether a child can safely receive `ref`.
+const FORWARD_REF_SYMBOL = Symbol.for("react.forward_ref");
+
+type TgphSlotProps = ComponentPropsWithRef<"span"> &
+  Record<string, unknown> & {
+    children?: ReactNode;
+  };
+
+type SlottableChildProps = Record<string, unknown> &
+  RefAttributes<HTMLElement> & {
+    tgphRef?: Ref<HTMLElement>;
+  };
+
+type IntrinsicMergeProps = ComponentPropsWithRef<"span">;
+
+type ElementWithRef = ReactElement<SlottableChildProps> & {
+  $$typeof?: symbol;
+  ref?: Ref<HTMLElement>;
+  type:
+    | string
+    | {
+        $$typeof?: symbol;
+      };
+};
+
+type WarningGetter = (() => unknown) & {
+  isReactWarning?: boolean;
+};
+
+const isReactWarningGetter = (
+  getter: (() => unknown) | undefined,
+): getter is WarningGetter => {
+  return Boolean(getter && "isReactWarning" in getter && getter.isReactWarning);
+};
+
+// React 18 and 19 expose child refs differently. Reading the wrong location can
+// trigger React's dev warning getter, so mirror Radix's defensive extraction
+// before composing the wrapper ref with the child's existing ref.
+const getElementRef = (element: ReactElement<SlottableChildProps>) => {
+  const propsRefGetter = Object.getOwnPropertyDescriptor(
+    element.props,
+    "ref",
+  )?.get;
+
+  if (isReactWarningGetter(propsRefGetter)) {
+    // React 18 can hide the real ref on the element when props.ref is only the
+    // dev warning getter, so read the element field in that case.
+    return (element as ElementWithRef).ref;
+  }
+
+  const elementRefGetter = Object.getOwnPropertyDescriptor(element, "ref")?.get;
+
+  if (isReactWarningGetter(elementRefGetter)) {
+    // React 19 moves refs into props; if element.ref is the warning getter,
+    // prefer the props ref so we do not trip the warning while composing refs.
+    return element.props.ref;
+  }
+
+  return element.props.ref ?? (element as ElementWithRef).ref;
+};
+
+const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref !== null && ref !== undefined) {
+    (ref as MutableRefObject<T | null>).current = value;
+  }
+};
+
+const composeRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
+  return (node: T | null) => {
+    refs.forEach((ref) => setRef(ref, node));
+  };
+};
+
+const getDefinedRefs = <T,>(refs: (Ref<T> | undefined)[]) => {
+  return refs.filter((ref): ref is Ref<T> => Boolean(ref));
+};
+
+const areRefsEqual = <T,>(refs: Ref<T>[], nextRefs: Ref<T>[]) => {
+  return (
+    refs.length === nextRefs.length &&
+    refs.every((ref, index) => ref === nextRefs[index])
+  );
+};
+
+const useStableComposedRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
+  const definedRefs = getDefinedRefs(refs);
+  const refsStorage = useRef(definedRefs);
+  const previousRefsStorage = useRef(definedRefs);
+  const nodeStorage = useRef<T | null>(null);
+
+  // Keep the returned callback stable while still giving it the latest refs.
+  refsStorage.current = definedRefs;
+
+  useEffect(() => {
+    const previousRefs = previousRefsStorage.current;
+    const currentRefs = refsStorage.current;
+    const currentNode = nodeStorage.current;
+
+    if (currentNode && !areRefsEqual(previousRefs, currentRefs)) {
+      // A child can add or remove refs between renders; clear removed refs and
+      // replay the mounted node to newly introduced refs without remounting it.
+      previousRefs.forEach((ref) => {
+        if (!currentRefs.includes(ref)) {
+          setRef(ref, null);
+        }
+      });
+
+      currentRefs.forEach((ref) => {
+        if (!previousRefs.includes(ref)) {
+          setRef(ref, currentNode);
+        }
+      });
+    }
+
+    previousRefsStorage.current = currentRefs;
+  });
+
+  const stableRef = useCallback((node: T | null) => {
+    // Store the latest node so the effect above can sync refs that appear after
+    // the callback was originally attached.
+    nodeStorage.current = node;
+    composeRefs(...refsStorage.current)(node);
+  }, []);
+
+  return definedRefs.length > 0 ? stableRef : undefined;
+};
+
+const isIntrinsicElement = (element: ElementWithRef) => {
+  return typeof element.type === "string";
+};
+
+const isForwardRefElement = (element: ElementWithRef) => {
+  return (
+    element.$$typeof === FORWARD_REF_SYMBOL ||
+    (typeof element.type !== "string" &&
+      element.type.$$typeof === FORWARD_REF_SYMBOL)
+  );
+};
+
+const getRefProps = (
+  child: ReactElement<SlottableChildProps>,
+  composedRef: Ref<HTMLElement> | undefined,
+  composedTgphRef: Ref<HTMLElement> | undefined,
+) => {
+  const childTgphRef = child.props.tgphRef;
+
+  if (!composedRef && !childTgphRef) {
+    return {};
+  }
+
+  const element = child as ElementWithRef;
+
+  if (isIntrinsicElement(element)) {
+    return { ref: composedRef };
+  }
+
+  // ForwardRef children already have a standard React ref channel. Only keep
+  // the Telegraph ref channel when the child explicitly opted into tgphRef.
+  if (isForwardRefElement(element)) {
+    return {
+      ...(composedRef ? { ref: composedRef } : {}),
+      ...(childTgphRef && composedTgphRef ? { tgphRef: composedTgphRef } : {}),
+    };
+  }
+
+  // Plain function components cannot receive `ref` without React warnings, so
+  // pass only `tgphRef` for Telegraph-style components that do not forward refs.
+  return {
+    ...(composedTgphRef ? { tgphRef: composedTgphRef } : {}),
+  };
+};
+
+const TgphSlot = forwardRef<HTMLElement, TgphSlotProps>(
+  ({ children, ...props }, forwardedRef) => {
+    // Match Radix Slot's one-child contract before cloning wrapper props into
+    // the child element.
+    const child = Children.only(children);
+    const slottableChild = isValidElement<SlottableChildProps>(child)
+      ? child
+      : null;
+    // Compose the wrapper ref with whichever ref API the child already uses so
+    // consumers keep their existing `ref` and `tgphRef` behavior.
+    const childRef = slottableChild ? getElementRef(slottableChild) : undefined;
+    const childTgphRef = slottableChild?.props.tgphRef;
+    const composedRef = useStableComposedRefs(forwardedRef, childRef);
+    const composedTgphRef = useStableComposedRefs(forwardedRef, childTgphRef);
+
+    if (!slottableChild) {
+      return null;
+    }
+
+    return cloneElement(slottableChild, {
+      // Merge events, className, and data attributes before assigning the
+      // compatible ref props chosen for this specific child shape.
+      ...mergeProps(
+        props as IntrinsicMergeProps,
+        slottableChild.props as IntrinsicMergeProps,
+      ),
+      ...getRefProps(slottableChild, composedRef, composedTgphRef),
+    });
+  },
+);
+
+export { TgphSlot };
+export type { TgphSlotProps };

--- a/packages/helpers/src/components/TgphSlot/index.ts
+++ b/packages/helpers/src/components/TgphSlot/index.ts
@@ -1,0 +1,1 @@
+export { TgphSlot, type TgphSlotProps } from "./TgphSlot";

--- a/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VisuallyHidden } from "./VisuallyHidden";
+
+describe("VisuallyHidden", () => {
+  it("renders content with visually hidden styles", () => {
+    render(<VisuallyHidden>Hidden label</VisuallyHidden>);
+
+    expect(screen.getByText("Hidden label")).toHaveStyle({
+      position: "absolute",
+      width: "1px",
+      height: "1px",
+      overflow: "hidden",
+    });
+  });
+
+  it("merges custom styles", () => {
+    render(
+      <VisuallyHidden style={{ whiteSpace: "normal" }}>
+        Wrapped label
+      </VisuallyHidden>,
+    );
+
+    expect(screen.getByText("Wrapped label")).toHaveStyle({
+      whiteSpace: "normal",
+    });
+  });
+
+  it("renders through TgphSlot when asChild is true", () => {
+    render(
+      <VisuallyHidden asChild>
+        <label htmlFor="email">Email</label>
+      </VisuallyHidden>,
+    );
+
+    expect(screen.getByText("Email").tagName).toBe("LABEL");
+    expect(screen.getByText("Email")).toHaveAttribute("for", "email");
+  });
+});

--- a/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,56 @@
+import {
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+
+import { TgphSlot } from "../TgphSlot";
+
+// Shared a11y-only styles used by migrated primitives that previously relied on
+// Radix VisuallyHidden. Keep this object frozen so callers cannot mutate the
+// base style contract across component instances.
+const VISUALLY_HIDDEN_STYLES = Object.freeze({
+  position: "absolute",
+  border: 0,
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  wordWrap: "normal",
+} satisfies CSSProperties);
+
+export type VisuallyHiddenProps = ComponentPropsWithoutRef<"span"> & {
+  asChild?: boolean;
+  children?: ReactNode;
+};
+
+const getVisuallyHiddenStyle = (
+  style: CSSProperties | undefined,
+): CSSProperties => {
+  return {
+    ...VISUALLY_HIDDEN_STYLES,
+    ...style,
+  };
+};
+
+export const VisuallyHidden = ({
+  asChild = false,
+  style,
+  ...props
+}: VisuallyHiddenProps) => {
+  const visuallyHiddenProps = {
+    style: getVisuallyHiddenStyle(style),
+    ...props,
+  };
+
+  if (asChild) {
+    // `asChild` lets consumers hide an existing semantic node, such as `label`
+    // or Base UI's title/description element, without adding an extra wrapper.
+    return <TgphSlot {...visuallyHiddenProps} />;
+  }
+
+  return <span {...visuallyHiddenProps} />;
+};

--- a/packages/helpers/src/components/VisuallyHidden/index.ts
+++ b/packages/helpers/src/components/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export { VisuallyHidden, type VisuallyHiddenProps } from "./VisuallyHidden";

--- a/packages/helpers/src/hooks/useControllableState.test.tsx
+++ b/packages/helpers/src/hooks/useControllableState.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useControllableState } from "./useControllableState";
+
+const UncontrolledStateExample = ({
+  onChange,
+}: {
+  onChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useControllableState({
+    defaultProp: "one",
+    onChange,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("two")}>
+        Set two
+      </button>
+    </>
+  );
+};
+
+const DuplicateUpdateExample = ({
+  onChange,
+}: {
+  onChange?: (value: boolean) => void;
+}) => {
+  const [, setValue] = useControllableState({
+    defaultProp: true,
+    onChange,
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setValue(false);
+        setValue(false);
+      }}
+    >
+      Close twice
+    </button>
+  );
+};
+
+const ControlledStateExample = ({
+  onChange,
+}: {
+  onChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useControllableState({
+    prop: "controlled",
+    defaultProp: "uncontrolled",
+    onChange,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("requested")}>
+        Request update
+      </button>
+    </>
+  );
+};
+
+const UpdaterExample = () => {
+  const [value, setValue] = useControllableState({
+    defaultProp: 1,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue((current) => current + 1)}>
+        Increment
+      </button>
+    </>
+  );
+};
+
+const ControlledRerenderExample = () => {
+  const [controlledValue, setControlledValue] = useState("one");
+  const [value, setValue] = useControllableState({
+    prop: controlledValue,
+    defaultProp: "fallback",
+    onChange: setControlledValue,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("two")}>
+        Set controlled value
+      </button>
+    </>
+  );
+};
+
+describe("useControllableState", () => {
+  it("updates uncontrolled state and calls onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<UncontrolledStateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Set two" }));
+
+    expect(screen.getByText("two")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("two");
+  });
+
+  it("dedupes same-value uncontrolled updates before rerender", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<DuplicateUpdateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Close twice" }));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("requests controlled updates without changing the current value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ControlledStateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Request update" }));
+
+    expect(screen.getByText("controlled")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("requested");
+  });
+
+  it("supports updater functions", async () => {
+    const user = userEvent.setup();
+
+    render(<UpdaterExample />);
+
+    await user.click(screen.getByRole("button", { name: "Increment" }));
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("uses the next controlled prop after onChange updates it", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledRerenderExample />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Set controlled value" }),
+    );
+
+    expect(screen.getByText("two")).toBeInTheDocument();
+  });
+});

--- a/packages/helpers/src/hooks/useControllableState.ts
+++ b/packages/helpers/src/hooks/useControllableState.ts
@@ -1,0 +1,61 @@
+import {
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type UseControllableStateParams<T> = {
+  defaultProp: T;
+  onChange?: (value: T) => void;
+  prop?: T;
+};
+
+export const useControllableState = <T>({
+  defaultProp,
+  onChange,
+  prop,
+}: UseControllableStateParams<T>) => {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultProp);
+  // Keep the current uncontrolled value available to the setter without making
+  // the setter depend on every value change. That keeps callback identity stable
+  // for component primitives that pass setters through context.
+  const uncontrolledValueRef = useRef(uncontrolledValue);
+  // `undefined` keeps the previous Radix-style contract: anything else means
+  // the caller owns the value and we only emit changes.
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolledValue;
+
+  useEffect(() => {
+    uncontrolledValueRef.current = uncontrolledValue;
+  }, [uncontrolledValue]);
+
+  const setValue = useCallback(
+    (nextValueOrUpdater: SetStateAction<T>) => {
+      // React-style updater functions need the freshest value from the active
+      // source, not a stale value captured when this setter was created.
+      const currentValue = isControlled ? prop : uncontrolledValueRef.current;
+      const nextValue =
+        typeof nextValueOrUpdater === "function"
+          ? (nextValueOrUpdater as (previousValue: T) => T)(currentValue)
+          : nextValueOrUpdater;
+
+      if (Object.is(currentValue, nextValue)) {
+        return;
+      }
+
+      if (!isControlled) {
+        // Update the ref before React commits state so multiple same-tick setter
+        // calls compare against the latest queued uncontrolled value.
+        uncontrolledValueRef.current = nextValue;
+        setUncontrolledValue(nextValue);
+      }
+
+      onChange?.(nextValue);
+    },
+    [isControlled, onChange, prop],
+  );
+
+  return [value, setValue] as const;
+};

--- a/packages/helpers/src/hooks/useDeterminateState.ts
+++ b/packages/helpers/src/hooks/useDeterminateState.ts
@@ -7,7 +7,7 @@
  * to the user that the action is being processed.
  *
  */
-import React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type UseDeterminateStateParams<T> = {
   value: T;
@@ -20,9 +20,9 @@ const useDeterminateState = <T>({
   determinateValue,
   minDurationMs = 1000,
 }: UseDeterminateStateParams<T>): T => {
-  const [state, setState] = React.useState<T>(value);
-  const timeoutRef = React.useRef<NodeJS.Timeout | null>(null);
-  const startTimeRef = React.useRef<number | null>(null);
+  const [state, setState] = useState<T>(value);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number | null>(null);
 
   const clearExistingTimeout = () => {
     if (timeoutRef.current) {
@@ -31,7 +31,7 @@ const useDeterminateState = <T>({
     }
   };
 
-  const handleTransition = React.useCallback(() => {
+  const handleTransition = useCallback(() => {
     if (value === determinateValue) {
       clearExistingTimeout();
       setState(determinateValue);
@@ -55,7 +55,7 @@ const useDeterminateState = <T>({
     }
   }, [value, determinateValue, minDurationMs]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     handleTransition();
     return clearExistingTimeout;
   }, [value, handleTransition]);

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -14,3 +14,8 @@ export type {
 export { RefToTgphRef } from "./components/RefToTgphRef";
 
 export { useDeterminateState } from "./hooks/useDeterminateState";
+
+export {
+  createTgphBaseUIRender,
+  type TgphBaseUIRenderElement,
+} from "./base-ui";

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -22,6 +22,14 @@ export { useControllableState } from "./hooks/useControllableState";
 export { useDeterminateState } from "./hooks/useDeterminateState";
 
 export {
+  callLegacyDismissHandlers,
   createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+  type BaseUIChangeDetails,
+  type BaseUIFloatingSide,
+  type BaseUIPositionerVisibilityStyleParams,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type TgphBaseUIRenderElement,
 } from "./base-ui";

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -12,7 +12,13 @@ export type {
 } from "./types/utility";
 
 export { RefToTgphRef } from "./components/RefToTgphRef";
+export { TgphSlot, type TgphSlotProps } from "./components/TgphSlot";
+export {
+  VisuallyHidden,
+  type VisuallyHiddenProps,
+} from "./components/VisuallyHidden";
 
+export { useControllableState } from "./hooks/useControllableState";
 export { useDeterminateState } from "./hooks/useDeterminateState";
 
 export {

--- a/packages/helpers/vitest.config.mts
+++ b/packages/helpers/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "helpers",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -73,23 +73,25 @@ For advanced use cases, use the composition API:
 
 Container component that wraps the input and slots.
 
-| Prop         | Type                   | Default     | Description                         |
-| ------------ | ---------------------- | ----------- | ----------------------------------- |
-| `size`       | `"1" \| "2" \| "3"`    | `"2"`       | Input size                          |
-| `variant`    | `"outline" \| "ghost"` | `"outline"` | Visual style variant                |
-| `errored`    | `boolean`              | `false`     | Shows error state styling           |
-| `disabled`   | `boolean`              | `false`     | Disables the input                  |
-| `textProps`  | `object`               | `undefined` | Props to pass to the inner Text component  |
-| `stackProps` | `object`               | `undefined` | Props to pass to the Stack container       |
-| `as`         | `TgphElement`          | `"input"`   | HTML element or component to render |
+| Prop         | Type                   | Default     | Description                               |
+| ------------ | ---------------------- | ----------- | ----------------------------------------- |
+| `size`       | `"1" \| "2" \| "3"`    | `"2"`       | Input size                                |
+| `variant`    | `"outline" \| "ghost"` | `"outline"` | Visual style variant                      |
+| `errored`    | `boolean`              | `false`     | Shows error state styling                 |
+| `disabled`   | `boolean`              | `false`     | Disables the input                        |
+| `textProps`  | `object`               | `undefined` | Props to pass to the inner Text component |
+| `stackProps` | `object`               | `undefined` | Props to pass to the Stack container      |
+| `as`         | `TgphElement`          | `"input"`   | HTML element or component to render       |
 
 #### `<Input.Slot>`
 
-Wrapper for leading and trailing components.
+Wrapper for leading and trailing components. Props passed to `Input.Slot` are
+merged into its single child, and refs are forwarded to that child.
 
 | Prop       | Type                      | Default     | Description          |
 | ---------- | ------------------------- | ----------- | -------------------- |
 | `position` | `"leading" \| "trailing"` | `"leading"` | Position of the slot |
+| `size`     | `"1" \| "2" \| "3"`       | Root size   | Slot size override   |
 
 ## Usage Patterns
 

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -32,7 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4",
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/input/src/Input/Input.test.tsx
+++ b/packages/input/src/Input/Input.test.tsx
@@ -1,9 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Input } from "./Input";
 import type { InputProps, InputRootProps } from "./index";
 
 describe("Input", () => {
+  it("renders slot data attributes and forwards props to the child", () => {
+    render(
+      <Input.Root>
+        <Input.Slot
+          className="slot-child"
+          data-testid="slot-button"
+          position="trailing"
+        >
+          <button className="child" type="button">
+            Action
+          </button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    const slot = document.querySelector("[data-tgph-input-slot]");
+    const button = screen.getByTestId("slot-button");
+
+    expect(slot).toHaveAttribute("data-tgph-input-slot-position", "trailing");
+    expect(slot).toHaveAttribute("data-tgph-input-slot-size", "2");
+    expect(button).toHaveClass("child");
+    expect(button).toHaveClass("slot-child");
+  });
+
+  it("uses explicit slot size for data attributes and child props", () => {
+    render(
+      <Input.Root size="1">
+        <Input.Slot data-testid="slot-button" position="leading" size="3">
+          <button type="button">Action</button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    const slot = document.querySelector("[data-tgph-input-slot]");
+    const button = screen.getByTestId("slot-button");
+
+    expect(slot).toHaveAttribute("data-tgph-input-slot-position", "leading");
+    expect(slot).toHaveAttribute("data-tgph-input-slot-size", "3");
+    expect(button).toHaveAttribute("size", "3");
+  });
+
+  it("forwards Input.Slot refs to the slotted child", () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    render(
+      <Input.Root>
+        <Input.Slot data-testid="slot-button" ref={ref}>
+          <button type="button">Action</button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("slot-button"));
+  });
+
   describe("type inheritance", () => {
     it("accepts valid input-specific props", () => {
       const validProps: InputRootProps = {

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -1,14 +1,23 @@
-import { Slot as RadixSlot } from "@radix-ui/react-slot";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import type {
   PolymorphicProps,
   Required,
   TgphComponentProps,
   TgphElement,
+  TgphSlotProps,
 } from "@telegraph/helpers";
+import { TgphSlot } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
-import React from "react";
+import {
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+  createContext,
+  forwardRef,
+  useContext,
+  useRef,
+} from "react";
 
 import { COLOR, SIZE } from "./Input.constants";
 
@@ -19,15 +28,15 @@ export type BaseRootProps = {
 };
 
 export type RootProps<T extends TgphElement = "input"> = BaseRootProps & {
-  textProps?: Omit<React.ComponentProps<typeof Text<T>>, "as">;
-  stackProps?: Omit<React.ComponentProps<typeof Stack>, "as">;
-} & Omit<React.ComponentProps<typeof Text<T>>, "as" | keyof BaseRootProps>;
+  textProps?: Omit<ComponentProps<typeof Text<T>>, "as">;
+  stackProps?: Omit<ComponentProps<typeof Stack>, "as">;
+} & Omit<ComponentProps<typeof Text<T>>, "as" | keyof BaseRootProps>;
 
 type InternalProps = Omit<BaseRootProps, "errored"> & {
   state: "default" | "disabled" | "error";
 };
 
-const InputContext = React.createContext<Required<InternalProps>>({
+const InputContext = createContext<Required<InternalProps>>({
   state: "default",
   size: "2",
   variant: "outline",
@@ -46,7 +55,7 @@ const Root = <T extends TgphElement = "input">({
   ...props
 }: RootProps<T>) => {
   const Component = as;
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const composedRefs = useComposedRefs(tgphRef, inputRef);
 
   const state = disabled ? "disabled" : errored ? "error" : "default";
@@ -55,7 +64,7 @@ const Root = <T extends TgphElement = "input">({
     <InputContext.Provider value={{ size, variant, state }}>
       <Stack
         // Focus the input when clicking on the container
-        onPointerDown={(event: React.MouseEvent<HTMLDivElement>) => {
+        onPointerDown={(event: MouseEvent<HTMLDivElement>) => {
           const target = event.target as HTMLElement;
 
           // Make sure we're not clicking on an interactive element
@@ -104,15 +113,17 @@ const Root = <T extends TgphElement = "input">({
   );
 };
 
-export type SlotProps = React.ComponentPropsWithoutRef<typeof RadixSlot> & {
+export type SlotProps = Omit<TgphSlotProps, "size"> & {
   size?: "1" | "2" | "3";
   position?: "leading" | "trailing";
 };
-type SlotRef = React.ElementRef<typeof RadixSlot>;
+type SlotRef = HTMLElement;
 
-const Slot = React.forwardRef<SlotRef, SlotProps>(
+const Slot = forwardRef<SlotRef, SlotProps>(
   ({ position = "leading", ...props }, forwardedRef) => {
-    const context = React.useContext(InputContext);
+    const context = useContext(InputContext);
+    const slotSize = props.size ?? context.size;
+
     return (
       <Stack
         align="center"
@@ -120,11 +131,11 @@ const Slot = React.forwardRef<SlotRef, SlotProps>(
         h="full"
         data-tgph-input-slot
         data-tgph-input-slot-position={position}
-        data-tgph-input-slot-size={props.size ?? context.size}
+        data-tgph-input-slot-size={slotSize}
         {...(position === "leading" && SIZE.SlotLeading[context.size])}
         {...(position === "trailing" && SIZE.SlotTrailing[context.size])}
       >
-        <RadixSlot size={context.size} {...props} ref={forwardedRef} />
+        <TgphSlot size={slotSize} {...props} ref={forwardedRef} />
       </Stack>
     );
   },
@@ -135,8 +146,8 @@ export type DefaultProps<T extends TgphElement = "input"> = Omit<
   keyof BaseRootProps
 > &
   TgphComponentProps<typeof Root> & {
-    LeadingComponent?: React.ReactNode;
-    TrailingComponent?: React.ReactNode;
+    LeadingComponent?: ReactNode;
+    TrailingComponent?: ReactNode;
   };
 
 const Default = <T extends TgphElement = "input">({

--- a/packages/input/vitest.config.mts
+++ b/packages/input/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "input",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/layout/src/Box/Box.constants.ts
+++ b/packages/layout/src/Box/Box.constants.ts
@@ -8,6 +8,7 @@ import type { CSSProperties } from "react";
 
 // Type that allows both positive and negative spacing values
 type SpacingValue = WithNegativeSpacing<keyof typeof tokens.spacing>;
+type SizeValue = keyof typeof tokens.spacing | (string & {});
 
 export type BaseStyleProps = {
   display: "block" | "inline-block" | "inline" | "flex" | "inline-flex";
@@ -47,12 +48,12 @@ export type BaseStyleProps = {
   borderLeftRadius: keyof typeof tokens.rounded;
   borderRightRadius: keyof typeof tokens.rounded;
   boxShadow: keyof typeof tokens.shadow;
-  width: keyof typeof tokens.spacing;
-  height: keyof typeof tokens.spacing;
-  minWidth: keyof typeof tokens.spacing;
-  minHeight: keyof typeof tokens.spacing;
-  maxWidth: keyof typeof tokens.spacing;
-  maxHeight: keyof typeof tokens.spacing;
+  width: SizeValue;
+  height: SizeValue;
+  minWidth: SizeValue;
+  minHeight: SizeValue;
+  maxWidth: SizeValue;
+  maxHeight: SizeValue;
   zIndex: keyof (typeof tokens)["zIndex"];
   position: "relative" | "absolute" | "fixed" | "sticky";
   top: SpacingValue;
@@ -63,6 +64,7 @@ export type BaseStyleProps = {
   overflowX: "hidden" | "visible" | "scroll" | "auto";
   overflowY: "hidden" | "visible" | "scroll" | "auto";
   alignSelf: CSSProperties["alignSelf"];
+  flexDirection: CSSProperties["flexDirection"];
 };
 
 type ShorthandStyleProps = {
@@ -85,12 +87,12 @@ type ShorthandStyleProps = {
   ml: SpacingValue;
   mr: SpacingValue;
   shadow: keyof typeof tokens.shadow;
-  w: keyof typeof tokens.spacing;
-  h: keyof typeof tokens.spacing;
-  minW: keyof typeof tokens.spacing;
-  minH: keyof typeof tokens.spacing;
-  maxW: keyof typeof tokens.spacing;
-  maxH: keyof typeof tokens.spacing;
+  w: SizeValue;
+  h: SizeValue;
+  minW: SizeValue;
+  minH: SizeValue;
+  maxW: SizeValue;
+  maxH: SizeValue;
   rounded: keyof typeof tokens.rounded;
   roundedTopLeft: keyof typeof tokens.rounded;
   roundedTopRight: keyof typeof tokens.rounded;
@@ -104,6 +106,7 @@ type ShorthandStyleProps = {
   borderBottom: keyof typeof tokens.spacing;
   borderLeft: keyof typeof tokens.spacing;
   borderRight: keyof typeof tokens.spacing;
+  direction: BaseStyleProps["flexDirection"];
 };
 
 const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
@@ -288,26 +291,32 @@ const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
   width: {
     cssVar: "--width",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   height: {
     cssVar: "--height",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   minWidth: {
     cssVar: "--min-width",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   minHeight: {
     cssVar: "--min-height",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   maxWidth: {
     cssVar: "--max-width",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   maxHeight: {
     cssVar: "--max-height",
     value: "var(--tgph-spacing-VARIABLE)",
+    allowRawValue: true,
   },
   zIndex: {
     cssVar: "--z-index",
@@ -352,6 +361,10 @@ const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
     cssVar: "--align-self",
     value: "VARIABLE",
   },
+  flexDirection: {
+    cssVar: "--flex-direction",
+    value: "VARIABLE",
+  },
 } as const;
 
 const shorthandCssVars: Record<keyof ShorthandStyleProps, CssVarProp> = {
@@ -393,6 +406,7 @@ const shorthandCssVars: Record<keyof ShorthandStyleProps, CssVarProp> = {
   borderBottom: baseCssVars.borderBottomWidth,
   borderLeft: baseCssVars.borderLeftWidth,
   borderRight: baseCssVars.borderRightWidth,
+  direction: baseCssVars.flexDirection,
 } as const;
 
 export const cssVars = {

--- a/packages/layout/src/Box/Box.styles.css
+++ b/packages/layout/src/Box/Box.styles.css
@@ -21,6 +21,7 @@
   --bottom: auto;
   --overflow: visible visible;
   --align-self: auto;
+  --flex-direction: row;
 
   background-color: var(--background-color);
   border-width: var(--border-width);
@@ -44,6 +45,7 @@
   bottom: var(--bottom);
   overflow: var(--overflow);
   align-self: var(--align-self);
+  flex-direction: var(--flex-direction);
 }
 
 /* Auto-generates interactive pseudo-class rules (hover, focus, active,

--- a/packages/layout/src/Box/Box.test.tsx
+++ b/packages/layout/src/Box/Box.test.tsx
@@ -159,6 +159,8 @@ describe("Box", () => {
         padding: "2",
         margin: "1",
         display: "flex",
+        direction: "column",
+        maxH: "400px",
       };
       void validProps;
     });
@@ -184,7 +186,14 @@ describe("Box", () => {
 
     it("accepts shorthand props in pseudo objects", () => {
       const shorthands: BoxProps = {
-        _hover: { p: "4", m: "2", rounded: "2", w: "10", h: "8" },
+        _hover: {
+          p: "4",
+          m: "2",
+          rounded: "2",
+          w: "10",
+          h: "8",
+          maxH: "400px",
+        },
       };
       void shorthands;
     });
@@ -227,6 +236,26 @@ describe("Box", () => {
         _disabled: { shadow: "not-a-shadow" },
       };
       void invalid;
+    });
+  });
+
+  describe("flex and size compatibility props", () => {
+    it("applies direction to the flex-direction css variable", () => {
+      const { container } = render(<Box direction="column" />);
+      const box = container.querySelector(".tgph-box");
+
+      expect(box).toHaveStyle({
+        "--flex-direction": "column",
+      });
+    });
+
+    it("passes raw maxH css values through unchanged", () => {
+      const { container } = render(<Box maxH="400px" />);
+      const box = container.querySelector(".tgph-box");
+
+      expect(box).toHaveStyle({
+        "--max-height": "400px",
+      });
     });
   });
 });

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -107,7 +107,9 @@ All Stack props are also supported for additional styling.
 and CSS variables remain available outside the local subtree. The package also
 continues to expose Radix-compatible Popper CSS custom properties, such as
 `--radix-popper-anchor-width` and `--radix-popper-available-height`, mapped to
-Base UI's positioning variables for downstream style compatibility.
+Base UI's positioning variables for downstream style compatibility. The portal
+positioner owns the popover z-index layer so menu-backed popups keep rendering
+above modal overlays and other lower layering surfaces.
 
 ### `<Menu.Button>`
 

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -1,6 +1,6 @@
 # 📋 Menu
 
-> Accessible dropdown menu component built on Radix UI with Telegraph design system styling.
+> Accessible dropdown menu component built on Base UI with Telegraph design system styling.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -88,19 +88,26 @@ The trigger element that opens/closes the menu. Must wrap a single focusable ele
 
 The dropdown content container that holds menu items.
 
-| Prop          | Type                                     | Default    | Description                   |
-| ------------- | ---------------------------------------- | ---------- | ----------------------------- |
-| `side`        | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"` | Side to display menu          |
-| `align`       | `"start" \| "center" \| "end"`           | `"center"` | Alignment relative to trigger |
-| `sideOffset`  | `number`                                 | `4`        | Distance from trigger         |
-| `gap`         | `SpacingToken`                           | `"1"`      | Gap between menu items        |
-| `py`          | `SpacingToken`                           | `"1"`      | Vertical padding              |
-| `rounded`     | `RoundedToken`                           | `"4"`      | Border radius                 |
-| `shadow`      | `ShadowToken`                            | `"2"`      | Drop shadow                   |
-| `border`      | `SpacingToken`                           | `"px"`     | Border width                  |
-| `borderColor` | `ColorToken`                             | `"gray-8"` | Border color                  |
+| Prop          | Type                                     | Default    | Description                      |
+| ------------- | ---------------------------------------- | ---------- | -------------------------------- |
+| `side`        | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"` | Side to display menu             |
+| `align`       | `"start" \| "center" \| "end"`           | `"center"` | Alignment relative to trigger    |
+| `sideOffset`  | `number`                                 | `4`        | Distance from trigger            |
+| `gap`         | `SpacingToken`                           | `"1"`      | Gap between menu items           |
+| `py`          | `SpacingToken`                           | `"1"`      | Vertical padding                 |
+| `rounded`     | `RoundedToken`                           | `"4"`      | Border radius                    |
+| `shadow`      | `ShadowToken`                            | `"2"`      | Drop shadow                      |
+| `border`      | `SpacingToken`                           | `"px"`     | Border width                     |
+| `borderColor` | `ColorToken`                             | `"gray-8"` | Border color                     |
+| `forceMount`  | `boolean`                                | `false`    | Keep content mounted when closed |
 
 All Stack props are also supported for additional styling.
+
+`Menu.Content` renders in a portal with `className="tgph"` so Telegraph styles
+and CSS variables remain available outside the local subtree. The package also
+continues to expose Radix-compatible Popper CSS custom properties, such as
+`--radix-popper-anchor-width` and `--radix-popper-available-height`, mapped to
+Base UI's positioning variables for downstream style compatibility.
 
 ### `<Menu.Button>`
 
@@ -125,23 +132,23 @@ Inherits all Button props for additional styling.
 Groups a `Menu.SubTrigger` with its `Menu.SubContent` to create a nested submenu
 that opens on hover/focus. Render it inside a `Menu.Content`.
 
-| Prop           | Type                      | Default     | Description                      |
-| -------------- | ------------------------- | ----------- | -------------------------------- |
-| `open`         | `boolean`                 | `undefined` | Controlled open state            |
-| `defaultOpen`  | `boolean`                 | `false`     | Initial open state (uncontrolled)|
-| `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes |
+| Prop           | Type                      | Default     | Description                       |
+| -------------- | ------------------------- | ----------- | --------------------------------- |
+| `open`         | `boolean`                 | `undefined` | Controlled open state             |
+| `defaultOpen`  | `boolean`                 | `false`     | Initial open state (uncontrolled) |
+| `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes  |
 
 ### `<Menu.SubTrigger>`
 
 The item inside a `Menu.Sub` that opens the submenu on hover (or `→` / `Enter`).
 Accepts the same props as `Menu.Button` and defaults to a trailing chevron icon.
 
-| Prop           | Type              | Default        | Description                                   |
-| -------------- | ----------------- | -------------- | --------------------------------------------- |
-| `children`     | `React.ReactNode` | required       | Trigger label                                 |
-| `trailingIcon` | `IconProps`       | `ChevronRight` | Trailing icon; pass your own to override      |
-| `leadingIcon`  | `IconProps`       | `undefined`    | Icon before text                              |
-| `disabled`     | `boolean`         | `false`        | Whether the submenu trigger is disabled       |
+| Prop           | Type              | Default        | Description                              |
+| -------------- | ----------------- | -------------- | ---------------------------------------- |
+| `children`     | `React.ReactNode` | required       | Trigger label                            |
+| `trailingIcon` | `IconProps`       | `ChevronRight` | Trailing icon; pass your own to override |
+| `leadingIcon`  | `IconProps`       | `undefined`    | Icon before text                         |
+| `disabled`     | `boolean`         | `false`        | Whether the submenu trigger is disabled  |
 
 Inherits all `Menu.Button` props.
 
@@ -151,14 +158,14 @@ The container for a submenu's items. Always opens to the side of its trigger
 (`right`, flipping to `left` on collision); `side` and `align` are managed
 automatically and are not accepted.
 
-| Prop          | Type           | Default | Description                           |
-| ------------- | -------------- | ------- | ------------------------------------- |
-| `sideOffset`  | `number`       | `0`     | Distance from the trigger             |
-| `alignOffset` | `number`       | `0`     | Offset along the trigger's edge       |
-| `gap`         | `SpacingToken` | `"1"`   | Gap between menu items                |
-| `py`          | `SpacingToken` | `"1"`   | Vertical padding                      |
-| `rounded`     | `RoundedToken` | `"4"`   | Border radius                         |
-| `shadow`      | `ShadowToken`  | `"2"`   | Drop shadow                           |
+| Prop          | Type           | Default | Description                     |
+| ------------- | -------------- | ------- | ------------------------------- |
+| `sideOffset`  | `number`       | `0`     | Distance from the trigger       |
+| `alignOffset` | `number`       | `0`     | Offset along the trigger's edge |
+| `gap`         | `SpacingToken` | `"1"`   | Gap between menu items          |
+| `py`          | `SpacingToken` | `"1"`   | Vertical padding                |
+| `rounded`     | `RoundedToken` | `"4"`   | Border radius                   |
+| `shadow`      | `ShadowToken`  | `"2"`   | Drop shadow                     |
 
 All Stack props are also supported for additional styling.
 
@@ -338,9 +345,9 @@ const ControlledMenu = () => {
 ### Menu with Custom Components
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Box } from "@telegraph/layout";
 import { Menu } from "@telegraph/menu";
+import { Tag } from "@telegraph/tag";
 
 <Menu.Root>
   <Menu.Trigger>
@@ -486,8 +493,8 @@ import { Copy, Cut, Paste, Redo, Undo } from "lucide-react";
 ### Menu with Loading States
 
 ```tsx
-import { Menu } from "@telegraph/menu";
 import { Spinner } from "@telegraph/icon";
+import { Menu } from "@telegraph/menu";
 import { useState } from "react";
 
 const MenuWithLoading = () => {
@@ -643,9 +650,9 @@ Typeahead is also supported: type the first characters of an item to focus it.
 ### User Profile Menu
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Box, Stack } from "@telegraph/layout";
 import { Menu } from "@telegraph/menu";
+import { Tag } from "@telegraph/tag";
 import { CreditCard, LogOut, Settings, User } from "lucide-react";
 
 export const UserProfileMenu = ({ user }) => (
@@ -667,7 +674,13 @@ export const UserProfileMenu = ({ user }) => (
         leadingComponent={
           <Box as="img" src={user.avatar} alt="" w="5" h="5" rounded="full" />
         }
-        trailingComponent={user.isPro && <Tag size="0" color="accent">Pro</Tag>}
+        trailingComponent={
+          user.isPro && (
+            <Tag size="0" color="accent">
+              Pro
+            </Tag>
+          )
+        }
       >
         {user.name}
       </Menu.Button>
@@ -828,7 +841,7 @@ export const FilterMenu = ({ onFilterChange }) => {
 
 ## References
 
-- [Radix UI Menu](https://www.radix-ui.com/docs/primitives/components/dropdown-menu)
+- [Base UI Menu](https://base-ui.com/react/components/menu)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/menu)
 
 ## Contributing

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -32,9 +32,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-menu": "^2.1.16",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/menu/src/Menu/Menu.helpers.ts
+++ b/packages/menu/src/Menu/Menu.helpers.ts
@@ -1,0 +1,338 @@
+import {
+  type BaseUIChangeDetails,
+  type LegacyDismissHandlers,
+  callLegacyDismissHandlers,
+} from "@telegraph/helpers";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type SyntheticEvent,
+} from "react";
+
+export type PreventableSyntheticEvent = SyntheticEvent & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuContentKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuTriggerKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuButtonKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuContentCallbacksScope = "root" | "submenu";
+
+export type MenuContentCallbacksEntry = {
+  callbacks: LegacyDismissHandlers;
+  id: symbol;
+  scope: MenuContentCallbacksScope;
+};
+
+export type MenuContentCallbacksRef = {
+  current: MenuContentCallbacksEntry[];
+};
+
+type OpenAutoFocusRestoreTargetParams = {
+  focusedElementAfterHandler: Element | null;
+  previouslyFocusedElement: Element | null;
+};
+
+export const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;
+
+export const RADIX_POPPER_COMPATIBILITY_VARS = {
+  "--radix-popper-transform-origin": "var(--transform-origin)",
+  "--radix-popper-available-width": "var(--available-width)",
+  "--radix-popper-available-height": "var(--available-height)",
+  "--radix-popper-anchor-width": "var(--anchor-width)",
+  "--radix-popper-anchor-height": "var(--anchor-height)",
+} as const;
+
+export const MENU_SELECTION_KEYS = ["Enter", " "];
+
+// Base UI handles ordinary roving focus; these helpers preserve Telegraph's
+// Radix-era edge cases around nested focusable children and prevented handlers.
+const FIRST_ITEM_KEYS = ["ArrowDown", "PageUp", "Home"];
+const LAST_ITEM_KEYS = ["ArrowUp", "PageDown", "End"];
+const MENU_ITEM_SELECTOR = "[data-tgph-menu-button]";
+
+export const callContentDismissHandlers = (
+  eventDetails: BaseUIChangeDetails,
+  contentCallbacksRef: MenuContentCallbacksRef,
+) => {
+  // Nested content registers after root content, so newest-first gives the
+  // deepest open menu first chance to cancel dismissal.
+  return contentCallbacksRef.current
+    .slice()
+    .reverse()
+    .some((entry) => callLegacyDismissHandlers(eventDetails, entry.callbacks));
+};
+
+export const callLatestContentDismissHandler = (
+  eventDetails: BaseUIChangeDetails,
+  contentCallbacksRef: MenuContentCallbacksRef,
+  scope: MenuContentCallbacksScope,
+) => {
+  const entry = contentCallbacksRef.current
+    .slice()
+    .reverse()
+    .find((contentCallbacksEntry) => {
+      // Submenus should only consult submenu callbacks; otherwise root content
+      // could accidentally cancel a submenu close that Radix kept scoped.
+      return contentCallbacksEntry.scope === scope;
+    });
+
+  return entry
+    ? callLegacyDismissHandlers(eventDetails, entry.callbacks)
+    : false;
+};
+
+export const upsertContentCallbacks = (
+  contentCallbacksRef: MenuContentCallbacksRef,
+  id: symbol,
+  scope: MenuContentCallbacksScope,
+  callbacks: LegacyDismissHandlers,
+) => {
+  const existingIndex = contentCallbacksRef.current.findIndex(
+    (entry) => entry.id === id,
+  );
+
+  if (existingIndex === -1) {
+    contentCallbacksRef.current.push({ callbacks, id, scope });
+    return;
+  }
+
+  contentCallbacksRef.current[existingIndex] = { callbacks, id, scope };
+};
+
+export const removeContentCallbacks = (
+  contentCallbacksRef: MenuContentCallbacksRef,
+  id: symbol,
+) => {
+  const existingIndex = contentCallbacksRef.current.findIndex(
+    (entry) => entry.id === id,
+  );
+
+  if (existingIndex !== -1) {
+    contentCallbacksRef.current.splice(existingIndex, 1);
+  }
+};
+
+export const preventBaseUIHandlerWhenDefaultPrevented = (
+  event: PreventableSyntheticEvent,
+) => {
+  if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+    // Base UI has its own internal handler pipeline, so mirror React prevention
+    // into Base UI's explicit opt-out hook.
+    event.preventBaseUIHandler?.();
+  }
+};
+
+export const labelBaseUIFocusGuards = (ownerDocument: Document) => {
+  ownerDocument
+    .querySelectorAll<HTMLElement>('[data-base-ui-focus-guard][role="button"]')
+    .forEach((focusGuard) => {
+      if (!focusGuard.getAttribute("aria-label")) {
+        // Base UI focus guards are implementation-detail buttons; label them so
+        // accessibility tooling does not report anonymous controls.
+        focusGuard.setAttribute("aria-label", "Focus boundary");
+      }
+    });
+};
+
+export const getOpenAutoFocusRestoreTarget = ({
+  focusedElementAfterHandler,
+  previouslyFocusedElement,
+}: OpenAutoFocusRestoreTargetParams) => {
+  if (
+    focusedElementAfterHandler instanceof HTMLElement &&
+    focusedElementAfterHandler !== previouslyFocusedElement
+  ) {
+    // If the legacy autofocus handler moved focus itself, restore to that
+    // explicit target after Base UI's autofocus work settles.
+    return focusedElementAfterHandler;
+  }
+
+  if (previouslyFocusedElement instanceof HTMLElement) {
+    // Otherwise match Radix's prevented-open-autofocus behavior by restoring the
+    // element that had focus before the menu opened.
+    return previouslyFocusedElement;
+  }
+
+  return null;
+};
+
+const getFocusableMenuItems = (content: HTMLElement) => {
+  return Array.from(
+    content.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+  ).filter((item) => {
+    return (
+      item.getAttribute("aria-disabled") !== "true" &&
+      item.getAttribute("data-disabled") === null &&
+      !item.hasAttribute("disabled")
+    );
+  });
+};
+
+export const focusMenuItemFromContentKeyDown = (
+  event: MenuContentKeyDownEvent,
+) => {
+  if (event.target !== event.currentTarget) {
+    // Nested focusable children handle their own keys; only the content surface
+    // should translate edge keys into first/last menu item focus.
+    return;
+  }
+
+  const items = getFocusableMenuItems(event.currentTarget);
+
+  if (FIRST_ITEM_KEYS.includes(event.key)) {
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    items[0]?.focus();
+    return;
+  }
+
+  if (LAST_ITEM_KEYS.includes(event.key)) {
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    items.at(-1)?.focus();
+  }
+};
+
+const isTriggerOpen = (trigger: HTMLElement) => {
+  return (
+    trigger.getAttribute("aria-expanded") === "true" ||
+    trigger.getAttribute("data-state") === "open" ||
+    trigger.hasAttribute("data-popup-open")
+  );
+};
+
+const isControlledContentOpen = (content: HTMLElement) => {
+  return (
+    content.getAttribute("data-state") === "open" ||
+    Boolean(content.closest('[data-state="open"]'))
+  );
+};
+
+const focusMenuItem = (content: HTMLElement, focusFirstItem: boolean) => {
+  const items = getFocusableMenuItems(content);
+  const item = focusFirstItem ? items[0] : items.at(-1);
+
+  item?.focus();
+
+  return Boolean(item);
+};
+
+const scheduleContentMenuItemFocus = (
+  content: HTMLElement,
+  event: MenuContentKeyDownEvent,
+  focusFirstItem: boolean,
+) => {
+  content.ownerDocument.defaultView?.setTimeout(() => {
+    // Let the nested control finish its keydown first, then bail if user code
+    // prevented during that same turn.
+    if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+      return;
+    }
+
+    focusMenuItem(content, focusFirstItem);
+  }, 0);
+};
+
+export const focusMenuItemFromNestedControlKeyDown = (
+  event: MenuContentKeyDownEvent,
+) => {
+  if (!(event.target instanceof HTMLElement)) {
+    return;
+  }
+
+  if (event.target === event.currentTarget) {
+    return;
+  }
+
+  if (event.target.closest(MENU_ITEM_SELECTOR)) {
+    return;
+  }
+
+  if (FIRST_ITEM_KEYS.includes(event.key)) {
+    // ArrowDown from embedded controls should re-enter menu navigation without
+    // asking Base UI to treat that nested control as the active menu item.
+    scheduleContentMenuItemFocus(event.currentTarget, event, true);
+  }
+};
+
+const scheduleMenuItemFocus = (
+  ownerDocument: Document,
+  contentId: string,
+  focusFirstItem: boolean,
+) => {
+  const focus = () => {
+    const content = ownerDocument.getElementById(contentId);
+
+    if (content) {
+      focusMenuItem(content, focusFirstItem);
+    }
+  };
+
+  const ownerWindow = ownerDocument.defaultView;
+
+  ownerWindow?.setTimeout(focus, 0);
+};
+
+export const focusMenuItemFromOpenTriggerKeyDown = (
+  event: MenuTriggerKeyDownEvent,
+) => {
+  const isFirstItemKey = FIRST_ITEM_KEYS.includes(event.key);
+  const isLastItemKey = LAST_ITEM_KEYS.includes(event.key);
+
+  if (!isFirstItemKey && !isLastItemKey) {
+    return false;
+  }
+
+  const contentId = event.currentTarget.getAttribute("aria-controls");
+  const content = contentId
+    ? event.currentTarget.ownerDocument.getElementById(contentId)
+    : null;
+  const focusFirstItem = isFirstItemKey;
+
+  if (
+    !content &&
+    contentId &&
+    (event.defaultPrevented || event.nativeEvent.defaultPrevented)
+  ) {
+    // The popup may not exist until Base UI processes the trigger key, so defer
+    // first/last item focus until the controlled content is in the document.
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    scheduleMenuItemFocus(
+      event.currentTarget.ownerDocument,
+      contentId,
+      focusFirstItem,
+    );
+
+    return true;
+  }
+
+  if (
+    !content ||
+    (!isTriggerOpen(event.currentTarget) && !isControlledContentOpen(content))
+  ) {
+    return false;
+  }
+
+  if (!focusMenuItem(content, focusFirstItem)) {
+    return false;
+  }
+
+  event.preventDefault();
+  event.preventBaseUIHandler?.();
+
+  return true;
+};

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1,12 +1,65 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChevronRight } from "lucide-react";
-import { describe, it } from "vitest";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useEffect,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Menu } from "./Menu";
 import type {
+  MenuButtonProps,
   MenuContentProps,
   MenuSubContentProps,
   MenuSubProps,
   MenuSubTriggerProps,
 } from "./index";
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+const renderBasicMenu = ({
+  defaultOpen,
+  onOpenChange,
+}: {
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+} = {}) => {
+  return render(
+    <>
+      <button type="button">Outside</button>
+      <Menu.Root defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content data-testid="menu-content">
+          <Menu.Button onClick={() => {}}>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>
+    </>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Menu", () => {
   describe("type inheritance", () => {
@@ -89,5 +142,772 @@ describe("Menu", () => {
       const invalidProp: MenuSubContentProps = { sideOffset: "4" };
       void invalidProp;
     });
+  });
+
+  it("is accessible when open", async () => {
+    renderBasicMenu({ defaultOpen: true });
+
+    const menu = await screen.findByRole("menu");
+
+    expectToHaveNoViolations(await axe(menu));
+  });
+
+  it("opens and closes with the trigger in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    renderBasicMenu({ onOpenChange });
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole("menu")).toHaveTextContent(
+      "Manage workflow",
+    );
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledMenu = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Menu.Root
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+        >
+          <Menu.Trigger>
+            <TestButton>Workflow actions</TestButton>
+          </Menu.Trigger>
+          <Menu.Content>
+            <Menu.Button>Manage workflow</Menu.Button>
+          </Menu.Content>
+        </Menu.Root>
+      );
+    };
+
+    render(<ControlledMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    expect(await screen.findByRole("menu")).toHaveTextContent(
+      "Manage workflow",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("lets a custom trigger click handler own open state changes", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Menu.Root onOpenChange={onOpenChange}>
+        <Menu.Trigger onClick={onClick}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("dismisses with Escape and outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Menu.Root defaultOpen>
+          <Menu.Trigger>
+            <TestButton>Workflow actions</TestButton>
+          </Menu.Trigger>
+          <Menu.Content
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            <Menu.Button>Manage workflow</Menu.Button>
+          </Menu.Content>
+        </Menu.Root>
+      </>,
+    );
+
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+    await screen.findByRole("menu");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the menu open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content onEscapeKeyDown={(event) => event.preventDefault()}>
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps submenu content open when submenu dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSubmenuEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+
+    render(
+      <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content data-testid="root-content">
+          <Menu.Sub defaultOpen>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent
+              data-testid="submenu-content"
+              onEscapeKeyDown={onSubmenuEscapeKeyDown}
+            >
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByTestId("submenu-content");
+    screen.getByRole("menuitem", { name: "Copy link" }).focus();
+    await user.keyboard("{Escape}");
+
+    expect(onSubmenuEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("root-content")).toBeInTheDocument();
+    expect(screen.getByTestId("submenu-content")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("lets submenu content close when parent dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onRootEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+    const onSubmenuOpenChange = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content
+          data-testid="root-content"
+          onEscapeKeyDown={onRootEscapeKeyDown}
+        >
+          <Menu.Sub defaultOpen onOpenChange={onSubmenuOpenChange}>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent data-testid="submenu-content">
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByTestId("submenu-content");
+    screen.getByRole("menuitem", { name: "Copy link" }).focus();
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("submenu-content")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("root-content")).toBeInTheDocument();
+    expect(onRootEscapeKeyDown).not.toHaveBeenCalled();
+    expect(onSubmenuOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps parent dismissal handlers after submenu content unmounts", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onPointerDownOutside = vi.fn((event: Event) => {
+      event.preventDefault();
+    });
+
+    const ControlledSubmenu = () => {
+      const [submenuOpen, setSubmenuOpen] = useState(true);
+
+      useEffect(() => {
+        setSubmenuOpen(false);
+      }, []);
+
+      return (
+        <>
+          <button type="button">Outside</button>
+          <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+            <Menu.Trigger>
+              <TestButton>Workflow actions</TestButton>
+            </Menu.Trigger>
+            <Menu.Content onPointerDownOutside={onPointerDownOutside}>
+              <Menu.Button>Parent action</Menu.Button>
+              <Menu.Sub open={submenuOpen} onOpenChange={setSubmenuOpen}>
+                <Menu.SubTrigger>Share</Menu.SubTrigger>
+                <Menu.SubContent data-testid="submenu-content">
+                  <Menu.Button>Copy link</Menu.Button>
+                </Menu.SubContent>
+              </Menu.Sub>
+            </Menu.Content>
+          </Menu.Root>
+        </>
+      );
+    };
+
+    render(<ControlledSubmenu />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("submenu-content")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("returns focus to the trigger after dismissal", async () => {
+    const user = userEvent.setup();
+
+    renderBasicMenu();
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("lets legacy open autofocus handlers move focus", async () => {
+    const user = userEvent.setup();
+    const archiveRef = createRef<HTMLElement>();
+    const onOpenAutoFocus = vi.fn((event: Event) => {
+      event.preventDefault();
+      archiveRef.current?.focus();
+    });
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content onOpenAutoFocus={onOpenAutoFocus}>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button tgphRef={archiveRef}>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    const archiveItem = await screen.findByRole("menuitem", {
+      name: "Archive workflow",
+    });
+
+    await waitFor(() => {
+      expect(archiveItem).toHaveFocus();
+    });
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = renderBasicMenu({ defaultOpen: true });
+
+    const content = await screen.findByTestId("menu-content");
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("role", "menu");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(content).toHaveStyle({
+      "--radix-popper-transform-origin": "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("forwards trigger and content refs through tgphRef", async () => {
+    const triggerRef = createRef<HTMLElement>();
+    const triggerTgphRef = createRef<HTMLElement>();
+    const contentTgphRef = createRef<HTMLDivElement>();
+    const contentStackRef = createRef<HTMLDivElement>();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger ref={triggerRef} tgphRef={triggerTgphRef}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content
+          contentStackRef={contentStackRef}
+          data-testid="menu-content"
+          tgphRef={contentTgphRef}
+        >
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Workflow actions" });
+    const content = await screen.findByTestId("menu-content");
+
+    expect(triggerRef.current).toBe(trigger);
+    expect(triggerTgphRef.current).toBe(trigger);
+    expect(contentTgphRef.current).toBe(content);
+    expect(contentStackRef.current).toBe(content);
+  });
+
+  it("focuses the first item from an open trigger with ArrowDown", async () => {
+    const user = userEvent.setup();
+
+    renderBasicMenu();
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("focuses the first item when an open trigger consumer prevents ArrowDown", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger onKeyDown={(event) => event.preventDefault()}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("focuses the first item from nested focusable trigger content", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton data-testid="trigger">
+            <span>Workflow actions</span>
+            <span tabIndex={0}>Email tag</span>
+          </TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByTestId("trigger"));
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    screen.getByText("Email tag").focus();
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("opens from nested focusable trigger content with Base UI keyboard handling", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton data-testid="trigger">
+            <span>Workflow actions</span>
+            <span tabIndex={0}>Email tag</span>
+          </TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    screen.getByText("Email tag").focus();
+    await user.keyboard("[ArrowDown]");
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Manage workflow" }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires item handlers once and closes by default", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onClick={onClick} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Manage workflow" }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("fires item keyboard handlers from a focused item", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown}>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires keyboard handlers for option-role items", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button
+            aria-selected="true"
+            data-tgph-combobox-option
+            data-tgph-combobox-option-value="email"
+            onKeyDown={onKeyDown}
+            role="option"
+          >
+            Email
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("option", { name: "Email" });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires select once from keyboard selection", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onSelect={onSelect}>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not double-call a shared keydown and select handler", async () => {
+    const user = userEvent.setup();
+    const handleSelection = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button
+            onKeyDown={
+              handleSelection as NonNullable<MenuButtonProps["onKeyDown"]>
+            }
+            onSelect={
+              handleSelection as NonNullable<MenuButtonProps["onSelect"]>
+            }
+          >
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(handleSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to keyboard activation when native keydown propagation is stopped", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.addEventListener("keydown", (event) => event.stopPropagation());
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+    expect(onKeyDown).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not reselect from the native keyboard click when keydown prevents default", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn((event) => event.preventDefault());
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the menu open when item handlers prevent default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onSelect={(event) => event.preventDefault()}>
+            Keep open
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Keep open" }),
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("respects closeOnClick=false", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button closeOnClick={false}>Keep open</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Keep open" }),
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("renders controlled submenu state and compatibility attributes", async () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Sub defaultOpen>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent data-testid="submenu-content">
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = await screen.findByRole("menuitem", { name: "Share" });
+    const submenu = await screen.findByTestId("submenu-content");
+
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(submenu).toHaveClass("tgph");
+    expect(submenu).toHaveAttribute("role", "menu");
+    expect(submenu).toHaveAttribute("data-side", "right");
+    expect(submenu).toHaveAttribute("data-align", "start");
   });
 });

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -484,10 +484,21 @@ describe("Menu", () => {
     expect(content).toHaveAttribute("data-state", "open");
     expect(content).toHaveAttribute("role", "menu");
     expect(content).toHaveStyle({
+      outline: "none",
+    });
+    expect(content).toHaveStyle({
       transformOrigin: "var(--transform-origin)",
     });
     expect(content).toHaveStyle({
       "--radix-popper-transform-origin": "var(--transform-origin)",
+    });
+    expect(content.parentElement).toHaveStyle({
+      zIndex: "var(--tgph-zIndex-popover)",
+    });
+    expect(
+      screen.getByRole("menuitem", { name: "Manage workflow" }),
+    ).toHaveStyle({
+      outline: "none",
     });
     expect(container).not.toContainElement(content);
   });

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -1,322 +1,937 @@
-import * as RadixMenu from "@radix-ui/react-menu";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Menu as BaseMenu } from "@base-ui/react/menu";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
-  RefToTgphRef,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type Ref,
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 
 import { MenuItem, type MenuItemProps } from "../MenuItem";
 
-export type RootProps = React.ComponentProps<typeof RadixMenu.Root> & {
-  defaultOpen?: boolean;
-};
+import {
+  MENU_SELECTION_KEYS,
+  type MenuButtonKeyDownEvent,
+  type MenuContentCallbacksEntry,
+  type MenuContentCallbacksRef,
+  type MenuContentCallbacksScope,
+  type MenuContentKeyDownEvent,
+  NO_COLLISION_AVOIDANCE,
+  type PreventableSyntheticEvent,
+  RADIX_POPPER_COMPATIBILITY_VARS,
+  callContentDismissHandlers,
+  callLatestContentDismissHandler,
+  focusMenuItemFromContentKeyDown,
+  focusMenuItemFromNestedControlKeyDown,
+  focusMenuItemFromOpenTriggerKeyDown,
+  getOpenAutoFocusRestoreTarget,
+  labelBaseUIFocusGuards,
+  preventBaseUIHandlerWhenDefaultPrevented,
+  removeContentCallbacks,
+  upsertContentCallbacks,
+} from "./Menu.helpers";
 
-type MenuContextProps = {
+type BaseMenuRootProps = ComponentProps<typeof BaseMenu.Root>;
+type BaseMenuTriggerProps = ComponentPropsWithoutRef<typeof BaseMenu.Trigger>;
+type BaseMenuPortalProps = ComponentPropsWithoutRef<typeof BaseMenu.Portal>;
+type BaseMenuPositionerProps = ComponentPropsWithoutRef<
+  typeof BaseMenu.Positioner
+>;
+type BaseMenuPopupProps = ComponentPropsWithoutRef<typeof BaseMenu.Popup>;
+type BaseMenuItemProps = ComponentPropsWithoutRef<typeof BaseMenu.Item>;
+type BaseMenuSubProps = ComponentProps<typeof BaseMenu.SubmenuRoot>;
+type BaseMenuSubTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseMenu.SubmenuTrigger
+>;
+
+type MenuPopupRenderState = {
   open: boolean;
-  setOpen: (open: boolean) => void;
 };
 
-const MenuContext = React.createContext<MenuContextProps>({
-  open: false,
-  setOpen: () => {},
-});
+type MenuTriggerRenderState = {
+  open: boolean;
+};
+
+type MenuSubTriggerRenderState = {
+  open: boolean;
+};
+
+type MenuPopupContentProps = Omit<
+  TgphComponentProps<typeof Stack>,
+  "children" | "tgphRef"
+> & {
+  children?: ReactNode;
+  contentRef: Ref<HTMLElement>;
+  onOpenAutoFocus?: LegacyDismissEventHandler;
+  popupState: MenuPopupRenderState;
+  tgphRef?: Ref<HTMLElement>;
+};
+
+type MenuContentKeyDownHandler = (event: MenuContentKeyDownEvent) => void;
+type MenuContentKeyDownCaptureHandler = (
+  event: MenuContentKeyDownEvent,
+) => void;
+
+type MenuCompatibilityContextProps = {
+  contentCallbacksRef: MenuContentCallbacksRef;
+};
+
+export type RootProps = Omit<BaseMenuRootProps, "onOpenChange"> & {
+  onOpenChange?: (open: boolean) => void;
+};
+
+const MenuCompatibilityContext =
+  createContext<MenuCompatibilityContextProps | null>(null);
+const MenuContentScopeContext =
+  createContext<MenuContentCallbacksScope>("root");
 
 const Root = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  modal = true,
   children,
+  modal = true,
+  onOpenChange,
   ...props
 }: RootProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
-  });
+  const contentCallbacksRef = useRef<MenuContentCallbacksEntry[]>([]);
+  const handleOpenChange = useCallback<
+    NonNullable<BaseMenuRootProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        callContentDismissHandlers(eventDetails, contentCallbacksRef)
+      ) {
+        // Legacy Radix content callbacks could cancel close, so translate that
+        // prevention into Base UI's cancel API at the root.
+        eventDetails.cancel();
+        return;
+      }
+
+      onOpenChange?.(open);
+    },
+    [onOpenChange],
+  );
+
   return (
-    <MenuContext.Provider value={{ open, setOpen }}>
-      <RadixMenu.Root
-        open={open}
-        onOpenChange={setOpen}
-        modal={modal}
-        {...props}
-      >
+    <MenuCompatibilityContext.Provider value={{ contentCallbacksRef }}>
+      <BaseMenu.Root modal={modal} onOpenChange={handleOpenChange} {...props}>
         {children}
-      </RadixMenu.Root>
-    </MenuContext.Provider>
+      </BaseMenu.Root>
+    </MenuCompatibilityContext.Provider>
   );
 };
 
-type Anchor = React.ComponentProps<typeof RadixMenu.Anchor> & {
-  tgphRef?: React.RefObject<HTMLDivElement>;
-};
+type BaseMenuTriggerCompatibilityProps = Partial<
+  Pick<
+    BaseMenuTriggerProps,
+    | "closeDelay"
+    | "delay"
+    | "disabled"
+    | "handle"
+    | "nativeButton"
+    | "openOnHover"
+    | "payload"
+  >
+>;
 
-const Trigger = ({ asChild = true, tgphRef, children, ...props }: Anchor) => {
-  const context = React.useContext(MenuContext);
-  return (
-    <RadixMenu.Anchor
-      onClick={() => {
-        context.setOpen(!context.open);
-      }}
-      asChild={asChild}
-      {...props}
-      ref={tgphRef}
-    >
-      <RefToTgphRef>{children}</RefToTgphRef>
-    </RadixMenu.Anchor>
-  );
-};
-
-export type ContentProps<T extends TgphElement = "div"> = React.ComponentProps<
-  typeof RadixMenu.Content
+export type TriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  keyof BaseMenuTriggerCompatibilityProps | "children"
 > &
+  BaseMenuTriggerCompatibilityProps & {
+    asChild?: boolean;
+    children?: ReactNode;
+    tgphRef?: Ref<HTMLButtonElement>;
+  };
+
+const TriggerWithRef = forwardRef<HTMLElement, TriggerProps>(
+  (
+    {
+      asChild = true,
+      children,
+      onClick,
+      onKeyDown,
+      onKeyDownCapture,
+      onMouseDown,
+      tgphRef,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const triggerRef = useComposedRefs<HTMLButtonElement>(
+      forwardedRef as Ref<HTMLButtonElement>,
+      tgphRef,
+    ) as Ref<HTMLButtonElement>;
+    // A custom onClick means callers likely own the trigger activation path, so
+    // avoid also letting Base UI process mousedown as a separate open signal.
+    const shouldSuppressBaseMouseDown = Boolean(onClick);
+    const handleClick = useCallback<
+      NonNullable<BaseMenuTriggerProps["onClick"]>
+    >(
+      (event) => {
+        onClick?.(event);
+
+        if (event.defaultPrevented) {
+          // Radix kept focus on prevented trigger clicks; preserve that for
+          // consumers that prevent open but still expect keyboard continuity.
+          event.currentTarget.focus();
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onClick],
+    );
+    const handleKeyDownCapture = useCallback<
+      NonNullable<BaseMenuTriggerProps["onKeyDownCapture"]>
+    >(
+      (event) => {
+        onKeyDownCapture?.(event);
+
+        if (event.defaultPrevented) {
+          return;
+        }
+
+        if (focusMenuItemFromOpenTriggerKeyDown(event)) {
+          event.stopPropagation();
+        }
+      },
+      [onKeyDownCapture],
+    );
+    const handleKeyDown = useCallback<
+      NonNullable<BaseMenuTriggerProps["onKeyDown"]>
+    >(
+      (event) => {
+        onKeyDown?.(event);
+
+        if (event.target !== event.currentTarget) {
+          // Custom trigger children can receive keydown first; still allow the
+          // open-trigger focus shim to run from the actual trigger wrapper.
+          focusMenuItemFromOpenTriggerKeyDown(event);
+          return;
+        }
+
+        if (focusMenuItemFromOpenTriggerKeyDown(event)) {
+          return;
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onKeyDown],
+    );
+    const handleMouseDown = useCallback<
+      NonNullable<BaseMenuTriggerProps["onMouseDown"]>
+    >(
+      (event) => {
+        onMouseDown?.(event);
+
+        if (shouldSuppressBaseMouseDown) {
+          event.preventBaseUIHandler?.();
+          return;
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onMouseDown, shouldSuppressBaseMouseDown],
+    );
+    const renderTriggerElement = (state: MenuTriggerRenderState) => {
+      if (asChild && isValidElement(children)) {
+        const child = children as ReactElement<Record<string, unknown>>;
+
+        return cloneElement(child, {
+          "aria-expanded": child.props["aria-expanded"] ?? state.open,
+          "data-state":
+            child.props["data-state"] ?? (state.open ? "open" : "closed"),
+        });
+      }
+
+      return (
+        <button
+          aria-expanded={state.open}
+          data-state={state.open ? "open" : "closed"}
+        >
+          {children}
+        </button>
+      );
+    };
+
+    return (
+      <BaseMenu.Trigger
+        {...props}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onKeyDownCapture={handleKeyDownCapture}
+        onMouseDown={handleMouseDown}
+        ref={triggerRef}
+        render={createTgphBaseUIRender(renderTriggerElement)}
+      />
+    );
+  },
+);
+
+const Trigger = TriggerWithRef as (props: TriggerProps) => ReactElement | null;
+
+const MenuPopupContent = ({
+  children,
+  contentRef,
+  onOpenAutoFocus,
+  popupState,
+  tgphRef,
+  ...props
+}: MenuPopupContentProps) => {
+  const localContentRef = useRef<HTMLElement>(null);
+  const openAutoFocusHandledRef = useRef(false);
+  const openAutoFocusTimeoutRef = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined);
+  const composedContentRef = useComposedRefs<HTMLElement>(
+    tgphRef,
+    contentRef,
+    localContentRef,
+  ) as Ref<HTMLElement>;
+
+  useLayoutEffect(() => {
+    const content = localContentRef.current;
+    const ownerWindow = content?.ownerDocument.defaultView;
+
+    if (!popupState.open) {
+      openAutoFocusHandledRef.current = false;
+
+      if (openAutoFocusTimeoutRef.current !== undefined) {
+        clearTimeout(openAutoFocusTimeoutRef.current);
+        openAutoFocusTimeoutRef.current = undefined;
+      }
+
+      return;
+    }
+
+    if (!content || !onOpenAutoFocus || openAutoFocusHandledRef.current) {
+      return;
+    }
+
+    openAutoFocusHandledRef.current = true;
+
+    const ownerDocument = content.ownerDocument;
+    const previouslyFocusedElement = ownerDocument.activeElement;
+    const event = new Event("openAutoFocus", { cancelable: true });
+    onOpenAutoFocus(event);
+
+    if (!event.defaultPrevented) {
+      return;
+    }
+
+    const restoreTarget = getOpenAutoFocusRestoreTarget({
+      focusedElementAfterHandler: ownerDocument.activeElement,
+      previouslyFocusedElement,
+    });
+
+    openAutoFocusTimeoutRef.current = ownerWindow?.setTimeout(() => {
+      openAutoFocusTimeoutRef.current = undefined;
+
+      if (restoreTarget && ownerDocument.contains(restoreTarget)) {
+        // Base UI has already run its focus pass; now restore the Radix-style
+        // prevented autofocus target without racing its internal handler.
+        restoreTarget.focus();
+      }
+    }, 0);
+  }, [onOpenAutoFocus, popupState.open]);
+
+  return (
+    <Stack
+      {...props}
+      data-state={popupState.open ? "open" : "closed"}
+      tgphRef={
+        composedContentRef as TgphComponentProps<typeof Stack>["tgphRef"]
+      }
+    >
+      {children}
+    </Stack>
+  );
+};
+
+export type ContentProps<T extends TgphElement = "div"> = Partial<
+  Omit<BaseMenuPositionerProps, "children" | "className" | "render" | "style">
+> &
+  Partial<
+    Omit<BaseMenuPopupProps, "children" | "className" | "render" | "style">
+  > &
   Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
-    contentStackRef?: React.RefObject<HTMLDivElement>;
+    avoidCollisions?: boolean;
+    contentStackRef?: Ref<HTMLDivElement>;
+    forceMount?: BaseMenuPortalProps["keepMounted"];
+    hideWhenDetached?: boolean;
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onEscapeKeyDown?: LegacyDismissHandlers["onEscapeKeyDown"];
+    onFocusOutside?: LegacyDismissHandlers["onFocusOutside"];
+    onInteractOutside?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+    onPointerDownOutside?: LegacyDismissHandlers["onPointerDownOutside"];
   };
 
 const Content = <T extends TgphElement = "div">({
-  direction = "column",
-  gap = "1",
-  rounded = "4",
-  py = "1",
-  shadow = "2",
-  sideOffset = 4,
+  align = "center",
+  alignOffset,
+  anchor,
+  arrowPadding,
+  avoidCollisions,
+  bg = "surface-1",
   children,
+  className,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  contentStackRef,
+  direction = "column",
+  disableAnchorTracking,
+  finalFocus,
+  forceMount,
+  gap = "1",
+  hideWhenDetached,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocusOutside,
   onInteractOutside,
   onKeyDown,
-  onCloseAutoFocus,
+  onKeyDownCapture,
+  onOpenAutoFocus,
+  onPointerDownOutside,
+  positionMethod,
+  py = "1",
+  rounded = "4",
+  shadow = "2",
+  side = "bottom",
+  sideOffset = 4,
+  sticky,
+  style,
   tgphRef,
   ...props
 }: ContentProps<T>) => {
+  const compatibilityContext = useContext(MenuCompatibilityContext);
+  const contentCallbacksScope = useContext(MenuContentScopeContext);
+  const contentCallbacksIdRef = useRef(Symbol("menu-content-callbacks"));
+  const internalContentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    contentStackRef as Ref<HTMLElement>,
+    internalContentRef as Ref<HTMLElement>,
+  ) as Ref<HTMLElement>;
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  const resolvedFinalFocus =
+    finalFocus ??
+    (() => {
+      if (!onCloseAutoFocus) {
+        return true;
+      }
+
+      const event = new Event("closeAutoFocus", { cancelable: true });
+      onCloseAutoFocus(event);
+
+      // Radix used preventDefault on closeAutoFocus; Base UI wants a boolean
+      // finalFocus result, so invert the same cancellation signal.
+      return event.defaultPrevented ? false : true;
+    });
+  const stackProps = props as TgphComponentProps<typeof Stack>;
+
+  useLayoutEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    const contentCallbacksRef = compatibilityContext.contentCallbacksRef;
+    const contentCallbacksId = contentCallbacksIdRef.current;
+
+    // Register a stable slot immediately so root/submenu close events can find
+    // this content even before the first callback-prop effect runs.
+    upsertContentCallbacks(
+      contentCallbacksRef,
+      contentCallbacksId,
+      contentCallbacksScope,
+      {},
+    );
+
+    return () => {
+      removeContentCallbacks(contentCallbacksRef, contentCallbacksId);
+    };
+  }, [compatibilityContext, contentCallbacksScope]);
+
+  useLayoutEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Keep the latest Radix-style dismiss callbacks in shared root state because
+    // Base UI reports dismissal through Root/Submenu onOpenChange details.
+    upsertContentCallbacks(
+      compatibilityContext.contentCallbacksRef,
+      contentCallbacksIdRef.current,
+      contentCallbacksScope,
+      {
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      },
+    );
+  }, [
+    compatibilityContext,
+    contentCallbacksScope,
+    onEscapeKeyDown,
+    onFocusOutside,
+    onInteractOutside,
+    onPointerDownOutside,
+  ]);
+
+  useEffect(() => {
+    const ownerDocument = internalContentRef.current?.ownerDocument;
+
+    if (!ownerDocument) {
+      return;
+    }
+
+    // Base UI can insert focus guards after the popup surface commits, so label
+    // them after each render and on the next tick before axe or screen readers see them.
+    labelBaseUIFocusGuards(ownerDocument);
+
+    const timeout = ownerDocument.defaultView?.setTimeout(() => {
+      labelBaseUIFocusGuards(ownerDocument);
+    }, 0);
+
+    return () => {
+      if (timeout !== undefined) {
+        ownerDocument.defaultView?.clearTimeout(timeout);
+      }
+    };
+  });
+
   return (
-    <RadixMenu.Portal>
-      <RadixMenu.Content
-        onInteractOutside={onInteractOutside}
-        onKeyDown={onKeyDown}
-        onCloseAutoFocus={onCloseAutoFocus}
-        asChild
+    <BaseMenu.Portal keepMounted={forceMount}>
+      <BaseMenu.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        arrowPadding={arrowPadding}
+        collisionAvoidance={resolvedCollisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        disableAnchorTracking={disableAnchorTracking}
+        positionMethod={positionMethod}
+        side={side}
         sideOffset={sideOffset}
-        {...props}
-        // Need to cast this type since RadixMenu.Content doesn't accept tgphRef
-        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+        sticky={sticky}
+        style={(state) =>
+          getBaseUIPositionerVisibilityStyle({
+            anchorHidden: state.anchorHidden,
+            hideWhenDetached,
+            zIndex: "var(--tgph-zIndex-popover)",
+          })
+        }
       >
-        <RefToTgphRef>
-          {/* Keep this Stack surface in sync with `SubContent` below. */}
-          <Stack
-            bg="surface-1"
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-            }}
-            zIndex="popover"
-          >
-            <LazyMotion features={domAnimation}>{children}</LazyMotion>
-          </Stack>
-        </RefToTgphRef>
-      </RadixMenu.Content>
-    </RadixMenu.Portal>
+        <BaseMenu.Popup
+          finalFocus={resolvedFinalFocus}
+          render={createTgphBaseUIRender((state: MenuPopupRenderState) => (
+            <MenuPopupContent
+              bg={bg}
+              className={["tgph", className].filter(Boolean).join(" ")}
+              contentRef={contentRef}
+              data-tgph-menu-content
+              direction={direction}
+              gap={gap}
+              onOpenAutoFocus={onOpenAutoFocus}
+              onKeyDown={(event: MenuContentKeyDownEvent) => {
+                (onKeyDown as MenuContentKeyDownHandler | undefined)?.(event);
+
+                if (!event.defaultPrevented) {
+                  focusMenuItemFromContentKeyDown(event);
+                }
+              }}
+              onKeyDownCapture={(event: MenuContentKeyDownEvent) => {
+                (
+                  onKeyDownCapture as
+                    | MenuContentKeyDownCaptureHandler
+                    | undefined
+                )?.(event);
+
+                if (!event.defaultPrevented) {
+                  focusMenuItemFromNestedControlKeyDown(event);
+                }
+              }}
+              popupState={state}
+              rounded={rounded}
+              py={py}
+              shadow={shadow}
+              style={{
+                overflowY: "auto",
+                transformOrigin: "var(--transform-origin)",
+                ...RADIX_POPPER_COMPATIBILITY_VARS,
+                ...style,
+              }}
+              zIndex="popover"
+              {...stackProps}
+            >
+              <LazyMotion features={domAnimation}>{children}</LazyMotion>
+            </MenuPopupContent>
+          ))}
+        />
+      </BaseMenu.Positioner>
+    </BaseMenu.Portal>
   );
 };
 
-export type ButtonProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof MenuItem<T>
+type MenuButtonItemProps = Omit<
+  MenuItemProps,
+  "onClick" | "onKeyDown" | "tgphRef"
+>;
+
+export type ButtonProps<T extends TgphElement = "button"> = Partial<
+  Omit<
+    BaseMenuItemProps,
+    | "children"
+    | "className"
+    | "onClick"
+    | "onKeyDown"
+    | "onSelect"
+    | "render"
+    | "style"
+  >
 > &
-  React.ComponentProps<typeof RadixMenu.Item>;
+  MenuButtonItemProps & {
+    as?: T;
+    onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
+    onKeyDown?: (event: MenuButtonKeyDownEvent) => void;
+    onSelect?: (event: Event) => void;
+    tgphRef?: Ref<HTMLElement>;
+  };
 
 const Button = <T extends TgphElement = "button">({
+  closeOnClick,
+  disabled,
   mx = "1",
-  asChild = true,
   icon,
   leadingIcon,
+  label,
   trailingIcon,
   leadingComponent,
   trailingComponent,
   selected,
   tgphRef,
   onClick,
+  onKeyDown,
+  onSelect,
+  nativeButton = true,
   ...props
 }: ButtonProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
+  const itemRef = useRef<HTMLElement>(null);
+  const menuItemProps = props as MenuItemProps<T>;
+  // Keyboard selection can arrive through React keydown, native keyup/click, or
+  // Base UI internals; these refs dedupe those paths while preserving cancel.
+  const ignoreNextKeyboardClickRef = useRef(false);
+  const nativeKeyboardClickHandledRef = useRef(false);
+  const nativeKeyboardSelectionPendingRef = useRef(false);
+  const preventNextKeyboardCloseRef = useRef(false);
+  const reactKeyboardSelectionHandledRef = useRef(false);
+  const composedTgphRef = useComposedRefs<HTMLElement>(
+    tgphRef,
+    itemRef,
+  ) as Ref<HTMLElement>;
+
+  useEffect(() => {
+    const item = itemRef.current;
+
+    if (!item || disabled) {
+      return;
+    }
+
+    let fallbackTimeout: ReturnType<typeof setTimeout> | undefined;
+    const resetNativeKeyboardState = () => {
+      nativeKeyboardClickHandledRef.current = false;
+      nativeKeyboardSelectionPendingRef.current = false;
+      reactKeyboardSelectionHandledRef.current = false;
+    };
+    const clearFallbackTimeout = () => {
+      if (fallbackTimeout !== undefined) {
+        item.ownerDocument.defaultView?.clearTimeout(fallbackTimeout);
+        fallbackTimeout = undefined;
+      }
+    };
+    const handleNativeKeyDown = (event: KeyboardEvent) => {
+      if (MENU_SELECTION_KEYS.includes(event.key)) {
+        // Mark the native keyboard path as pending until keyup tells us whether
+        // React/Base UI handled the same selection first.
+        nativeKeyboardClickHandledRef.current = false;
+        nativeKeyboardSelectionPendingRef.current = true;
+        reactKeyboardSelectionHandledRef.current = false;
+      }
+    };
+    const handleNativeKeyUp = (event: KeyboardEvent) => {
+      if (
+        !MENU_SELECTION_KEYS.includes(event.key) ||
+        !nativeKeyboardSelectionPendingRef.current
+      ) {
+        return;
+      }
+
+      clearFallbackTimeout();
+      fallbackTimeout = item.ownerDocument.defaultView?.setTimeout(() => {
+        // Defer one tick so React keydown and Base UI selection can mark their
+        // refs before the native fallback fires a duplicate selection.
+        if (
+          reactKeyboardSelectionHandledRef.current ||
+          nativeKeyboardClickHandledRef.current
+        ) {
+          resetNativeKeyboardState();
+          return;
+        }
+
+        if (onSelect) {
+          onSelect(event);
+          ignoreNextKeyboardClickRef.current = true;
+          preventNextKeyboardCloseRef.current = event.defaultPrevented;
+        }
+
+        // Trigger the normal click path for parity with native button keyboard
+        // activation after the legacy onSelect callback has had a chance to cancel.
+        item.click();
+        resetNativeKeyboardState();
+      }, 0);
+    };
+
+    item.addEventListener("keydown", handleNativeKeyDown);
+    item.addEventListener("keyup", handleNativeKeyUp);
+
+    return () => {
+      clearFallbackTimeout();
+      item.removeEventListener("keydown", handleNativeKeyDown);
+      item.removeEventListener("keyup", handleNativeKeyUp);
+    };
+  }, [disabled, onSelect]);
+
+  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
+    if (event.detail === 0) {
+      // Browsers synthesize detail=0 clicks for keyboard activation.
+      nativeKeyboardClickHandledRef.current = true;
+    }
+
+    if (ignoreNextKeyboardClickRef.current && event.detail === 0) {
+      ignoreNextKeyboardClickRef.current = false;
+      if (preventNextKeyboardCloseRef.current) {
+        (event as PreventableSyntheticEvent).preventBaseUIHandler?.();
+      }
+      preventNextKeyboardCloseRef.current = false;
+      return;
+    }
+
+    ignoreNextKeyboardClickRef.current = false;
+    preventNextKeyboardCloseRef.current = false;
+    onClick?.(event);
+    onSelect?.(event.nativeEvent);
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    const isSelectionKey = MENU_SELECTION_KEYS.includes(event.key);
+
+    (onKeyDown as ((event: MenuButtonKeyDownEvent) => void) | undefined)?.(
+      event as MenuButtonKeyDownEvent,
+    );
+
+    if (isSelectionKey) {
+      reactKeyboardSelectionHandledRef.current = true;
+
+      const keyDownPrevented =
+        event.defaultPrevented || event.nativeEvent.defaultPrevented;
+
+      if (!keyDownPrevented && onSelect !== (onKeyDown as unknown)) {
+        // Preserve the old API where Enter/Space could invoke onSelect during
+        // keydown, while avoiding double-calling when onKeyDown is the handler.
+        onSelect?.(event.nativeEvent);
+      }
+
+      ignoreNextKeyboardClickRef.current = true;
+      preventNextKeyboardCloseRef.current =
+        keyDownPrevented ||
+        event.defaultPrevented ||
+        event.nativeEvent.defaultPrevented;
+    }
+
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+
   return (
-    <RadixMenu.Item
-      {...props}
-      asChild={asChild}
-      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-    >
-      <RefToTgphRef>
-        <MenuItem
-          onClick={
-            onClick as React.MouseEventHandler<HTMLButtonElement> | undefined
-          }
+    <BaseMenu.Item
+      closeOnClick={closeOnClick}
+      disabled={disabled}
+      label={label}
+      nativeButton={nativeButton}
+      render={createTgphBaseUIRender(
+        <MenuItem<T>
+          {...menuItemProps}
+          onClick={handleClick as MenuItemProps<T>["onClick"]}
+          onKeyDown={handleKeyDown as MenuItemProps<T>["onKeyDown"]}
           selected={selected}
           leadingIcon={combinedLeadingIcon}
           trailingIcon={trailingIcon}
           leadingComponent={leadingComponent}
           trailingComponent={trailingComponent}
           data-tgph-menu-button
+          disabled={disabled}
           mx={mx}
           style={{
             flexShrink: 0,
+            ...menuItemProps.style,
           }}
-          {...props}
-        />
-      </RefToTgphRef>
-    </RadixMenu.Item>
+          tgphRef={composedTgphRef as MenuItemProps<T>["tgphRef"]}
+        />,
+      )}
+    />
   );
 };
 
-export type SubProps = React.ComponentProps<typeof RadixMenu.Sub> & {
-  defaultOpen?: boolean;
+export type SubProps = Partial<Omit<BaseMenuSubProps, "onOpenChange">> & {
+  onOpenChange?: (open: boolean) => void;
 };
 
-/**
- * Groups a `SubTrigger` with its `SubContent` to form a nested submenu that
- * opens on hover/focus. Works uncontrolled by default; pass `open`/`onOpenChange`
- * to control it, or `defaultOpen` to set the initial state.
- *
- * Note: the underlying `RadixMenu.Sub` is controlled-only (it has no internal
- * uncontrolled state), so we manage open state here via `useControllableState`,
- * mirroring `Menu.Root`. Without this the submenu would never open on hover.
- */
-const Sub = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  children,
-  ...props
-}: SubProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
-  });
+const Sub = ({ children, onOpenChange, ...props }: SubProps) => {
+  const compatibilityContext = useContext(MenuCompatibilityContext);
+  const handleOpenChange = useCallback<
+    NonNullable<BaseMenuSubProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        compatibilityContext &&
+        callLatestContentDismissHandler(
+          eventDetails,
+          compatibilityContext.contentCallbacksRef,
+          "submenu",
+        )
+      ) {
+        // Submenu close should only honor submenu content callbacks, not root
+        // callbacks, which matches Radix's scoped dismissal behavior.
+        eventDetails.cancel();
+        return;
+      }
+
+      onOpenChange?.(open);
+    },
+    [compatibilityContext, onOpenChange],
+  );
+
   return (
-    <RadixMenu.Sub open={open} onOpenChange={setOpen} {...props}>
+    <BaseMenu.SubmenuRoot onOpenChange={handleOpenChange} {...props}>
       {children}
-    </RadixMenu.Sub>
+    </BaseMenu.SubmenuRoot>
   );
 };
 
-export type SubTriggerProps<T extends TgphElement = "button"> =
-  MenuItemProps<T> & React.ComponentProps<typeof RadixMenu.SubTrigger>;
+type MenuSubTriggerItemProps = Omit<MenuItemProps, "onClick" | "tgphRef">;
+
+export type SubTriggerProps<T extends TgphElement = "button"> = Partial<
+  Omit<
+    BaseMenuSubTriggerProps,
+    "children" | "className" | "onClick" | "render" | "style"
+  >
+> &
+  MenuSubTriggerItemProps & {
+    as?: T;
+    onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
+    tgphRef?: Ref<HTMLElement>;
+  };
 
 const SubTrigger = <T extends TgphElement = "button">({
+  closeDelay,
+  delay,
+  disabled,
   mx = "1",
-  asChild = true,
   icon,
   leadingIcon,
+  label,
   trailingIcon,
   leadingComponent,
   trailingComponent,
+  openOnHover,
   tgphRef,
   onClick,
+  nativeButton = true,
   ...props
 }: SubTriggerProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
-  // Default to a chevron so the item reads as "opens a submenu". Only apply it
-  // when the caller supplies neither a trailing icon nor a trailing component —
-  // `MenuItemTrailing` renders `trailingIcon` in preference to
-  // `trailingComponent`, so an unconditional default would hide a caller's
-  // `trailingComponent`. Annotating with `typeof trailingIcon` keeps
-  // `aria-hidden` as the literal `true` the icon type requires instead of
-  // widening it to `boolean`.
+  const menuItemProps = props as MenuItemProps<T>;
   const combinedTrailingIcon: typeof trailingIcon =
     trailingIcon === undefined && trailingComponent === undefined
       ? { icon: ChevronRight, "aria-hidden": true }
       : trailingIcon;
+  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
+    onClick?.(event);
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+
   return (
-    <RadixMenu.SubTrigger
-      {...props}
-      asChild={asChild}
-      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-    >
-      <RefToTgphRef>
-        <MenuItem
-          // Pass onClick only to MenuItem (not also via {...props} to
-          // RadixMenu.SubTrigger) so RefToTgphRef doesn't compose a
-          // caller-supplied handler twice. Mirrors Menu.Button.
-          onClick={
-            onClick as React.MouseEventHandler<HTMLButtonElement> | undefined
-          }
+    <BaseMenu.SubmenuTrigger
+      closeDelay={closeDelay}
+      delay={delay}
+      disabled={disabled}
+      label={label}
+      nativeButton={nativeButton}
+      openOnHover={openOnHover}
+      render={createTgphBaseUIRender((state: MenuSubTriggerRenderState) => (
+        <MenuItem<T>
+          {...menuItemProps}
+          onClick={handleClick as MenuItemProps<T>["onClick"]}
           leadingIcon={combinedLeadingIcon}
           trailingIcon={combinedTrailingIcon}
           leadingComponent={leadingComponent}
           trailingComponent={trailingComponent}
+          data-state={state.open ? "open" : "closed"}
           data-tgph-menu-button
+          disabled={disabled}
           mx={mx}
           style={{
             flexShrink: 0,
+            ...menuItemProps.style,
           }}
-          {...props}
+          tgphRef={tgphRef as MenuItemProps<T>["tgphRef"]}
         />
-      </RefToTgphRef>
-    </RadixMenu.SubTrigger>
+      ))}
+    />
   );
 };
 
-export type SubContentProps<T extends TgphElement = "div"> =
-  React.ComponentProps<typeof RadixMenu.SubContent> &
-    Omit<TgphComponentProps<typeof Stack<T>>, "align">;
+export type SubContentProps<T extends TgphElement = "div"> = Omit<
+  ContentProps<T>,
+  "align" | "side"
+>;
 
 const SubContent = <T extends TgphElement = "div">({
-  direction = "column",
-  gap = "1",
-  rounded = "4",
-  py = "1",
-  shadow = "2",
-  // Submenus open to the side with no gap by default; `side`/`align` are
-  // managed by Radix and intentionally not accepted here.
   sideOffset = 0,
-  children,
-  onInteractOutside,
-  onKeyDown,
-  tgphRef,
   ...props
 }: SubContentProps<T>) => {
   return (
-    <RadixMenu.Portal>
-      <RadixMenu.SubContent
-        onInteractOutside={onInteractOutside}
-        onKeyDown={onKeyDown}
-        asChild
-        sideOffset={sideOffset}
-        {...props}
-        // Need to cast this type since RadixMenu.SubContent doesn't accept tgphRef
-        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-      >
-        <RefToTgphRef>
-          {/* Keep this Stack surface in sync with `Content` above. */}
-          <Stack
-            bg="surface-1"
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-            }}
-            zIndex="popover"
-          >
-            <LazyMotion features={domAnimation}>{children}</LazyMotion>
-          </Stack>
-        </RefToTgphRef>
-      </RadixMenu.SubContent>
-    </RadixMenu.Portal>
+    <MenuContentScopeContext.Provider value="submenu">
+      <Content align="start" side="right" sideOffset={sideOffset} {...props} />
+    </MenuContentScopeContext.Provider>
   );
 };
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -583,6 +583,7 @@ const Content = <T extends TgphElement = "div">({
               py={py}
               shadow={shadow}
               style={{
+                outline: "none",
                 overflowY: "auto",
                 transformOrigin: "var(--transform-origin)",
                 ...RADIX_POPPER_COMPATIBILITY_VARS,
@@ -653,6 +654,9 @@ const Button = <T extends TgphElement = "button">({
   const nativeKeyboardSelectionPendingRef = useRef(false);
   const preventNextKeyboardCloseRef = useRef(false);
   const reactKeyboardSelectionHandledRef = useRef(false);
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
   const composedTgphRef = useComposedRefs<HTMLElement>(
     tgphRef,
     itemRef,
@@ -665,16 +669,17 @@ const Button = <T extends TgphElement = "button">({
       return;
     }
 
-    let fallbackTimeout: ReturnType<typeof setTimeout> | undefined;
     const resetNativeKeyboardState = () => {
       nativeKeyboardClickHandledRef.current = false;
       nativeKeyboardSelectionPendingRef.current = false;
       reactKeyboardSelectionHandledRef.current = false;
     };
     const clearFallbackTimeout = () => {
-      if (fallbackTimeout !== undefined) {
-        item.ownerDocument.defaultView?.clearTimeout(fallbackTimeout);
-        fallbackTimeout = undefined;
+      if (fallbackTimeoutRef.current !== undefined) {
+        item.ownerDocument.defaultView?.clearTimeout(
+          fallbackTimeoutRef.current,
+        );
+        fallbackTimeoutRef.current = undefined;
       }
     };
     const handleNativeKeyDown = (event: KeyboardEvent) => {
@@ -695,28 +700,31 @@ const Button = <T extends TgphElement = "button">({
       }
 
       clearFallbackTimeout();
-      fallbackTimeout = item.ownerDocument.defaultView?.setTimeout(() => {
-        // Defer one tick so React keydown and Base UI selection can mark their
-        // refs before the native fallback fires a duplicate selection.
-        if (
-          reactKeyboardSelectionHandledRef.current ||
-          nativeKeyboardClickHandledRef.current
-        ) {
+      fallbackTimeoutRef.current = item.ownerDocument.defaultView?.setTimeout(
+        () => {
+          // Defer one tick so React keydown and Base UI selection can mark their
+          // refs before the native fallback fires a duplicate selection.
+          if (
+            reactKeyboardSelectionHandledRef.current ||
+            nativeKeyboardClickHandledRef.current
+          ) {
+            resetNativeKeyboardState();
+            return;
+          }
+
+          if (onSelect) {
+            onSelect(event);
+            ignoreNextKeyboardClickRef.current = true;
+            preventNextKeyboardCloseRef.current = event.defaultPrevented;
+          }
+
+          // Trigger the normal click path for parity with native button keyboard
+          // activation after the legacy onSelect callback has had a chance to cancel.
+          item.click();
           resetNativeKeyboardState();
-          return;
-        }
-
-        if (onSelect) {
-          onSelect(event);
-          ignoreNextKeyboardClickRef.current = true;
-          preventNextKeyboardCloseRef.current = event.defaultPrevented;
-        }
-
-        // Trigger the normal click path for parity with native button keyboard
-        // activation after the legacy onSelect callback has had a chance to cancel.
-        item.click();
-        resetNativeKeyboardState();
-      }, 0);
+        },
+        0,
+      );
     };
 
     item.addEventListener("keydown", handleNativeKeyDown);
@@ -799,6 +807,7 @@ const Button = <T extends TgphElement = "button">({
           disabled={disabled}
           mx={mx}
           style={{
+            outline: "none",
             flexShrink: 0,
             ...menuItemProps.style,
           }}
@@ -909,6 +918,7 @@ const SubTrigger = <T extends TgphElement = "button">({
           disabled={disabled}
           mx={mx}
           style={{
+            outline: "none",
             flexShrink: 0,
             ...menuItemProps.style,
           }}

--- a/packages/menu/src/MenuItem/MenuItem.stories.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.stories.tsx
@@ -77,7 +77,7 @@ export const Default: Story = {
       : undefined;
 
     const selected = type === "selectable" ? selectedProp : undefined;
-    console.log(selected, type, args);
+
     return (
       <>
         <TelegraphMenuItem

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -1,16 +1,24 @@
 import { Button } from "@telegraph/button";
-import { TgphComponentProps, TgphElement } from "@telegraph/helpers";
+import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Check } from "lucide-react";
 import * as motion from "motion/react-m";
+import type { ReactNode } from "react";
+
+type MenuItemIconProps = {
+  icon?: TgphComponentProps<typeof Button.Icon>;
+  leadingIcon?: TgphComponentProps<typeof Button.Icon>;
+  trailingIcon?: TgphComponentProps<typeof Button.Icon>;
+};
 
 export type MenuItemProps<T extends TgphElement = "button"> =
-  TgphComponentProps<typeof Button<T>> & {
-    selected?: boolean | null;
-    leadingComponent?: React.ReactNode;
-    trailingComponent?: React.ReactNode;
-    textProps?: TgphComponentProps<typeof Button.Text>;
-  };
+  TgphComponentProps<typeof Button.Root<T>> &
+    MenuItemIconProps & {
+      selected?: boolean | null;
+      leadingComponent?: ReactNode;
+      trailingComponent?: ReactNode;
+      textProps?: TgphComponentProps<typeof Button.Text>;
+    };
 
 const MenuItem = <T extends TgphElement = "button">({
   variant = "ghost",
@@ -28,6 +36,8 @@ const MenuItem = <T extends TgphElement = "button">({
   textProps,
   ...props
 }: MenuItemProps<T>) => {
+  const rootProps = props as TgphComponentProps<typeof Button.Root>;
+
   return (
     <Button.Root
       size={size}
@@ -36,7 +46,7 @@ const MenuItem = <T extends TgphElement = "button">({
       px={px}
       justify={justify}
       w={w}
-      {...props}
+      {...rootProps}
     >
       <Stack gap={gap} align="center" w="full">
         <MenuItemLeading
@@ -46,13 +56,13 @@ const MenuItem = <T extends TgphElement = "button">({
           leadingComponent={leadingComponent}
         />
         <Button.Text
-          weight={props?.fontWeight || "medium"}
+          weight={rootProps.fontWeight || "medium"}
           w="full"
           overflow="hidden"
           textOverflow="ellipsis"
           {...textProps}
         >
-          {props.children}
+          {rootProps.children}
         </Button.Text>
       </Stack>
       <MenuItemTrailing

--- a/packages/menu/src/default.css
+++ b/packages/menu/src/default.css
@@ -3,10 +3,15 @@
   outline: none;
 }
 
+[data-tgph-menu-content]:focus,
+[data-tgph-menu-content]:focus-visible {
+  outline: none;
+}
+
 /* Keep a submenu trigger highlighted while its submenu is open, so it stays
-   clear which parent item the open submenu belongs to. Radix sets
-   data-state="open" on the active SubTrigger; we reuse the button's own hover
-   background so the highlight matches its color/variant automatically. */
+   clear which parent item the open submenu belongs to. Telegraph re-emits the
+   Radix-era data-state="open" attribute from Base UI state; we reuse the
+   button's own hover background so the highlight matches automatically. */
 [data-tgph-menu-button][data-state="open"] {
   background-color: var(--hover--background-color, var(--background-color));
 }

--- a/packages/menu/vitest.config.mts
+++ b/packages/menu/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "menu",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -1,6 +1,6 @@
 # 🪟 Modal
 
-> Accessible modal dialog component with stacking support, animations, and focus management built on Radix UI.
+> Accessible modal dialog component with stacking support, animations, and focus management built on Base UI Dialog.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -31,6 +31,11 @@ import "@telegraph/modal/default.css";
 ```
 
 > Then, include `className="tgph"` on the farthest parent element wrapping the telegraph components
+
+`Modal` is implemented with Base UI Dialog primitives and Telegraph-rendered
+layout surfaces. It keeps the long-standing Telegraph API while preserving
+accessible titles/descriptions, portal style scoping, focus management, outside
+click dismissal, Escape dismissal, and stacked modal behavior.
 
 ## Quick Start
 
@@ -76,17 +81,17 @@ export const BasicModal = () => {
 
 The root modal container that manages state and provides context.
 
-| Prop                 | Type                      | Default     | Description                                |
-| -------------------- | ------------------------- | ----------- | ------------------------------------------ |
-| `open`               | `boolean`                 | `undefined` | Controlled open state                      |
-| `defaultOpen`        | `boolean`                 | `false`     | Default open state                         |
-| `onOpenChange`       | `(open: boolean) => void` | `undefined` | Callback when open state changes           |
-| `a11yTitle`          | `string`                  | required    | Accessible title for screen readers        |
-| `a11yDescription`    | `string`                  | `undefined` | Accessible description for screen readers  |
-| `trapped`            | `boolean`                 | `true`      | Whether focus should be trapped            |
-| `onMountAutoFocus`   | `(event: Event) => void`  | `undefined` | Called when modal opens and focuses        |
-| `onUnmountAutoFocus` | `(event: Event) => void`  | `undefined` | Called when modal closes and focus returns |
-| `layer`              | `number`                  | `undefined` | Layer index for stacked modals             |
+| Prop                 | Type                      | Default     | Description                                                                                      |
+| -------------------- | ------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `open`               | `boolean`                 | `undefined` | Controlled open state                                                                            |
+| `defaultOpen`        | `boolean`                 | `false`     | Default open state                                                                               |
+| `onOpenChange`       | `(open: boolean) => void` | `undefined` | Callback when open state changes                                                                 |
+| `a11yTitle`          | `string`                  | required    | Accessible title for screen readers                                                              |
+| `a11yDescription`    | `string`                  | `undefined` | Accessible description for screen readers                                                        |
+| `trapped`            | `boolean`                 | top layer   | Whether focus should be trapped. `false` keeps the modal overlay and document scroll lock active |
+| `onMountAutoFocus`   | `(event: Event) => void`  | `undefined` | Called when modal opens and focuses                                                              |
+| `onUnmountAutoFocus` | `(event: Event) => void`  | `undefined` | Called when modal closes and focus returns                                                       |
+| `layer`              | `number`                  | `undefined` | Layer index for stacked modals                                                                   |
 
 Inherits all Stack props for additional styling.
 
@@ -134,11 +139,11 @@ Inherits all Stack props for layout and styling.
 
 Standardized heading component for modal titles with consistent styling.
 
-| Prop     | Type                                              | Default    | Description        |
-| -------- | ------------------------------------------------- | ---------- | ------------------ |
-| `as`     | `TgphElement`                                     | `"h2"`     | HTML element type  |
-| `size`   | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| ... ` | `"3"`      | Heading size       |
-| `weight` | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight        |
+| Prop     | Type                                             | Default    | Description       |
+| -------- | ------------------------------------------------ | ---------- | ----------------- |
+| `as`     | `TgphElement`                                    | `"h2"`     | HTML element type |
+| `size`   | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| ... ` | `"3"`      | Heading size      |
+| `weight` | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight       |
 
 Inherits all Heading props from `@telegraph/typography` for additional styling.
 
@@ -694,6 +699,10 @@ The modal component uses Telegraph design tokens for consistent styling:
 - ✅ **Backdrop Interaction**: Click outside to close
 - ✅ **Focus Restoration**: Returns focus to trigger element
 
+When modals are stacked with `ModalStackingProvider`, only the top layer handles
+Escape and backdrop dismissal. Lower layers stay mounted visually but do not
+own the active focus trap unless `trapped` is explicitly set.
+
 ### Keyboard Shortcuts
 
 | Key               | Action                                 |
@@ -885,7 +894,12 @@ export const ImageGalleryModal = ({
     <Modal.Root open={open} onOpenChange={onClose} a11yTitle="Image Gallery">
       <Modal.Content w="screen" maxW="screen" h="screen" rounded="0" p="0">
         <Modal.Header px="6" py="4">
-          <Stack direction="row" align="center" justify="space-between" w="full">
+          <Stack
+            direction="row"
+            align="center"
+            justify="space-between"
+            w="full"
+          >
             <Modal.Heading>
               {currentImage?.title || `Image ${currentIndex + 1}`}
             </Modal.Heading>
@@ -1040,7 +1054,9 @@ export const ExportModal = ({ open, onClose, onExport }) => {
                   <input
                     type="checkbox"
                     checked={includeHeaders}
-                    onChange={(event) => setIncludeHeaders(event.target.checked)}
+                    onChange={(event) =>
+                      setIncludeHeaders(event.target.checked)
+                    }
                   />
                   Include column headers
                 </label>
@@ -1048,7 +1064,9 @@ export const ExportModal = ({ open, onClose, onExport }) => {
                   <input
                     type="checkbox"
                     checked={includeMetadata}
-                    onChange={(event) => setIncludeMetadata(event.target.checked)}
+                    onChange={(event) =>
+                      setIncludeMetadata(event.target.checked)
+                    }
                   />
                   Include metadata
                 </label>
@@ -1071,7 +1089,7 @@ export const ExportModal = ({ open, onClose, onExport }) => {
 
 ## References
 
-- [Radix UI Dialog](https://www.radix-ui.com/docs/primitives/components/dialog)
+- [Base UI Dialog](https://base-ui.com/react/components/dialog)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/modal)
 
 ## Contributing

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,11 +29,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.15",
-    "@radix-ui/react-focus-scope": "^1.1.8",
-    "@radix-ui/react-portal": "^1.1.10",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/modal/src/Modal/Modal.helpers.ts
+++ b/packages/modal/src/Modal/Modal.helpers.ts
@@ -1,0 +1,18 @@
+import { type SyntheticEvent } from "react";
+
+export type BaseUIPreventableEvent = (Event | SyntheticEvent) & {
+  nativeEvent?: Event;
+  preventBaseUIHandler?: () => void;
+  stopPropagation?: () => void;
+};
+
+export const callAutoFocusHandler = (
+  handler: ((event: Event) => void) | undefined,
+  eventName: string,
+) => {
+  // Radix passed cancelable autofocus lifecycle events; synthesize the same
+  // event shape and return whether the legacy handler prevented it.
+  const event = new Event(eventName, { cancelable: true });
+  handler?.(event);
+  return event.defaultPrevented;
+};

--- a/packages/modal/src/Modal/Modal.test.tsx
+++ b/packages/modal/src/Modal/Modal.test.tsx
@@ -1,13 +1,405 @@
-import { describe, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 import { Modal } from "./Modal";
+import { ModalStackingProvider } from "./ModalStacking";
 import type {
   ModalBodyProps,
   ModalFooterProps,
   ModalHeaderProps,
 } from "./index";
 
+const TestModal = ({
+  a11yTitle = "Settings",
+  open = true,
+  onOpenChange = vi.fn(),
+  onEscapeKeyDown,
+  onPointerDownOutside,
+  trapped,
+}: {
+  a11yTitle?: string;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onOpenChange?: (open: boolean) => void;
+  onPointerDownOutside?: (
+    event: MouseEvent | PointerEvent | TouchEvent,
+  ) => void;
+  open?: boolean;
+  trapped?: boolean;
+}) => {
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      a11yTitle={a11yTitle}
+      a11yDescription="Configure notification settings"
+      trapped={trapped}
+    >
+      <Modal.Content
+        onEscapeKeyDown={onEscapeKeyDown}
+        onPointerDownOutside={onPointerDownOutside}
+      >
+        <Modal.Header>
+          <Modal.Heading>{a11yTitle}</Modal.Heading>
+          <Modal.Close />
+        </Modal.Header>
+        <Modal.Body>Modal body</Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};
+
 describe("Modal", () => {
+  it("renders an accessible dialog with hidden title and description", async () => {
+    render(<TestModal />);
+
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    expect(dialog).toHaveAccessibleDescription(
+      "Configure notification settings",
+    );
+    expect(screen.getByText("Modal body")).toBeInTheDocument();
+  });
+
+  it("opens without ref or transform-origin warnings", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      render(<TestModal />);
+
+      await screen.findByRole("dialog", { name: "Settings" });
+
+      const consoleOutput = [...errorSpy.mock.calls, ...warnSpy.mock.calls]
+        .flat()
+        .join("\n");
+
+      expect(consoleOutput).not.toMatch(
+        /Function components cannot be given refs|transformOrigin/,
+      );
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("calls onOpenChange when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestModal onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("dedupes repeated uncontrolled open changes before rerender", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal.Root
+        defaultOpen
+        onOpenChange={onOpenChange}
+        a11yTitle="Settings"
+        a11yDescription="Configure notification settings"
+      >
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Heading>Settings</Modal.Heading>
+            <Modal.Close />
+          </Modal.Header>
+          <Modal.Body>Modal body</Modal.Body>
+        </Modal.Content>
+      </Modal.Root>,
+    );
+
+    await user.dblClick(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the modal open when escape dismissal is prevented", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+    render(
+      <TestModal
+        onOpenChange={onOpenChange}
+        onEscapeKeyDown={onEscapeKeyDown}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps document scroll locked when focus trapping is disabled", async () => {
+    const previousOverflow = document.body.style.overflow;
+
+    try {
+      render(<TestModal trapped={false} />);
+
+      await screen.findByRole("dialog", { name: "Settings" });
+
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+    } finally {
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it("keeps document scroll locked while stacked non-trapped modals remain open", async () => {
+    const user = userEvent.setup();
+    const previousOverflow = document.body.style.overflow;
+
+    const StatefulStackedNonTrappedModals = () => {
+      const [firstOpen, setFirstOpen] = useState(true);
+      const [secondOpen, setSecondOpen] = useState(true);
+
+      return (
+        <ModalStackingProvider>
+          <TestModal
+            a11yTitle="First modal"
+            open={firstOpen}
+            onOpenChange={setFirstOpen}
+            trapped={false}
+          />
+          <TestModal
+            a11yTitle="Second modal"
+            open={secondOpen}
+            onOpenChange={setSecondOpen}
+            trapped={false}
+          />
+        </ModalStackingProvider>
+      );
+    };
+
+    try {
+      render(<StatefulStackedNonTrappedModals />);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+      });
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+
+      const overlay = document.querySelector("[data-tgph-modal-overlay]");
+      expect(overlay).toBeInTheDocument();
+
+      await user.click(overlay as HTMLElement);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+      });
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+
+      await user.click(overlay as HTMLElement);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(0);
+      });
+      expect(document.body.style.overflow).toBe(previousOverflow);
+    } finally {
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it("calls onOpenChange when the backdrop is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestModal onOpenChange={onOpenChange} />);
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not suppress the next close after a prevented backdrop dismissal", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onPointerDownOutside = vi.fn(
+      (event: MouseEvent | PointerEvent | TouchEvent) => {
+        event.preventDefault();
+      },
+    );
+
+    render(
+      <TestModal
+        onOpenChange={onOpenChange}
+        onPointerDownOutside={onPointerDownOutside}
+      />,
+    );
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("only closes the top layer when stacked modals receive escape", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="First modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Second modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    await user.keyboard("{Escape}");
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call escape handlers for lower stacked layers", async () => {
+    const user = userEvent.setup();
+    const onFirstEscapeKeyDown = vi.fn();
+    const onSecondEscapeKeyDown = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal
+          a11yTitle="First modal"
+          onEscapeKeyDown={onFirstEscapeKeyDown}
+        />
+        <TestModal
+          a11yTitle="Second modal"
+          onEscapeKeyDown={onSecondEscapeKeyDown}
+        />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    await user.keyboard("{Escape}");
+
+    expect(onSecondEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(onFirstEscapeKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("only closes the top layer when stacked modals receive backdrop clicks", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="First modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Second modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps modals with duplicate accessible titles as independent stack layers", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="Shared modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Shared modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlays = document.querySelectorAll("[data-tgph-modal-overlay]");
+    expect(overlays).toHaveLength(1);
+
+    await user.click(overlays[0] as HTMLElement);
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress the next escape after a stacked backdrop dismissal", async () => {
+    const user = userEvent.setup();
+
+    const StatefulStackedModals = () => {
+      const [firstOpen, setFirstOpen] = useState(true);
+      const [secondOpen, setSecondOpen] = useState(true);
+
+      return (
+        <ModalStackingProvider>
+          <TestModal
+            a11yTitle="First modal"
+            open={firstOpen}
+            onOpenChange={setFirstOpen}
+          />
+          <TestModal
+            a11yTitle="Second modal"
+            open={secondOpen}
+            onOpenChange={setSecondOpen}
+          />
+        </ModalStackingProvider>
+      );
+    };
+
+    render(<StatefulStackedModals />);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+    });
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(0);
+    });
+  });
+
   describe("type inheritance", () => {
     it("accepts valid polymorphic props on Body", () => {
       const validProps: ModalBodyProps<"section"> = {

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -1,31 +1,128 @@
-import * as Dialog from "@radix-ui/react-dialog";
-import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
-import { FocusScope } from "@radix-ui/react-focus-scope";
-import * as Portal from "@radix-ui/react-portal";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import { Button } from "@telegraph/button";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type PolymorphicProps,
   RefToTgphRef,
   RemappedOmit,
   type TgphComponentProps,
   type TgphElement,
+  VisuallyHidden,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { Heading as TelegraphHeading } from "@telegraph/typography";
 import { X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+} from "react";
 
+import {
+  type BaseUIPreventableEvent,
+  callAutoFocusHandler,
+} from "./Modal.helpers";
 import { useModalStacking } from "./ModalStacking";
 
-export type RootProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Dialog.Root>,
-  "modal"
-> &
-  React.ComponentPropsWithoutRef<typeof FocusScope> &
+const BASE_UI_OUTSIDE_PRESS_DISMISS_REASON = "outside-press";
+const ROOT_OUTSIDE_DISMISS_SUPPRESSION_DELAY_MS = 100;
+
+type BaseDialogRootProps = ComponentProps<typeof BaseDialog.Root>;
+type BaseDialogPopupProps = ComponentPropsWithoutRef<typeof BaseDialog.Popup>;
+type BaseDialogCloseProps = ComponentPropsWithoutRef<typeof BaseDialog.Close>;
+
+type LegacyFocusScopeProps = {
+  loop?: boolean;
+  onMountAutoFocus?: (event: Event) => void;
+  onUnmountAutoFocus?: (event: Event) => void;
+  trapped?: boolean;
+};
+
+type ModalCompatibilityContextProps = {
+  contentCallbacksRef: {
+    current: LegacyDismissHandlers;
+  };
+  requestPointerDismiss: (event: BaseUIPreventableEvent) => void;
+  rootFocusCallbacksRef: {
+    current: Pick<
+      LegacyFocusScopeProps,
+      "onMountAutoFocus" | "onUnmountAutoFocus"
+    >;
+  };
+};
+
+type RootDialogProps = {
+  children?: BaseDialogRootProps["children"];
+  defaultOpen?: BaseDialogRootProps["defaultOpen"];
+  open?: BaseDialogRootProps["open"];
+  onOpenChange?: (open: boolean) => void;
+};
+
+const ModalCompatibilityContext =
+  createContext<ModalCompatibilityContextProps | null>(null);
+
+const bodyScrollLockLayers = new Set<string>();
+let bodyScrollLockPreviousOverflow: string | undefined;
+
+const lockBodyScroll = (layerId: string) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  if (bodyScrollLockLayers.size === 0) {
+    bodyScrollLockPreviousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+
+  bodyScrollLockLayers.add(layerId);
+};
+
+const unlockBodyScroll = (layerId: string) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  bodyScrollLockLayers.delete(layerId);
+
+  if (bodyScrollLockLayers.size === 0) {
+    document.body.style.overflow = bodyScrollLockPreviousOverflow ?? "";
+    bodyScrollLockPreviousOverflow = undefined;
+  }
+};
+
+const useBodyScrollLock = (layerId: string, enabled: boolean) => {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    // Multiple non-trapped stacked dialogs can need the fallback lock at once.
+    // Keep the body locked until the last owning layer releases it.
+    lockBodyScroll(layerId);
+
+    return () => {
+      unlockBodyScroll(layerId);
+    };
+  }, [enabled, layerId]);
+};
+
+export type RootProps = RootDialogProps &
+  LegacyFocusScopeProps &
   TgphComponentProps<typeof Stack> & {
     a11yTitle: string;
     a11yDescription?: string;
@@ -45,162 +142,356 @@ const Root = ({
   });
 
   const stacking = useModalStacking();
-  const id = props.a11yTitle;
+  const stackId = useId();
 
-  React.useEffect(() => {
-    if (!open && stacking.layers.includes(id)) {
-      stacking.removeLayer(id);
+  useEffect(() => {
+    if (!open && stacking.layers.includes(stackId)) {
+      stacking.removeLayer(stackId);
     }
-  }, [id, stacking, open]);
+  }, [stackId, stacking, open]);
 
   // Prevent rendering anything within the modal if it is not open
   if (!open) return;
 
-  return <RootComponent open={open} onOpenChange={onOpenChange} {...props} />;
+  return (
+    <RootComponent
+      open={open}
+      onOpenChange={onOpenChange}
+      stackId={stackId}
+      {...props}
+    />
+  );
 };
 
 type RootComponentProps = RootProps & {
   open: boolean;
   onOpenChange: (value: boolean) => void;
+  stackId: string;
 };
 
 const RootComponent = ({
   open,
   onOpenChange,
+  stackId,
   a11yTitle,
   a11yDescription,
   children,
-  // Focus scope props
+  // The previous Radix implementation accepted `loop` through FocusScope
+  // types but did not wire it through. Keep consuming it as a no-op
+  // compatibility prop so existing callers do not leak it to the DOM.
+  loop: _loop,
   trapped,
   onMountAutoFocus,
   onUnmountAutoFocus,
   ...props
 }: RootComponentProps) => {
-  // We use the a11yTitle as the id for the modal as it is unique
-  // and can be used to identify the modal in the stacking context.
-  // Without the need to generate a random id and manage between
-  // different modal rendering patterns.
-  const id = a11yTitle;
+  const layerId = stackId;
   const stacking = useModalStacking();
-  React.useEffect(() => {
-    if (!stacking || !open || stacking.layers.includes(id)) return;
-    stacking.addLayer(id);
-  }, [id, stacking, open]);
+  const contentCallbacksRef = useRef<LegacyDismissHandlers>({});
+  // Shared backdrop clicks can be translated into a manual stack close. Keep
+  // this scoped to Base UI outside-press reports so it cannot cancel the next
+  // unrelated Escape or close-button request.
+  const suppressNextRootOutsideDismissRef = useRef(false);
+  const rootFocusCallbacksRef = useRef<
+    ModalCompatibilityContextProps["rootFocusCallbacksRef"]["current"]
+  >({});
 
-  const layer = stacking.layers?.indexOf(id) || 0;
+  // Keep the latest Root-level autofocus callbacks available to Content, where
+  // Base UI actually asks for initial/final focus decisions.
+  rootFocusCallbacksRef.current = {
+    onMountAutoFocus,
+    onUnmountAutoFocus,
+  };
+
+  useLayoutEffect(() => {
+    if (!stacking || !open || stacking.layers.includes(layerId)) return;
+    stacking.addLayer(layerId);
+  }, [layerId, stacking, open]);
+
+  const layerIndex = stacking.layers.indexOf(layerId);
+  const layer = layerIndex === -1 ? 0 : layerIndex;
   const layersLength = stacking.layers?.length || 0;
   const isStacked = layer !== 0;
-  const isTopLayer = id === stacking.layers[stacking.layers.length - 1];
+  const isTopLayer =
+    layersLength === 0 ||
+    layerId === stacking.layers[stacking.layers.length - 1];
+  const trappedFocus = typeof trapped === "boolean" ? trapped : isTopLayer;
+  const shouldLockScroll = open && trapped === false;
+
+  useBodyScrollLock(layerId, shouldLockScroll);
+
+  const requestClose = useCallback(() => {
+    const hasLayers = stacking?.layers?.length > 0;
+
+    if (hasLayers) {
+      if (layerId !== stacking.layers[stacking.layers.length - 1]) {
+        // Non-top layers stay open when a shared backdrop event reaches them.
+        return false;
+      }
+
+      // The modal stack owns layer bookkeeping; only then do we mirror the
+      // close through Telegraph's public open state.
+      stacking.removeLayer(layerId);
+      onOpenChange(false);
+      return true;
+    }
+
+    onOpenChange(false);
+    return true;
+  }, [layerId, onOpenChange, stacking]);
+  const suppressNextRootOutsideDismiss = useCallback(() => {
+    suppressNextRootOutsideDismissRef.current = true;
+
+    globalThis.setTimeout(() => {
+      suppressNextRootOutsideDismissRef.current = false;
+    }, ROOT_OUTSIDE_DISMISS_SUPPRESSION_DELAY_MS);
+  }, []);
+  const closeFromPointerDismiss = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      const nativeEvent = (event.nativeEvent ?? event) as Event;
+      const legacyDismissPrevented = callLegacyDismissHandlers(
+        {
+          event: nativeEvent,
+          reason: BASE_UI_OUTSIDE_PRESS_DISMISS_REASON,
+        },
+        contentCallbacksRef.current,
+      );
+
+      if (legacyDismissPrevented || event.defaultPrevented) {
+        // Preserve Radix's cancelable outside-interaction callbacks and stop
+        // Base UI from closing after legacy code has prevented dismissal.
+        suppressNextRootOutsideDismiss();
+        event.preventDefault();
+        event.stopPropagation?.();
+        event.preventBaseUIHandler?.();
+        return false;
+      }
+
+      // We handle pointer dismissal through Telegraph's stack so only the top
+      // modal closes and lower layers do not each process the same event.
+      event.preventDefault();
+      event.stopPropagation?.();
+      event.preventBaseUIHandler?.();
+      const didRequestClose = requestClose();
+
+      if (didRequestClose) {
+        suppressNextRootOutsideDismiss();
+      }
+
+      return didRequestClose;
+    },
+    [requestClose, suppressNextRootOutsideDismiss],
+  );
+  const requestPointerDismiss = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      const nativeEvent = (event.nativeEvent ?? event) as Event;
+
+      const hasLayers = stacking?.layers?.length > 0;
+
+      // Base UI sees each dialog independently. Telegraph's stacked modal
+      // backdrop is shared, so backdrop clicks need to close only the top layer.
+      if (
+        hasLayers &&
+        layerId !== stacking.layers[stacking.layers.length - 1]
+      ) {
+        // A backdrop click can originate over a lower layer. Suppress every
+        // non-top layer, then ask the stack to dismiss only the top layer.
+        stacking.layers
+          .filter(
+            (currentLayerId) =>
+              currentLayerId !== stacking.layers[stacking.layers.length - 1],
+          )
+          .forEach((currentLayerId) => {
+            stacking.suppressNextDismissForLayer(currentLayerId);
+          });
+        stacking.ignorePointerDismissEvent(nativeEvent);
+        stacking.dismissTopLayerWithPointer(nativeEvent);
+        suppressNextRootOutsideDismiss();
+        event.preventDefault();
+        event.stopPropagation?.();
+        event.preventBaseUIHandler?.();
+        return;
+      }
+
+      closeFromPointerDismiss(event);
+    },
+    [
+      closeFromPointerDismiss,
+      layerId,
+      stacking,
+      suppressNextRootOutsideDismiss,
+    ],
+  );
+
+  const handleOpenChange = useCallback<
+    NonNullable<BaseDialogRootProps["onOpenChange"]>
+  >(
+    (value, eventDetails) => {
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        suppressNextRootOutsideDismissRef.current
+      ) {
+        // requestPointerDismiss already handled this outside press.
+        suppressNextRootOutsideDismissRef.current = false;
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        stacking.consumeSuppressedDismiss(layerId)
+      ) {
+        // Lower layers marked by the shared backdrop path should not react to
+        // the same outside-press details from Base UI.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        stacking.shouldIgnorePointerDismissEvent(eventDetails.event)
+      ) {
+        // The stack has already consumed this pointer event while dismissing the
+        // top layer, so ignore duplicate root notifications.
+        eventDetails.cancel();
+        return;
+      }
+
+      const hasLayers = stacking?.layers?.length > 0;
+
+      if (
+        !value &&
+        hasLayers &&
+        layerId !== stacking.layers[stacking.layers.length - 1]
+      ) {
+        // Lower stacked layers are inert; cancel before running consumer
+        // dismissal callbacks so only the active top layer sees Escape.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        callLegacyDismissHandlers(eventDetails, contentCallbacksRef.current)
+      ) {
+        // Content-level legacy dismissal handlers still get final say on close.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (hasLayers) {
+        if (
+          value === false &&
+          layerId === stacking.layers[stacking.layers.length - 1]
+        ) {
+          stacking.removeLayer(layerId);
+          onOpenChange(false);
+          return;
+        }
+
+        if (value === false) {
+          // A lower stacked layer should remain open if Base UI asks it to close
+          // while a higher layer is still present.
+          eventDetails.cancel();
+        }
+
+        return;
+      }
+
+      onOpenChange(value);
+    },
+    [layerId, onOpenChange, stacking],
+  );
+
+  useEffect(() => {
+    return stacking.registerPointerDismissHandler(
+      layerId,
+      closeFromPointerDismiss,
+    );
+  }, [closeFromPointerDismiss, layerId, stacking]);
 
   return (
     <LazyMotion features={domAnimation}>
-      <DismissableLayer
-        onEscapeKeyDown={(event) => {
-          if (!isTopLayer) return;
-          event.preventDefault();
-          stacking.removeTopLayer();
-          onOpenChange(false);
-        }}
-        onPointerDownOutside={(event) => {
-          if (!isTopLayer) return;
-          event.preventDefault();
-          stacking.removeTopLayer();
-          onOpenChange(false);
+      <ModalCompatibilityContext.Provider
+        value={{
+          contentCallbacksRef,
+          requestPointerDismiss,
+          rootFocusCallbacksRef,
         }}
       >
-        <Dialog.Root
+        <BaseDialog.Root
           open={open}
-          onOpenChange={(value) => {
-            const hasLayers = stacking?.layers?.length > 0;
-
-            if (hasLayers) {
-              if (
-                value === false &&
-                id === stacking.layers[stacking.layers.length - 1]
-              ) {
-                stacking.removeLayer(id);
-                return onOpenChange(false);
-              }
-              // If the modal is not the top layer, do not call onOpenChange
-              // when we are stacking the modals
-              return;
-            }
-
-            onOpenChange(value);
-          }}
-          key={id}
+          onOpenChange={handleOpenChange}
+          modal={trappedFocus}
+          disablePointerDismissal={!isTopLayer}
+          key={layerId}
         >
-          <VisuallyHidden.Root>
-            <Dialog.Title>{a11yTitle}</Dialog.Title>
+          <VisuallyHidden>
+            <BaseDialog.Title>{a11yTitle}</BaseDialog.Title>
             {a11yDescription && (
-              <Dialog.Description>{a11yDescription}</Dialog.Description>
+              <BaseDialog.Description>{a11yDescription}</BaseDialog.Description>
             )}
-          </VisuallyHidden.Root>
+          </VisuallyHidden>
           {open && (
             // We add the className "tgph" here so that styles within
             // the portal get scoped properly to telegraph
-            <Portal.Root className="tgph">
+            <BaseDialog.Portal className="tgph">
               <Overlay layer={layer}>
-                <FocusScope
-                  trapped={typeof trapped === "boolean" ? trapped : isTopLayer}
-                  onMountAutoFocus={onMountAutoFocus}
-                  onUnmountAutoFocus={onUnmountAutoFocus}
-                  asChild
-                >
-                  <RefToTgphRef>
+                <RefToTgphRef>
+                  <Stack
+                    as={motion.div}
+                    initial={{
+                      top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layersLength - 1})`,
+                    }}
+                    animate={{
+                      top: isStacked
+                        ? `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer} )`
+                        : "var(--tgph-spacing-16)",
+                    }}
+                    exit={{ top: 0 }}
+                    transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+                    w="full"
+                    justify="center"
+                    style={{
+                      position: "fixed",
+                      left: 0,
+                      maxHeight: "calc(100vh - var(--tgph-spacing-32))",
+                      maxWidth: "calc(100vw - var(--tgph-spacing-8))",
+                      zIndex: `calc(var(--tgph-zIndex-modal) + ${layer})`,
+                    }}
+                    key={`container-${layerId}`}
+                  >
                     <Stack
                       as={motion.div}
-                      initial={{
-                        top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layersLength - 1})`,
-                      }}
+                      direction="column"
                       animate={{
-                        top: isStacked
-                          ? `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer} )`
-                          : "var(--tgph-spacing-16)",
+                        scale: 1.02 - Math.abs(layersLength - layer) * 0.02,
                       }}
-                      exit={{ top: 0 }}
-                      transition={{ type: "spring", duration: 0.3, bounce: 0 }}
-                      w="full"
-                      justify="center"
-                      style={{
-                        position: "fixed",
-                        left: 0,
-                        maxHeight: "calc(100vh - var(--tgph-spacing-32))",
-                        maxWidth: "calc(100vw - var(--tgph-spacing-8))",
-                        zIndex: `calc(var(--tgph-zIndex-modal) + ${layer})`,
+                      transition={{
+                        duration: 0.2,
+                        bounce: 0,
+                        type: "spring",
                       }}
-                      key={`container-${id}`}
+                      maxW={props.maxW ?? "160"}
+                      w={props.w ?? "full"}
+                      bg="surface-1"
+                      rounded="4"
+                      shadow="3"
+                      key={`content-${layerId}`}
+                      {...props}
                     >
-                      <Stack
-                        direction="column"
-                        as={motion.div}
-                        animate={{
-                          scale: 1.02 - Math.abs(layersLength - layer) * 0.02,
-                          transformOrigin: "center center",
-                        }}
-                        transition={{
-                          duration: 0.2,
-                          bounce: 0,
-                          type: "spring",
-                        }}
-                        maxW={props.maxW ?? "160"}
-                        w={props.w ?? "full"}
-                        bg="surface-1"
-                        rounded="4"
-                        shadow="3"
-                        key={`content-${id}`}
-                        {...props}
-                      >
-                        {children}
-                      </Stack>
+                      {children}
                     </Stack>
-                  </RefToTgphRef>
-                </FocusScope>
+                  </Stack>
+                </RefToTgphRef>
               </Overlay>
-            </Portal.Root>
+            </BaseDialog.Portal>
           )}
-        </Dialog.Root>
-      </DismissableLayer>
+        </BaseDialog.Root>
+      </ModalCompatibilityContext.Provider>
     </LazyMotion>
   );
 };
@@ -210,46 +501,154 @@ export type OverlayProps = TgphComponentProps<typeof Box> & {
 };
 
 const Overlay = ({ layer, children }: OverlayProps) => {
+  const compatibilityContext = useContext(ModalCompatibilityContext);
+
   // If the layer is greater than 0, we don't want to show this
   // overlay as to not stack the overlays on top of each other.
   if (layer > 0) return children;
+
   return (
-    <Dialog.Overlay>
-      <Box
-        as={motion.div}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3, bounce: 0, type: "spring" }}
-        bg="alpha-black-6"
-        w="full"
-        h="full"
-        zIndex="overlay"
-        style={{
-          position: "fixed",
-          cursor: "pointer",
-          inset: "0px",
-        }}
+    <>
+      <BaseDialog.Backdrop
+        render={createTgphBaseUIRender(
+          <Box
+            as={motion.div}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, bounce: 0, type: "spring" }}
+            bg="alpha-black-6"
+            w="full"
+            h="full"
+            zIndex="overlay"
+            data-tgph-modal-overlay
+            onPointerDownCapture={(event) => {
+              compatibilityContext?.requestPointerDismiss(event);
+            }}
+            style={{
+              position: "fixed",
+              cursor: "pointer",
+              inset: "0px",
+            }}
+          />,
+        )}
       />
       {children}
-    </Dialog.Overlay>
+    </>
   );
 };
 
-export type ContentProps = React.ComponentPropsWithoutRef<
-  typeof Dialog.Content
+export type ContentProps = Partial<
+  Omit<
+    BaseDialogPopupProps,
+    | "children"
+    | "className"
+    | "finalFocus"
+    | "initialFocus"
+    | "render"
+    | "style"
+  >
 > &
-  TgphComponentProps<typeof Stack>;
-type ContentRef = React.ElementRef<typeof Dialog.Content>;
+  LegacyDismissHandlers & {
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+  } & TgphComponentProps<typeof Stack>;
+type ContentRef = HTMLDivElement;
 
-const Content = React.forwardRef<ContentRef, ContentProps>(
-  ({ children, ...props }, forwardedRef) => {
+type ModalContentStackProps = TgphComponentProps<typeof Stack> & {
+  tgphRef?: Ref<ContentRef>;
+};
+
+const ModalContentStack = forwardRef<ContentRef, ModalContentStackProps>(
+  ({ tgphRef, ...props }, forwardedRef) => {
+    const composedRef = useComposedRefs(forwardedRef, tgphRef);
+
+    return <Stack tgphRef={composedRef} {...props} />;
+  },
+);
+
+ModalContentStack.displayName = "ModalContentStack";
+
+const Content = forwardRef<ContentRef, ContentProps>(
+  (
+    {
+      children,
+      onCloseAutoFocus,
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onOpenAutoFocus,
+      onPointerDownOutside,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const compatibilityContext = useContext(ModalCompatibilityContext);
+    const resolvedInitialFocus = useCallback(() => {
+      // Combine Root and Content autofocus callbacks before converting their
+      // Radix-style preventDefault result into Base UI's boolean focus API.
+      const rootFocusPrevented = callAutoFocusHandler(
+        compatibilityContext?.rootFocusCallbacksRef.current.onMountAutoFocus,
+        "mountAutoFocus",
+      );
+      const contentFocusPrevented = callAutoFocusHandler(
+        onOpenAutoFocus,
+        "openAutoFocus",
+      );
+
+      return rootFocusPrevented || contentFocusPrevented ? false : true;
+    }, [compatibilityContext, onOpenAutoFocus]);
+    const resolvedFinalFocus = useCallback(() => {
+      // Close autofocus follows the same Radix preventDefault contract as open
+      // autofocus, but maps to Base UI's finalFocus callback.
+      const rootFocusPrevented = callAutoFocusHandler(
+        compatibilityContext?.rootFocusCallbacksRef.current.onUnmountAutoFocus,
+        "unmountAutoFocus",
+      );
+      const contentFocusPrevented = callAutoFocusHandler(
+        onCloseAutoFocus,
+        "closeAutoFocus",
+      );
+
+      return rootFocusPrevented || contentFocusPrevented ? false : true;
+    }, [compatibilityContext, onCloseAutoFocus]);
+
+    useEffect(() => {
+      if (!compatibilityContext) {
+        return;
+      }
+
+      // Store the latest content dismiss callbacks where Root can consult them
+      // from Base UI's single onOpenChange details callback.
+      compatibilityContext.contentCallbacksRef.current = {
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      };
+
+      return () => {
+        compatibilityContext.contentCallbacksRef.current = {};
+      };
+    }, [
+      compatibilityContext,
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onPointerDownOutside,
+    ]);
+
     return (
-      <Dialog.Content ref={forwardedRef} asChild {...props}>
-        <Stack direction="column" h="full" {...props}>
-          {children}
-        </Stack>
-      </Dialog.Content>
+      <BaseDialog.Popup
+        ref={forwardedRef}
+        initialFocus={resolvedInitialFocus}
+        finalFocus={resolvedFinalFocus}
+        render={createTgphBaseUIRender(
+          <ModalContentStack direction="column" h="full" {...props}>
+            {children}
+          </ModalContentStack>,
+        )}
+      />
     );
   },
 );
@@ -257,21 +656,41 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
 export type CloseProps<T extends TgphElement = "button"> = TgphComponentProps<
   typeof Button<T>
 > &
-  Omit<React.ComponentPropsWithoutRef<typeof Dialog.Close>, "color">;
+  Omit<BaseDialogCloseProps, "children" | "color" | "render">;
 const Close = <T extends TgphElement = "button">({
+  disabled,
+  onClick,
   size = "1",
   variant = "ghost",
   ...props
 }: CloseProps<T>) => {
+  const handleClick = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      onClick?.(event);
+
+      if (event.defaultPrevented) {
+        // Prevented custom close clicks should also opt out of Base UI's close
+        // handler, matching Radix Close asChild behavior.
+        event.preventBaseUIHandler?.();
+      }
+    },
+    [onClick],
+  );
+
   return (
-    <Dialog.Close asChild>
-      <Button
-        icon={{ icon: X, alt: "Close Modal" }}
-        variant={variant}
-        size={size}
-        {...props}
-      />
-    </Dialog.Close>
+    <BaseDialog.Close
+      disabled={disabled}
+      render={createTgphBaseUIRender(
+        <Button
+          disabled={disabled}
+          icon={{ icon: X, alt: "Close Modal" }}
+          onClick={handleClick}
+          variant={variant}
+          size={size}
+          {...props}
+        />,
+      )}
+    />
   );
 };
 
@@ -357,14 +776,14 @@ const Heading = <T extends TgphElement = "h2">({
   weight = "medium",
   ...props
 }: HeadingProps<T>) => {
-  return (
-    <TelegraphHeading
-      as={(as || "h2") as T}
-      size={size}
-      weight={weight}
-      {...props}
-    />
-  );
+  const headingProps = {
+    as: (as || "h2") as T,
+    size,
+    weight,
+    ...props,
+  } as TgphComponentProps<typeof TelegraphHeading<T>>;
+
+  return <TelegraphHeading {...headingProps} />;
 };
 
 const Modal = {} as {

--- a/packages/modal/src/Modal/ModalStacking.tsx
+++ b/packages/modal/src/Modal/ModalStacking.tsx
@@ -1,43 +1,152 @@
-import React from "react";
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-const ModalStackingContext = React.createContext<{
+type PointerDismissHandler = (event: Event) => void;
+
+const SUPPRESSED_POINTER_DISMISS_RESET_DELAY_MS = 100;
+
+const ModalStackingContext = createContext<{
+  dismissTopLayerWithPointer: (event: Event) => void;
+  ignorePointerDismissEvent: (event: Event) => void;
   layers: Array<string>;
-  setLayers: React.Dispatch<React.SetStateAction<Array<string>>>;
+  setLayers: Dispatch<SetStateAction<Array<string>>>;
   addLayer: (id: string) => void;
+  consumeSuppressedDismiss: (id: string) => boolean;
+  registerPointerDismissHandler: (
+    id: string,
+    handler: PointerDismissHandler,
+  ) => () => void;
   removeLayer: (id: string) => void;
   removeTopLayer: () => void;
+  shouldIgnorePointerDismissEvent: (event: Event) => boolean;
+  suppressNextDismissForLayer: (id: string) => void;
 }>({
+  dismissTopLayerWithPointer: () => {},
+  ignorePointerDismissEvent: () => {},
   layers: [],
   setLayers: () => {},
   addLayer: () => {},
+  consumeSuppressedDismiss: () => false,
+  registerPointerDismissHandler: () => () => {},
   removeLayer: () => {},
   removeTopLayer: () => {},
+  shouldIgnorePointerDismissEvent: () => false,
+  suppressNextDismissForLayer: () => {},
 });
 
 type ModalStackingProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const ModalStackingProvider = ({ children }: ModalStackingProviderProps) => {
-  const [layers, setLayers] = React.useState<Array<string>>([]);
+  const [layers, setLayers] = useState<Array<string>>([]);
+  const layersRef = useRef<Array<string>>([]);
+  const ignoredPointerDismissEventsRef = useRef(new WeakSet<Event>());
+  const pointerDismissHandlersRef = useRef(
+    new Map<string, PointerDismissHandler>(),
+  );
+  const suppressedDismissLayersRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    layersRef.current = layers;
+  }, [layers]);
 
   const addLayer = (id: string) => {
-    setLayers((current) => [...current, id]);
+    setLayers((current) => {
+      const nextLayers = current.includes(id) ? current : [...current, id];
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
 
   const removeLayer = (id: string) => {
-    setLayers(layers.filter((layer) => layer !== id));
+    setLayers((current) => {
+      const nextLayers = current.filter((layer) => layer !== id);
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
 
   const removeTopLayer = () => {
-    const id = layers[layers.length - 1];
-    if (!id) return;
-    removeLayer(id);
+    setLayers((current) => {
+      const nextLayers = current.slice(0, -1);
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
+
+  const registerPointerDismissHandler = useCallback(
+    (id: string, handler: PointerDismissHandler) => {
+      pointerDismissHandlersRef.current.set(id, handler);
+
+      return () => {
+        if (pointerDismissHandlersRef.current.get(id) === handler) {
+          pointerDismissHandlersRef.current.delete(id);
+        }
+      };
+    },
+    [],
+  );
+
+  const dismissTopLayerWithPointer = useCallback((event: Event) => {
+    const topLayer = layersRef.current[layersRef.current.length - 1];
+
+    if (!topLayer) {
+      return;
+    }
+
+    pointerDismissHandlersRef.current.get(topLayer)?.(event);
+  }, []);
+  const ignorePointerDismissEvent = useCallback((event: Event) => {
+    ignoredPointerDismissEventsRef.current.add(event);
+  }, []);
+  const shouldIgnorePointerDismissEvent = useCallback((event: Event) => {
+    return ignoredPointerDismissEventsRef.current.has(event);
+  }, []);
+  const suppressNextDismissForLayer = useCallback((id: string) => {
+    suppressedDismissLayersRef.current.add(id);
+
+    globalThis.setTimeout(() => {
+      suppressedDismissLayersRef.current.delete(id);
+    }, SUPPRESSED_POINTER_DISMISS_RESET_DELAY_MS);
+  }, []);
+  const consumeSuppressedDismiss = useCallback((id: string) => {
+    const isSuppressed = suppressedDismissLayersRef.current.has(id);
+
+    if (isSuppressed) {
+      suppressedDismissLayersRef.current.delete(id);
+    }
+
+    return isSuppressed;
+  }, []);
 
   return (
     <ModalStackingContext.Provider
-      value={{ layers, setLayers, addLayer, removeLayer, removeTopLayer }}
+      value={{
+        dismissTopLayerWithPointer,
+        ignorePointerDismissEvent,
+        layers,
+        setLayers,
+        addLayer,
+        consumeSuppressedDismiss,
+        registerPointerDismissHandler,
+        removeLayer,
+        removeTopLayer,
+        shouldIgnorePointerDismissEvent,
+        suppressNextDismissForLayer,
+      }}
     >
       {children}
     </ModalStackingContext.Provider>
@@ -45,7 +154,7 @@ const ModalStackingProvider = ({ children }: ModalStackingProviderProps) => {
 };
 
 const useModalStacking = () => {
-  return React.useContext(ModalStackingContext);
+  return useContext(ModalStackingContext);
 };
 
 export { ModalStackingProvider, useModalStacking };

--- a/packages/modal/vitest.config.mts
+++ b/packages/modal/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "modal",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -1,6 +1,6 @@
 # 💬 Popover
 
-> Accessible popover component with positioning, animations, and portal rendering built on Radix UI.
+> Accessible popover component with positioning, animations, and portal rendering built on Base UI.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -76,22 +76,26 @@ The trigger element that opens/closes the popover. Must wrap a single focusable 
 
 The popover content container that appears in a portal.
 
-| Prop            | Type                                     | Default       | Description                           |
-| --------------- | ---------------------------------------- | ------------- | ------------------------------------- |
-| `side`          | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`    | Side to display popover               |
-| `align`         | `"start" \| "center" \| "end"`           | `"center"`    | Alignment relative to trigger         |
-| `sideOffset`    | `number`                                 | `4`           | Distance from trigger                 |
-| `alignOffset`   | `number`                                 | `0`           | Additional alignment offset           |
-| `gap`           | `SpacingToken`                           | `"1"`         | Gap between content items             |
-| `py`            | `SpacingToken`                           | `"1"`         | Vertical padding                      |
-| `rounded`       | `RoundedToken`                           | `"4"`         | Border radius                         |
-| `shadow`        | `ShadowToken`                            | `"2"`         | Drop shadow                           |
-| `border`        | `SpacingToken`                           | `"px"`        | Border width                          |
-| `borderColor`   | `ColorToken`                             | `"gray-8"`    | Border color                          |
-| `bg`            | `ColorToken`                             | `"surface-1"` | Background color                      |
-| `skipAnimation` | `boolean`                                | `false`       | Whether to skip enter/exit animations |
+| Prop               | Type                                     | Default       | Description                                     |
+| ------------------ | ---------------------------------------- | ------------- | ----------------------------------------------- |
+| `side`             | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`    | Side to display popover                         |
+| `align`            | `"start" \| "center" \| "end"`           | `"center"`    | Alignment relative to trigger                   |
+| `sideOffset`       | `number`                                 | `4`           | Distance from trigger                           |
+| `alignOffset`      | `number`                                 | `0`           | Additional alignment offset                     |
+| `avoidCollisions`  | `boolean`                                | `true`        | Flip/shift content to avoid viewport collisions |
+| `hideWhenDetached` | `boolean`                                | `false`       | Hide content while the anchor is detached       |
+| `gap`              | `SpacingToken`                           | `"1"`         | Gap between content items                       |
+| `py`               | `SpacingToken`                           | `"1"`         | Vertical padding                                |
+| `rounded`          | `RoundedToken`                           | `"4"`         | Border radius                                   |
+| `shadow`           | `ShadowToken`                            | `"2"`         | Drop shadow                                     |
+| `border`           | `SpacingToken`                           | `"px"`        | Border width                                    |
+| `borderColor`      | `ColorToken`                             | `"gray-8"`    | Border color                                    |
+| `bg`               | `ColorToken`                             | `"surface-1"` | Background color                                |
+| `skipAnimation`    | `boolean`                                | `false`       | Whether to skip enter/exit animations           |
 
 Inherits all Stack props for additional styling.
+
+Popover is implemented with Base UI Popover primitives and rendered through Telegraph layout components, so the public API, styling tokens, and `tgphRef` support remain stable while the underlying headless behavior comes from Base UI.
 
 ## Usage Patterns
 
@@ -645,9 +649,9 @@ The popover component uses Telegraph design tokens for consistent styling:
 
 ```tsx
 import { Button } from "@telegraph/button";
-import { Tag } from "@telegraph/tag";
 import { Box, Stack } from "@telegraph/layout";
 import { Popover } from "@telegraph/popover";
+import { Tag } from "@telegraph/tag";
 
 export const UserProfilePopover = ({ user }) => (
   <Popover.Root>
@@ -670,7 +674,11 @@ export const UserProfilePopover = ({ user }) => (
           <Stack direction="column" gap="1">
             <Stack direction="row" align="center" gap="2">
               <strong>{user.name}</strong>
-              {user.isOnline && <Tag size="0" color="green">Online</Tag>}
+              {user.isOnline && (
+                <Tag size="0" color="green">
+                  Online
+                </Tag>
+              )}
             </Stack>
             <span>{user.role}</span>
           </Stack>
@@ -984,7 +992,7 @@ export const SearchFilterPopover = ({ onApplyFilters }) => {
 
 ## References
 
-- [Radix UI Popover](https://www.radix-ui.com/docs/primitives/components/popover)
+- [Base UI Popover](https://base-ui.com/react/components/popover)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/popover)
 
 ## Contributing

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -32,8 +32,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-popover": "^1.1.15",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",
     "motion": "^12.38.0"

--- a/packages/popover/src/Popover/Popover.helpers.ts
+++ b/packages/popover/src/Popover/Popover.helpers.ts
@@ -1,0 +1,7 @@
+const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;
+
+export { NO_COLLISION_AVOIDANCE };

--- a/packages/popover/src/Popover/Popover.stories.tsx
+++ b/packages/popover/src/Popover/Popover.stories.tsx
@@ -6,6 +6,25 @@ import { Ellipsis } from "lucide-react";
 
 import { Popover } from "./Popover";
 
+const placementOptions = [
+  {
+    label: "Top",
+    side: "top",
+  },
+  {
+    label: "Right",
+    side: "right",
+  },
+  {
+    label: "Bottom",
+    side: "bottom",
+  },
+  {
+    label: "Left",
+    side: "left",
+  },
+] as const;
+
 const meta: Meta = {
   tags: ["autodocs"],
   title: "Components/Popover",
@@ -63,6 +82,63 @@ export const Default: Story = {
             <p>Test popover content</p>
           </Popover.Content>
         </Popover.Root>
+      </Stack>
+    );
+  },
+};
+
+export const Closed: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center">
+        <Popover.Root {...args}>
+          <Popover.Trigger asChild={true}>
+            <Button
+              variant="outline"
+              leadingIcon={{ icon: Ellipsis, "aria-hidden": true }}
+            />
+          </Popover.Trigger>
+          <Popover.Content
+            px="4"
+            align={args.align}
+            side={args.side}
+            skipAnimation={args.skipAnimation}
+          >
+            <p>Test popover content</p>
+          </Popover.Content>
+        </Popover.Root>
+      </Stack>
+    );
+  },
+};
+
+export const Placements: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack
+        w="full"
+        minH="96"
+        my="10"
+        direction="row"
+        gap="10"
+        align="center"
+        justify="center"
+      >
+        {placementOptions.map((placement) => (
+          <Popover.Root key={placement.side} {...args} defaultOpen={true}>
+            <Popover.Trigger asChild={true}>
+              <Button variant="outline">{placement.label}</Button>
+            </Popover.Trigger>
+            <Popover.Content
+              px="4"
+              align={args.align}
+              side={placement.side}
+              skipAnimation={args.skipAnimation}
+            >
+              <p>{placement.label} popover content</p>
+            </Popover.Content>
+          </Popover.Root>
+        ))}
       </Stack>
     );
   },

--- a/packages/popover/src/Popover/Popover.test.tsx
+++ b/packages/popover/src/Popover/Popover.test.tsx
@@ -1,11 +1,47 @@
-import { describe, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Popover } from "./Popover";
 import type { PopoverContentProps } from "./index";
+
+type PopoverRootActions = NonNullable<
+  NonNullable<
+    ComponentPropsWithoutRef<typeof Popover.Root>["actionsRef"]
+  >["current"]
+>;
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Popover", () => {
   describe("type inheritance", () => {
     it("accepts valid content-specific props", () => {
       const validProps: PopoverContentProps = {
+        avoidCollisions: false,
+        hideWhenDetached: true,
         side: "bottom",
         sideOffset: 4,
         skipAnimation: true,
@@ -28,5 +64,462 @@ describe("Popover", () => {
       const invalidProp: PopoverContentProps = { invalidProp: "invalid" };
       void invalidProp;
     });
+  });
+
+  it("is accessible when open", async () => {
+    render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content aria-label="Settings" skipAnimation>
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+
+    expectToHaveNoViolations(await axe(dialog));
+  });
+
+  it("opens and closes with the trigger in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover.Root onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Popover.Root
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+        >
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content skipAnimation>Settings content</Popover.Content>
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("opens on hover when Base UI trigger hover props are passed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger openOnHover delay={0} closeDelay={0}>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+  });
+
+  it("preserves Base UI touch-aware default open focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content>
+          <input aria-label="Setting name" />
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.pointer({
+      keys: "[TouchA]",
+      target: screen.getByRole("button", { name: "Open settings" }),
+    });
+
+    const dialog = await screen.findByRole("dialog");
+
+    expect(dialog).toHaveFocus();
+    expect(
+      screen.getByRole("textbox", { name: "Setting name" }),
+    ).not.toHaveFocus();
+  });
+
+  it("dismisses with Escape and outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Popover.Root defaultOpen>
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+            skipAnimation
+          >
+            Settings content
+          </Popover.Content>
+        </Popover.Root>
+      </>,
+    );
+
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the popover open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover.Root defaultOpen onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          skipAnimation
+        >
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("lets legacy open autofocus handlers move focus", async () => {
+    const user = userEvent.setup();
+    const inputRef = createRef<HTMLInputElement>();
+    const onOpenAutoFocus = vi.fn((event: Event) => {
+      event.preventDefault();
+      inputRef.current?.focus();
+    });
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content onOpenAutoFocus={onOpenAutoFocus} skipAnimation>
+          <input aria-label="Setting name" ref={inputRef} />
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    const input = await screen.findByRole("textbox", { name: "Setting name" });
+
+    expect(input).toHaveFocus();
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps animated content mounted while close motion starts", async () => {
+    const user = userEvent.setup();
+    const actionsRef: { current: PopoverRootActions | null } = {
+      current: null,
+    };
+    const unmount = vi.fn();
+
+    render(
+      <Popover.Root actionsRef={actionsRef} defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content data-testid="popover-content">
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+
+    actionsRef.current = {
+      ...actionsRef.current,
+      unmount,
+    } as PopoverRootActions;
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(screen.getByTestId("popover-content")).toHaveAttribute(
+      "data-state",
+      "closed",
+    );
+  });
+
+  it("finishes the deferred close unmount if controlled content unmounts before animation completion", async () => {
+    const user = userEvent.setup();
+    const actionsRef: { current: PopoverRootActions | null } = {
+      current: null,
+    };
+    const unmount = vi.fn();
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(true);
+
+      return (
+        <Popover.Root
+          open={open}
+          onOpenChange={setOpen}
+          actionsRef={actionsRef}
+        >
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          {open && (
+            <Popover.Content data-testid="popover-content">
+              Settings content
+            </Popover.Content>
+          )}
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+
+    actionsRef.current = {
+      ...actionsRef.current,
+      unmount,
+    } as PopoverRootActions;
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    await waitFor(() => {
+      expect(unmount).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByTestId("popover-content")).not.toBeInTheDocument();
+  });
+
+  it("keeps animated content mounted if the controlled root rerenders during close", async () => {
+    const user = userEvent.setup();
+    const unmount = vi.fn();
+    const onAnimationComplete = vi.fn();
+    let currentActions: PopoverRootActions | null = null;
+    const actionsRef: { current: PopoverRootActions | null } = {
+      get current() {
+        return currentActions;
+      },
+      set current(nextActions) {
+        currentActions = nextActions
+          ? ({ ...nextActions, unmount } as PopoverRootActions)
+          : null;
+      },
+    };
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(true);
+      const [rerenderCount, setRerenderCount] = useState(0);
+
+      return (
+        <Popover.Root
+          actionsRef={actionsRef}
+          open={open}
+          onOpenChange={(nextOpen) => {
+            setOpen(nextOpen);
+            setRerenderCount((count) => count + 1);
+          }}
+        >
+          <span data-testid="rerender-count">{rerenderCount}</span>
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content
+            data-testid="popover-content"
+            onAnimationComplete={onAnimationComplete}
+          >
+            Settings content
+          </Popover.Content>
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+    onAnimationComplete.mockClear();
+    unmount.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rerender-count")).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId("popover-content")).toHaveAttribute(
+      "data-state",
+      "closed",
+    );
+    await waitFor(() => {
+      expect(onAnimationComplete).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(unmount).toHaveBeenCalled();
+    });
+
+    expect(onAnimationComplete.mock.invocationCallOrder[0]).toBeLessThan(
+      unmount.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("returns focus to the trigger after dismissal", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+
+    await user.click(trigger);
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content data-testid="popover-content" skipAnimation>
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const content = await screen.findByTestId("popover-content");
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("role", "dialog");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("forwards trigger and content refs through tgphRef", async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const triggerTgphRef = createRef<HTMLButtonElement>();
+    const contentTgphRef = createRef<HTMLDivElement>();
+    const contentStackRef = createRef<HTMLDivElement>();
+
+    render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger ref={triggerRef} tgphRef={triggerTgphRef}>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content
+          contentStackRef={contentStackRef}
+          tgphRef={contentTgphRef}
+          skipAnimation
+        >
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+    const content = await screen.findByRole("dialog");
+
+    expect(triggerRef.current).toBe(trigger);
+    expect(triggerTgphRef.current).toBe(trigger);
+    expect(contentTgphRef.current).toBe(content);
+    expect(contentStackRef.current).toBe(content);
   });
 });

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -1,195 +1,405 @@
-import * as RadixPopover from "@radix-ui/react-popover";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Popover as BasePopover } from "@base-ui/react/popover";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
-  RefToTgphRef,
-  TgphComponentProps,
-  TgphElement,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
+  type TgphComponentProps,
+  type TgphElement,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
-export type RootProps = React.ComponentProps<typeof RadixPopover.Root> & {
-  defaultOpen?: boolean;
+import { NO_COLLISION_AVOIDANCE } from "./Popover.helpers";
+
+type BasePopoverRootProps = ComponentProps<typeof BasePopover.Root>;
+type BasePopoverTriggerProps = ComponentPropsWithoutRef<
+  typeof BasePopover.Trigger
+>;
+type BasePopoverPositionerProps = ComponentPropsWithoutRef<
+  typeof BasePopover.Positioner
+>;
+type BasePopoverPopupProps = ComponentPropsWithoutRef<typeof BasePopover.Popup>;
+type PopoverRootActions = BasePopover.Root.Actions;
+type MotionAnimationCompleteHandler = NonNullable<
+  ComponentProps<typeof motion.div>["onAnimationComplete"]
+>;
+
+export type RootProps = Omit<BasePopoverRootProps, "onOpenChange"> & {
+  onOpenChange?: (open: boolean) => void;
 };
 
-type PopoverContextProps = {
+type PopoverCompatibilityContextProps = {
+  closeAnimationRef: {
+    current: {
+      pendingCloseUnmount: boolean;
+      preventUnmountOnClose: boolean;
+    };
+  };
+  contentCallbacksRef: {
+    current: LegacyDismissHandlers;
+  };
+  rootActionsRef: RefObject<PopoverRootActions | null>;
+};
+
+type PopoverPopupRenderState = {
   open: boolean;
-  setOpen: (open: boolean) => void;
 };
 
-const PopoverContext = React.createContext<PopoverContextProps>({
-  open: false,
-  setOpen: () => {},
-});
+const PopoverCompatibilityContext =
+  createContext<PopoverCompatibilityContextProps | null>(null);
 
-const Root = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  children,
-  ...props
-}: RootProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
+const Root = ({ actionsRef, children, onOpenChange, ...props }: RootProps) => {
+  const internalRootActionsRef = useRef<PopoverRootActions | null>(null);
+  const rootActionsRef = actionsRef ?? internalRootActionsRef;
+  const closeAnimationRef = useRef({
+    pendingCloseUnmount: false,
+    preventUnmountOnClose: false,
   });
+  const contentCallbacksRef = useRef<LegacyDismissHandlers>({});
+  const compatibilityContext = useMemo<PopoverCompatibilityContextProps>(
+    () => ({
+      closeAnimationRef,
+      contentCallbacksRef,
+      rootActionsRef,
+    }),
+    [rootActionsRef],
+  );
+  const handleOpenChange = useCallback<
+    NonNullable<BasePopoverRootProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        callLegacyDismissHandlers(eventDetails, contentCallbacksRef.current)
+      ) {
+        // Legacy Radix outside/escape handlers could prevent dismissal, so
+        // translate that prevention back into Base UI's cancel API.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (open) {
+        closeAnimationRef.current.pendingCloseUnmount = false;
+      }
+
+      if (!open && closeAnimationRef.current.preventUnmountOnClose) {
+        // Keep the popup mounted through its exit animation; the content calls
+        // Base UI's action ref to unmount once motion reports completion.
+        closeAnimationRef.current.pendingCloseUnmount = true;
+        eventDetails.preventUnmountOnClose();
+      }
+
+      onOpenChange?.(open);
+    },
+    [onOpenChange],
+  );
 
   return (
     <LazyMotion features={domAnimation}>
-      <PopoverContext.Provider value={{ open, setOpen }}>
-        <RadixPopover.Root open={open} onOpenChange={setOpen} {...props}>
+      <PopoverCompatibilityContext.Provider value={compatibilityContext}>
+        <BasePopover.Root
+          actionsRef={rootActionsRef}
+          onOpenChange={handleOpenChange}
+          {...props}
+        >
           {children}
-        </RadixPopover.Root>
-      </PopoverContext.Provider>
+        </BasePopover.Root>
+      </PopoverCompatibilityContext.Provider>
     </LazyMotion>
   );
 };
 
-export type TriggerProps = React.ComponentProps<typeof RadixPopover.Trigger> & {
-  tgphRef?: React.RefObject<HTMLButtonElement>;
+export type TriggerProps = Omit<BasePopoverTriggerProps, "render"> & {
+  asChild?: boolean;
+  children?: ReactNode;
+  tgphRef?: Ref<HTMLButtonElement>;
 };
 
-const Trigger = ({
-  asChild = true,
-  tgphRef,
-  children,
-  ...props
-}: TriggerProps) => {
-  const context = React.useContext(PopoverContext);
+const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
+  ({ asChild = true, tgphRef, children, ...props }, forwardedRef) => {
+    const triggerRef = useComposedRefs<HTMLButtonElement>(
+      forwardedRef,
+      tgphRef,
+    );
 
-  return (
-    <RadixPopover.Trigger
-      onClick={() => {
-        context.setOpen(!context.open);
-      }}
-      asChild={asChild}
-      {...props}
-      ref={tgphRef}
-    >
-      <RefToTgphRef>{children}</RefToTgphRef>
-    </RadixPopover.Trigger>
-  );
-};
+    if (!asChild || !isValidElement(children)) {
+      return (
+        <BasePopover.Trigger {...props} ref={triggerRef}>
+          {children}
+        </BasePopover.Trigger>
+      );
+    }
 
-export type ContentProps<T extends TgphElement = "div"> = React.ComponentProps<
-  typeof RadixPopover.Content
+    return (
+      <BasePopover.Trigger
+        {...props}
+        ref={triggerRef}
+        render={createTgphBaseUIRender(children as ReactElement)}
+      />
+    );
+  },
+);
+
+export type ContentProps<T extends TgphElement = "div"> = Omit<
+  BasePopoverPositionerProps,
+  "children" | "className" | "render"
 > &
+  Omit<BasePopoverPopupProps, "children" | "className" | "render" | "style"> &
   Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
-    contentStackRef?: React.RefObject<HTMLDivElement>;
+    avoidCollisions?: boolean;
+    contentStackRef?: Ref<HTMLDivElement>;
+    forceMount?: boolean;
+    hideWhenDetached?: boolean;
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onEscapeKeyDown?: LegacyDismissHandlers["onEscapeKeyDown"];
+    onFocusOutside?: LegacyDismissHandlers["onFocusOutside"];
+    onInteractOutside?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+    onPointerDownOutside?: LegacyDismissHandlers["onPointerDownOutside"];
     skipAnimation?: boolean;
   };
 
 const Content = <T extends TgphElement = "div">({
+  align = "center",
+  alignOffset,
+  anchor,
+  arrowPadding,
+  children,
+  avoidCollisions,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  contentStackRef,
   direction = "column",
+  disableAnchorTracking,
+  finalFocus,
+  forceMount,
   gap = "1",
+  hideWhenDetached,
+  initialFocus,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocusOutside,
+  onInteractOutside,
+  onOpenAutoFocus,
+  onPointerDownOutside,
+  positionMethod,
   rounded = "4",
   py = "1",
   shadow = "2",
   side = "bottom",
   sideOffset = 4,
-  align = "center",
+  skipAnimation,
+  sticky,
   bg = "surface-1",
-  alignOffset,
   tgphRef,
   style,
-  skipAnimation,
-  children,
   ...props
 }: ContentProps<T>) => {
-  const deriveAnimationBasedOnSide = (side: ContentProps<T>["side"]) => {
-    const ANIMATION_OFFSET = 5;
-    if (side === "top") {
-      return {
-        y: -ANIMATION_OFFSET,
-      };
-    }
+  const compatibilityContext = useContext(PopoverCompatibilityContext);
+  const contentRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    contentStackRef as Ref<HTMLElement>,
+  );
+  const shouldAnimate = !skipAnimation;
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  // Base UI unmounts immediately on close unless we explicitly hold the popup
+  // mounted, which is only needed for animated, non-force-mounted content.
+  const shouldManageCloseAnimation = shouldAnimate && !forceMount;
+  const resolvedInitialFocus =
+    initialFocus ??
+    (onOpenAutoFocus
+      ? () => {
+          const event = new Event("openAutoFocus", { cancelable: true });
+          onOpenAutoFocus(event);
 
-    if (side === "bottom") {
-      return {
-        y: ANIMATION_OFFSET,
-      };
-    }
+          // Base UI uses `false` to cancel autofocus; Radix used
+          // preventDefault on the synthetic lifecycle event.
+          return event.defaultPrevented ? false : true;
+        }
+      : undefined);
+  const resolvedFinalFocus =
+    finalFocus ??
+    (onCloseAutoFocus
+      ? () => {
+          const event = new Event("closeAutoFocus", { cancelable: true });
+          onCloseAutoFocus(event);
 
-    if (side === "left") {
-      return {
-        x: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "right") {
-      return {
-        x: ANIMATION_OFFSET,
-      };
-    }
+          // Preserve Radix's close autofocus contract while using Base UI's
+          // boolean finalFocus callback shape.
+          return event.defaultPrevented ? false : true;
+        }
+      : undefined);
+  const { onAnimationComplete, ...stackProps } = props as typeof props & {
+    onAnimationComplete?: MotionAnimationCompleteHandler;
   };
 
+  useEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Tell the root whether this content needs Base UI's unmount prevented
+    // until the exit animation has had a chance to complete.
+    compatibilityContext.closeAnimationRef.current = {
+      ...compatibilityContext.closeAnimationRef.current,
+      preventUnmountOnClose: shouldManageCloseAnimation,
+    };
+
+    return () => {
+      if (compatibilityContext.closeAnimationRef.current.pendingCloseUnmount) {
+        // A controlled parent can stop rendering Content as soon as it sees
+        // onOpenChange(false); in that case the motion callback below will not
+        // fire, so finish Base UI's deferred unmount from cleanup.
+        compatibilityContext.rootActionsRef.current?.unmount();
+      }
+
+      compatibilityContext.closeAnimationRef.current = {
+        ...compatibilityContext.closeAnimationRef.current,
+        pendingCloseUnmount: false,
+        preventUnmountOnClose: false,
+      };
+    };
+  }, [compatibilityContext, shouldManageCloseAnimation]);
+
+  useEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Store the latest legacy dismiss callbacks where Root can reach them from
+    // Base UI's single `onOpenChange` dismissal details callback.
+    compatibilityContext.contentCallbacksRef.current = {
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onPointerDownOutside,
+    };
+
+    return () => {
+      compatibilityContext.contentCallbacksRef.current = {};
+    };
+  }, [
+    compatibilityContext,
+    onEscapeKeyDown,
+    onFocusOutside,
+    onInteractOutside,
+    onPointerDownOutside,
+  ]);
+  const closedAnimation = shouldAnimate
+    ? {
+        opacity: 0.5,
+        scale: 0.6,
+        ...getBaseUIMotionOffset(side),
+      }
+    : undefined;
+
   return (
-    <RadixPopover.Portal>
-      <RadixPopover.Content
-        asChild
-        side={side}
-        sideOffset={sideOffset}
+    <BasePopover.Portal keepMounted={forceMount}>
+      <BasePopover.Positioner
         align={align}
         alignOffset={alignOffset}
-        {...props}
-        ref={tgphRef}
+        anchor={anchor}
+        arrowPadding={arrowPadding}
+        collisionAvoidance={resolvedCollisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        disableAnchorTracking={disableAnchorTracking}
+        positionMethod={positionMethod}
+        side={side}
+        sideOffset={sideOffset}
+        sticky={sticky}
+        style={(state) =>
+          getBaseUIPositionerVisibilityStyle({
+            anchorHidden: state.anchorHidden,
+            hideWhenDetached,
+          })
+        }
       >
-        <RefToTgphRef>
-          <Stack
-            as={motion.div}
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            initial={
-              skipAnimation
-                ? undefined
-                : {
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
+        <BasePopover.Popup
+          initialFocus={resolvedInitialFocus}
+          finalFocus={resolvedFinalFocus}
+          render={createTgphBaseUIRender((state: PopoverPopupRenderState) => (
+            <Stack
+              as={motion.div}
+              className="tgph"
+              initial={closedAnimation}
+              animate={
+                shouldAnimate
+                  ? state.open
+                    ? {
+                        opacity: 1,
+                        scale: 1,
+                        x: 0,
+                        y: 0,
+                      }
+                    : closedAnimation
+                  : undefined
+              }
+              exit={closedAnimation}
+              transition={{
+                duration: 0.1,
+                type: "spring",
+                bounce: 0,
+              }}
+              bg={bg}
+              data-state={state.open ? "open" : "closed"}
+              direction={direction}
+              gap={gap}
+              rounded={rounded}
+              py={py}
+              shadow={shadow}
+              style={{
+                overflowY: "auto",
+                transformOrigin: "var(--transform-origin)",
+                ...style,
+              }}
+              tgphRef={contentRef}
+              zIndex="popover"
+              key="tgph-popover-content"
+              {...stackProps}
+              onAnimationComplete={(definition) => {
+                onAnimationComplete?.(definition);
+
+                if (!state.open && shouldManageCloseAnimation) {
+                  // The root held the popup mounted for the exit animation; now
+                  // that motion is done, ask Base UI to finish the unmount.
+                  if (compatibilityContext) {
+                    compatibilityContext.closeAnimationRef.current.pendingCloseUnmount = false;
                   }
-            }
-            animate={{
-              opacity: 1,
-              scale: 1,
-              x: 0,
-              y: 0,
-            }}
-            exit={
-              skipAnimation
-                ? undefined
-                : {
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
-                  }
-            }
-            transition={{
-              duration: 0.1,
-              type: "spring",
-              bounce: 0,
-            }}
-            bg={bg}
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-              transformOrigin: "var(--radix-tooltip-content-transform-origin)",
-              ...style,
-            }}
-            zIndex="popover"
-            key="tgph-popover-content"
-          >
-            {children}
-          </Stack>
-        </RefToTgphRef>
-      </RadixPopover.Content>
-    </RadixPopover.Portal>
+                  compatibilityContext?.rootActionsRef.current?.unmount();
+                }
+              }}
+            >
+              {children}
+            </Stack>
+          ))}
+        />
+      </BasePopover.Positioner>
+    </BasePopover.Portal>
   );
 };
 

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -75,6 +75,8 @@ export const ActionSelector = () => {
 ### `<RadioCards>`
 
 The main component that renders a radio group with card-style options.
+RadioCards is backed by Base UI Radio primitives and keeps the Telegraph public
+API, styling hooks, and `tgphRef` behavior stable.
 
 | Prop            | Type                                                     | Default     | Description                          |
 | --------------- | -------------------------------------------------------- | ----------- | ------------------------------------ |
@@ -88,8 +90,8 @@ The main component that renders a radio group with card-style options.
 ```tsx
 type RadioOption = {
   value: string;
-  title?: string;
-  description?: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
   icon?: { icon: LucideIcon; alt: string };
   // Additional RadioCards.Item props
 };
@@ -100,7 +102,7 @@ type RadioOption = {
 For custom layouts, use the individual components:
 
 - **`<RadioCards.Root>`** - Radio group container
-- **`<RadioCards.Item>`** - Individual radio button item
+- **`<RadioCards.Item>`** - Individual radio button item rendered as a Telegraph button
 - **`<RadioCards.ItemTitle>`** - Title text component
 - **`<RadioCards.ItemDescription>`** - Description text component
 - **`<RadioCards.ItemIcon>`** - Icon component
@@ -322,8 +324,8 @@ export const ConditionalRadio = ({ userPlan, options }) => {
 ### Loading States
 
 ```tsx
-import { RadioCards } from "@telegraph/radio";
 import { Box, Stack } from "@telegraph/layout";
+import { RadioCards } from "@telegraph/radio";
 
 export const RadioCardsWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -446,32 +448,32 @@ Individual radio button item.
 
 Title text component for radio items.
 
-| Prop       | Type                                  | Default     | Description        |
-| ---------- | ------------------------------------- | ----------- | ------------------ |
-| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"` | Text size |
-| `weight`   | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight        |
-| `children` | `ReactNode`                           | -           | Title text content |
+| Prop       | Type                                                                 | Default    | Description        |
+| ---------- | -------------------------------------------------------------------- | ---------- | ------------------ |
+| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"`      | Text size          |
+| `weight`   | `"regular" \| "medium" \| "semi-bold" \| "bold"`                     | `"medium"` | Font weight        |
+| `children` | `ReactNode`                                                          | -          | Title text content |
 
 ### `<RadioCards.ItemDescription>`
 
 Description text component for radio items.
 
-| Prop       | Type                              | Default  | Description              |
-| ---------- | --------------------------------- | -------- | ------------------------ |
-| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"0"` | Text size |
-| `color`    | `"default" \| "gray" \| "red" \| "beige" \| "blue" \| "green" \| "yellow" \| "purple" \| "accent" \| "white" \| "black" \| "disabled"` | `"gray"` | Text color |
-| `children` | `ReactNode`                       | -        | Description text content |
+| Prop       | Type                                                                                                                                   | Default  | Description              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------ |
+| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"`                                                                   | `"0"`    | Text size                |
+| `color`    | `"default" \| "gray" \| "red" \| "beige" \| "blue" \| "green" \| "yellow" \| "purple" \| "accent" \| "white" \| "black" \| "disabled"` | `"gray"` | Text color               |
+| `children` | `ReactNode`                                                                                                                            | -        | Description text content |
 
 ### `<RadioCards.ItemIcon>`
 
 Icon component for radio items.
 
-| Prop    | Type                                     | Default  | Description                   |
-| ------- | ---------------------------------------- | -------- | ----------------------------- |
-| `icon`  | `LucideIcon`                             | -        | Lucide icon component         |
-| `alt`   | `string`                                 | -        | Alternative text for the icon |
-| `size`  | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"` | Icon size |
-| `color` | `"default" \| "gray" \| "accent" \| "red" \| "blue" \| "green" \| "yellow" \| "purple" \| "beige" \| "white" \| "black" \| "disabled"` | `"gray"` | Icon color |
+| Prop    | Type                                                                                                                                   | Default  | Description                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| `icon`  | `LucideIcon`                                                                                                                           | -        | Lucide icon component         |
+| `alt`   | `string`                                                                                                                               | -        | Alternative text for the icon |
+| `size`  | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"`                                                                   | `"2"`    | Icon size                     |
+| `color` | `"default" \| "gray" \| "accent" \| "red" \| "blue" \| "green" \| "yellow" \| "purple" \| "beige" \| "white" \| "black" \| "disabled"` | `"gray"` | Icon color                    |
 
 ## Examples
 
@@ -541,7 +543,11 @@ export const PricingPlanSelector = () => {
                 <RadioCards.ItemTitle size="3" weight="semi-bold">
                   {plan.title}
                 </RadioCards.ItemTitle>
-                {plan.popular && <Tag size="0" color="accent">Popular</Tag>}
+                {plan.popular && (
+                  <Tag size="0" color="accent">
+                    Popular
+                  </Tag>
+                )}
               </Stack>
 
               <Text as="span" size="5" weight="bold">
@@ -630,7 +636,7 @@ export const DeliveryOptionsForm = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/radio)
-- [Radix UI Radio Group](https://www.radix-ui.com/primitives/docs/components/radio-group)
+- [Base UI Radio](https://base-ui.com/react/components/radio)
 
 ## Contributing
 

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -31,7 +31,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-radio-group": "^1.3.8",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/radio/src/RadioCards/RadioCards.helpers.ts
+++ b/packages/radio/src/RadioCards/RadioCards.helpers.ts
@@ -1,0 +1,217 @@
+import type { TextDirection } from "@base-ui/react/direction-provider";
+import type { KeyboardEvent, ReactNode } from "react";
+
+type NavigationOrientation = "horizontal" | "vertical";
+
+type RadioCardKeyboardEvent = KeyboardEvent<HTMLDivElement> & {
+  baseUIHandlerPrevented?: boolean;
+  preventBaseUIHandler: () => void;
+};
+
+const getHorizontalForwardKey = (dir: TextDirection | undefined) => {
+  return dir === "rtl" ? "ArrowLeft" : "ArrowRight";
+};
+
+const getHorizontalBackwardKey = (dir: TextDirection | undefined) => {
+  return dir === "rtl" ? "ArrowRight" : "ArrowLeft";
+};
+
+const isOrientationBlockedKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+) => {
+  // Radix ignored cross-axis arrows for fixed-orientation groups, while Base UI
+  // would otherwise continue moving focus through the radio group.
+  if (orientation === "horizontal") {
+    return key === "ArrowUp" || key === "ArrowDown";
+  }
+
+  if (orientation === "vertical") {
+    return key === "ArrowLeft" || key === "ArrowRight";
+  }
+
+  return false;
+};
+
+const isForwardNavigationKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  if (orientation === "vertical") {
+    return key === "ArrowDown";
+  }
+
+  return key === getHorizontalForwardKey(dir) || key === "ArrowDown";
+};
+
+const isBackwardNavigationKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  if (orientation === "vertical") {
+    return key === "ArrowUp";
+  }
+
+  return key === getHorizontalBackwardKey(dir) || key === "ArrowUp";
+};
+
+const getNavigationDirection = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const resolvedOrientation = orientation ?? "horizontal";
+
+  // Collapse vertical groups and RTL horizontal groups into one signed movement
+  // value so the wrapping logic below does not need separate branches.
+  if (isForwardNavigationKey(key, resolvedOrientation, dir)) {
+    return 1;
+  }
+
+  if (isBackwardNavigationKey(key, resolvedOrientation, dir)) {
+    return -1;
+  }
+
+  return 0;
+};
+
+const getEnabledRadios = (root: HTMLElement) => {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('[role="radio"]'),
+  ).filter(
+    (radio) =>
+      !radio.matches(":disabled, [data-disabled], [aria-disabled='true']"),
+  );
+};
+
+const getCurrentRadio = (root: HTMLElement, enabledRadios: HTMLElement[]) => {
+  const activeElement = root.ownerDocument.activeElement;
+
+  if (
+    activeElement instanceof HTMLElement &&
+    root.contains(activeElement) &&
+    activeElement.getAttribute("role") === "radio"
+  ) {
+    // Prefer the focused radio because keyboard navigation should continue from
+    // the user's current roving focus position, not only from the checked value.
+    return activeElement;
+  }
+
+  return (
+    enabledRadios.find(
+      (radio) => radio.getAttribute("aria-checked") === "true",
+    ) ?? null
+  );
+};
+
+const getNextRadio = (
+  event: RadioCardKeyboardEvent,
+  orientation: NavigationOrientation | undefined,
+  loop: boolean | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const navigationDirection = getNavigationDirection(
+    event.key,
+    orientation,
+    dir,
+  );
+
+  if (navigationDirection === 0) {
+    return null;
+  }
+
+  const enabledRadios = getEnabledRadios(event.currentTarget);
+  const currentRadio = getCurrentRadio(event.currentTarget, enabledRadios);
+  const currentIndex = currentRadio ? enabledRadios.indexOf(currentRadio) : -1;
+
+  if (currentIndex === -1) {
+    // If the selected/focused item is disabled, keep keyboard handling inside the
+    // compatibility shim and restart navigation from the appropriate enabled edge.
+    return navigationDirection === 1
+      ? (enabledRadios[0] ?? null)
+      : (enabledRadios[enabledRadios.length - 1] ?? null);
+  }
+
+  const nextIndex = currentIndex + navigationDirection;
+
+  if (nextIndex >= 0 && nextIndex < enabledRadios.length) {
+    return enabledRadios[nextIndex] ?? null;
+  }
+
+  if (loop === false) {
+    // Preserve Radix's `loop={false}` behavior by keeping focus on the edge
+    // option while still blocking Base UI from wrapping internally.
+    return currentRadio;
+  }
+
+  return navigationDirection === 1
+    ? enabledRadios[0]
+    : enabledRadios[enabledRadios.length - 1];
+};
+
+const preventBaseUIKeyboardNavigation = (event: RadioCardKeyboardEvent) => {
+  event.preventBaseUIHandler();
+};
+
+const syncRadioTabStops = (root: HTMLElement, activeRadio: HTMLElement) => {
+  // The selected radio is moved with click semantics for parity, then the
+  // roving tab stops are corrected so tabbing resumes from the focused item.
+  getEnabledRadios(root).forEach((radio) => {
+    radio.tabIndex = radio === activeRadio ? 0 : -1;
+  });
+
+  activeRadio.focus();
+};
+
+const handleCompatibilityKeyboardNavigation = (
+  event: RadioCardKeyboardEvent,
+  orientation: NavigationOrientation | undefined,
+  loop: boolean | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const resolvedOrientation = orientation ?? "horizontal";
+
+  if (isOrientationBlockedKey(event.key, resolvedOrientation)) {
+    // Stop Base UI before it treats a blocked cross-axis arrow as navigation.
+    preventBaseUIKeyboardNavigation(event);
+    event.preventDefault();
+    return;
+  }
+
+  const nextRadio = getNextRadio(event, resolvedOrientation, loop, dir);
+
+  if (!nextRadio) {
+    return;
+  }
+
+  preventBaseUIKeyboardNavigation(event);
+  event.preventDefault();
+
+  if (nextRadio === event.target) {
+    syncRadioTabStops(event.currentTarget, nextRadio);
+    return;
+  }
+
+  const root = event.currentTarget;
+
+  nextRadio.click();
+  queueMicrotask(() => {
+    // Let Base UI process the click selection first, then repair focus and
+    // tabIndex after its internal radio state has settled.
+    syncRadioTabStops(root, nextRadio);
+  });
+};
+
+const shouldRenderRadioCardContent = (content: ReactNode) => {
+  return (
+    content !== null &&
+    content !== undefined &&
+    typeof content !== "boolean" &&
+    content !== ""
+  );
+};
+
+export { handleCompatibilityKeyboardNavigation, shouldRenderRadioCardContent };
+export type { RadioCardKeyboardEvent };

--- a/packages/radio/src/RadioCards/RadioCards.stories.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Bell, DoorClosed } from "lucide-react";
-import React from "react";
+import { useState } from "react";
 
 import { RadioCards as TelegraphRadioCards } from "./RadioCards";
 
@@ -25,27 +25,66 @@ export default meta;
 
 type StorybookRadioCardsType = StoryObj<typeof TelegraphRadioCards>;
 
+const DEFAULT_OPTIONS = [
+  {
+    icon: { icon: Bell, alt: "Bell" },
+    title: "Option 1",
+    description: "Description 1",
+    value: "1",
+  },
+  {
+    icon: { icon: DoorClosed, alt: "Door" },
+    title: "Option 2",
+    description: "Description 2",
+    value: "2",
+  },
+];
+
 export const RadioCards: StorybookRadioCardsType = {
   render: ({ direction }) => {
     //eslint-disable-next-line
-    const [value, setValue] = React.useState("1");
+    const [value, setValue] = useState("1");
     return (
       <TelegraphRadioCards
         value={value}
         onValueChange={(value) => setValue(value)}
         direction={direction}
+        options={DEFAULT_OPTIONS}
+      />
+    );
+  },
+};
+
+export const Vertical: StorybookRadioCardsType = {
+  render: () => {
+    //eslint-disable-next-line
+    const [value, setValue] = useState("1");
+    return (
+      <TelegraphRadioCards
+        value={value}
+        onValueChange={(value) => setValue(value)}
+        direction="column"
+        orientation="vertical"
+        options={DEFAULT_OPTIONS}
+      />
+    );
+  },
+};
+
+export const DisabledOption: StorybookRadioCardsType = {
+  render: () => {
+    //eslint-disable-next-line
+    const [value, setValue] = useState("1");
+    return (
+      <TelegraphRadioCards
+        value={value}
+        onValueChange={(value) => setValue(value)}
+        direction="row"
         options={[
+          DEFAULT_OPTIONS[0],
           {
-            icon: { icon: Bell, alt: "Bell" },
-            title: "Option 1",
-            description: "Description 1",
-            value: "1",
-          },
-          {
-            icon: { icon: DoorClosed, alt: "Door" },
-            title: "Option 2",
-            description: "Description 2",
-            value: "2",
+            ...DEFAULT_OPTIONS[1],
+            disabled: true,
           },
         ]}
       />

--- a/packages/radio/src/RadioCards/RadioCards.test.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.test.tsx
@@ -1,0 +1,387 @@
+// @vitest-environment jsdom
+import { DirectionProvider } from "@base-ui/react/direction-provider";
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { RadioCards } from "./RadioCards";
+
+afterEach(() => {
+  cleanup();
+});
+
+const radioOptions = [
+  {
+    title: "Option one",
+    description: "The first option",
+    value: "one",
+  },
+  {
+    title: "Option two",
+    description: "The second option",
+    value: "two",
+  },
+];
+
+describe("RadioCards", () => {
+  it("is accessible", async () => {
+    const { container } = render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    expectToHaveNoViolations(await axe(container));
+  });
+
+  it("renders the default value with Telegraph and Radix-compatible state attributes", () => {
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    expect(firstRadio).toHaveAttribute("data-tgph-radio-group-button");
+    expect(firstRadio).toHaveAttribute("aria-checked", "true");
+    expect(firstRadio).toHaveAttribute("data-checked", "");
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("aria-checked", "false");
+    expect(secondRadio).toHaveAttribute("data-unchecked", "");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("supports controlled values and change callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledRadioCards = () => {
+      const [value, setValue] = useState("one");
+
+      return (
+        <RadioCards
+          aria-label="Delivery method"
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue);
+          }}
+          options={radioOptions}
+        />
+      );
+    };
+
+    render(<ControlledRadioCards />);
+
+    await user.click(screen.getByRole("radio", { name: /Option two/ }));
+
+    expect(onValueChange).toHaveBeenCalledWith("two");
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("does not select disabled items", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        onValueChange={onValueChange}
+        options={[
+          radioOptions[0],
+          {
+            ...radioOptions[1],
+            disabled: true,
+          },
+        ]}
+      />,
+    );
+
+    const disabledRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    expect(disabledRadio).toBeDisabled();
+    expect(disabledRadio).toHaveAttribute("data-disabled", "");
+
+    await user.click(disabledRadio);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("radio", { name: /Option one/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("moves from a disabled selected value to an enabled radio with keyboard navigation", async () => {
+    const onValueChange = vi.fn();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        onValueChange={onValueChange}
+        options={[
+          {
+            ...radioOptions[0],
+            disabled: true,
+          },
+          radioOptions[1],
+        ]}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(onValueChange).toHaveBeenCalledWith("two");
+    });
+
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("selects the next radio with arrow-key navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    screen.getByRole("radio", { name: /Option one/ }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("radio", { name: /Option one/ })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+  });
+
+  it("uses horizontal arrow-key navigation by default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowRight}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors inherited RTL direction for horizontal keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DirectionProvider direction="rtl">
+        <RadioCards
+          aria-label="Delivery method"
+          defaultValue="one"
+          loop={false}
+          options={radioOptions}
+        />
+      </DirectionProvider>,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowLeft}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors vertical orientation keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        orientation="vertical"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors loop=false keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        loop={false}
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowRight}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("participates in forms with hidden radio inputs", () => {
+    const { container } = render(
+      <form data-testid="form">
+        <RadioCards
+          aria-label="Delivery method"
+          defaultValue="two"
+          name="delivery"
+          options={radioOptions}
+        />
+      </form>,
+    );
+
+    const form = screen.getByTestId("form") as HTMLFormElement;
+    const selectedInput = container.querySelector(
+      'input[type="radio"][name="delivery"][value="two"]',
+    );
+
+    expect(selectedInput).toBeChecked();
+    expect(new FormData(form).get("delivery")).toBe("two");
+  });
+
+  it("renders numeric zero option title and description nodes", () => {
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        options={[
+          {
+            title: 0,
+            description: 0,
+            value: "zero",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("does not render empty string option title and description nodes", () => {
+    const { container } = render(
+      <RadioCards
+        aria-label="Delivery method"
+        options={[
+          {
+            title: "",
+            description: "",
+            value: "empty",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-button-text]"),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector("[data-tgph-radio-card-description]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("forwards ref and tgphRef to the rendered radio button", () => {
+    const forwardedRef = createRef<HTMLButtonElement>();
+    const tgphRef = createRef<HTMLButtonElement>();
+
+    render(
+      <RadioCards.Root aria-label="Delivery method" defaultValue="one">
+        <RadioCards.Item value="one" ref={forwardedRef} tgphRef={tgphRef}>
+          Option one
+        </RadioCards.Item>
+      </RadioCards.Root>,
+    );
+
+    const radio = screen.getByRole("radio", { name: "Option one" });
+
+    expect(forwardedRef.current).toBe(radio);
+    expect(tgphRef.current).toBe(radio);
+  });
+});

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -1,71 +1,200 @@
-import * as RadioGroup from "@radix-ui/react-radio-group";
+import {
+  DirectionProvider,
+  type TextDirection,
+  useDirection,
+} from "@base-ui/react/direction-provider";
+import { Radio as BaseRadio } from "@base-ui/react/radio";
+import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
 import { Button } from "@telegraph/button";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
 } from "@telegraph/helpers";
 import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
-import React from "react";
+import {
+  type CSSProperties,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+  forwardRef,
+} from "react";
 
-export type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root> &
-  TgphComponentProps<typeof Stack>;
+import {
+  type RadioCardKeyboardEvent,
+  handleCompatibilityKeyboardNavigation,
+  shouldRenderRadioCardContent,
+} from "./RadioCards.helpers";
 
-type RadioButtonInternalContext = {
-  value?: string;
+type BaseRadioGroupProps = ComponentPropsWithoutRef<typeof BaseRadioGroup>;
+
+type LegacyRadioGroupProps = {
+  // Kept for Radix API compatibility and enforced by the Telegraph wrapper
+  // because Base UI RadioGroup does not expose an orientation prop.
+  orientation?: "horizontal" | "vertical";
+  // Kept for Radix API compatibility and enforced by the Telegraph wrapper
+  // because Base UI RadioGroup does not expose a loop prop.
+  loop?: boolean;
+  // Kept for Radix API compatibility and forwarded through Base UI's
+  // DirectionProvider.
+  dir?: TextDirection;
 };
 
-const RadioButtonContext = React.createContext<RadioButtonInternalContext>({
-  value: "",
-});
+export type RootProps = Omit<
+  BaseRadioGroupProps,
+  | "children"
+  | "className"
+  | "defaultValue"
+  | "onValueChange"
+  | "render"
+  | "style"
+  | "value"
+> &
+  TgphComponentProps<typeof Stack> &
+  LegacyRadioGroupProps & {
+    defaultValue?: string;
+    value?: string | null;
+    onValueChange?: (value: string) => void;
+  };
 
-const Root = ({ value, children, onValueChange, ...props }: RootProps) => {
+type RootContentProps = RootProps;
+
+const RootContent = ({
+  value,
+  defaultValue,
+  children,
+  onValueChange,
+  disabled,
+  dir,
+  form,
+  inputRef,
+  loop,
+  name,
+  onKeyDown,
+  orientation,
+  readOnly,
+  required,
+  ...props
+}: RootContentProps) => {
+  const inheritedDir = useDirection();
+  const resolvedDir = dir ?? inheritedDir;
+  const handleValueChange: BaseRadioGroupProps["onValueChange"] | undefined =
+    onValueChange
+      ? (nextValue) => {
+          // Telegraph's public callback only emits concrete option values;
+          // ignore any Base UI callback value that does not match that contract.
+          if (typeof nextValue === "string") {
+            onValueChange(nextValue);
+          }
+        }
+      : undefined;
+
+  const handleKeyDown = (event: RadioCardKeyboardEvent) => {
+    onKeyDown?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    // Base UI handles radio roving focus differently than Radix, so run the
+    // compatibility shim after user handlers have had first chance to prevent.
+    handleCompatibilityKeyboardNavigation(
+      event,
+      orientation,
+      loop,
+      resolvedDir,
+    );
+  };
+
   return (
-    <RadioButtonContext.Provider value={{ value: value ?? "" }}>
-      <RadioGroup.Root
-        value={value}
-        onValueChange={onValueChange}
-        asChild
-        {...props}
-      >
-        <RefToTgphRef>
-          <Stack gap="1">{children}</Stack>
-        </RefToTgphRef>
-      </RadioGroup.Root>
-    </RadioButtonContext.Provider>
+    <BaseRadioGroup
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={handleValueChange}
+      disabled={disabled}
+      form={form}
+      inputRef={inputRef}
+      name={name}
+      readOnly={readOnly}
+      required={required}
+      render={createTgphBaseUIRender(
+        <Stack gap="1" dir={dir} onKeyDown={handleKeyDown} {...props}>
+          {children}
+        </Stack>,
+      )}
+    />
   );
 };
 
-export type ItemProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Item>;
-type ItemRef = React.ElementRef<typeof RadioGroup.Item>;
-
-const Item = React.forwardRef<ItemRef, ItemProps>(
-  ({ children, style, ...props }, forwardedRef) => {
-    const { value: contextValue } = React.useContext(RadioButtonContext);
+const Root = ({ dir, ...props }: RootProps) => {
+  if (dir) {
     return (
-      <>
-        <RadioGroup.Item {...props} ref={forwardedRef} asChild>
-          <RefToTgphRef>
+      <DirectionProvider direction={dir}>
+        <RootContent dir={dir} {...props} />
+      </DirectionProvider>
+    );
+  }
+
+  return <RootContent {...props} />;
+};
+
+type BaseRadioRootProps = ComponentPropsWithoutRef<typeof BaseRadio.Root>;
+type BaseRadioRenderProps = ComponentPropsWithoutRef<"button"> & {
+  ref?: Ref<HTMLElement>;
+};
+type BaseRadioState = {
+  checked: boolean;
+  disabled: boolean;
+};
+
+const getRadioCardButtonStyle = (
+  style: CSSProperties | undefined,
+): CSSProperties =>
+  ({
+    "--tgph-button-active-shadow": "inset 0 0 0 1px var(--tgph-blue-8)",
+    ...style,
+  }) as CSSProperties;
+
+export type ItemProps = Omit<
+  BaseRadioRootProps,
+  "children" | "className" | "render" | "style" | "value"
+> & {
+  children?: ReactNode;
+  style?: CSSProperties;
+  tgphRef?: Ref<HTMLButtonElement>;
+  value: string;
+};
+type ItemRef = HTMLButtonElement;
+
+const Item = forwardRef<ItemRef, ItemProps>(
+  ({ children, style, tgphRef, ...props }, forwardedRef) => {
+    return (
+      <BaseRadio.Root
+        {...props}
+        ref={forwardedRef as Ref<HTMLElement>}
+        nativeButton
+        render={createTgphBaseUIRender<BaseRadioRenderProps, BaseRadioState>(
+          (state) => (
             <Button.Root
               variant="outline"
-              active={props.value === contextValue}
+              active={state.checked}
+              disabled={state.disabled}
               h="full"
               w="full"
               px="0"
               py="0"
               data-tgph-radio-group-button
-              style={{
-                "--tgph-button-active-shadow":
-                  "inset 0 0 0 1px var(--tgph-blue-8)",
-                ...style,
-              }}
+              data-state={state.checked ? "checked" : "unchecked"}
+              tgphRef={tgphRef}
+              style={getRadioCardButtonStyle(style)}
             >
               {children}
             </Button.Root>
-          </RefToTgphRef>
-        </RadioGroup.Item>
-      </>
+          ),
+        )}
+      />
     );
   },
 );
@@ -106,15 +235,15 @@ const ItemIcon = <T extends TgphElement = "span">(props: ItemIconProps<T>) => {
   return <Button.Icon color="gray" data-tgph-radio-card-icon {...props} />;
 };
 
-type DefaultIconProps = React.ComponentProps<typeof Icon>;
+type DefaultIconProps = ComponentProps<typeof Icon>;
 
-export type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
+export type DefaultProps = ComponentPropsWithoutRef<typeof Root> & {
   options: Array<
     {
-      title?: string;
-      description?: string;
+      title?: ReactNode;
+      description?: ReactNode;
       icon?: DefaultIconProps;
-    } & React.ComponentPropsWithoutRef<typeof Item>
+    } & ComponentPropsWithoutRef<typeof Item>
   >;
 };
 
@@ -122,27 +251,29 @@ const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
   const isGroupHorizontal = direction === "row" || direction === "row-reverse";
   return (
     <Root direction={direction} {...props}>
-      {options.map((option) => (
-        <Item key={option.value} value={option.value}>
+      {options.map(({ title, description, icon, ...itemProps }) => (
+        <Item key={itemProps.value} {...itemProps}>
           <Stack
             direction={isGroupHorizontal ? "column" : "row"}
             align={isGroupHorizontal ? "flex-start" : "center"}
             p="3"
             w="full"
           >
-            {option.icon && (
+            {icon && (
               <Box
                 mb={isGroupHorizontal ? "2" : "0"}
                 mr={isGroupHorizontal ? "0" : "4"}
                 ml={isGroupHorizontal ? "0" : "1"}
               >
-                <ItemIcon {...option.icon} />
+                <ItemIcon {...icon} />
               </Box>
             )}
             <Stack direction="column" align="flex-start">
-              {option.title && <ItemTitle>{option.title}</ItemTitle>}
-              {option.description && (
-                <ItemDescription>{option.description}</ItemDescription>
+              {shouldRenderRadioCardContent(title) && (
+                <ItemTitle>{title}</ItemTitle>
+              )}
+              {shouldRenderRadioCardContent(description) && (
+                <ItemDescription>{description}</ItemDescription>
               )}
             </Stack>
           </Stack>

--- a/packages/segmented-control/README.md
+++ b/packages/segmented-control/README.md
@@ -67,16 +67,23 @@ The container component that manages the selection state and layout.
 | `rovingFocus`   | `boolean`                             | `true`         | Enable keyboard navigation              |
 | `loop`          | `boolean`                             | `true`         | Loop focus when reaching ends           |
 
+`SegmentedControl.Root` is implemented with Base UI ToggleGroup primitives. The
+Telegraph API keeps the previous value contract: `type="single"` uses a string
+value and `type="multiple"` uses a string array, even though Base UI normalizes
+toggle-group state internally as arrays. Root and option `tgphRef` props continue
+to resolve to the rendered DOM elements, and overflowing horizontal controls keep
+the same scroll-button behavior.
+
 ### `<SegmentedControl.Option>`
 
 Individual option button within the segmented control.
 
-| Prop       | Type                              | Default | Description                       |
-| ---------- | --------------------------------- | ------- | --------------------------------- |
-| `value`    | `string`                          | -       | Unique identifier for this option |
-| `disabled` | `boolean`                         | `false` | Disable this specific option      |
+| Prop       | Type                       | Default | Description                       |
+| ---------- | -------------------------- | ------- | --------------------------------- |
+| `value`    | `string`                   | -       | Unique identifier for this option |
+| `disabled` | `boolean`                  | `false` | Disable this specific option      |
 | `size`     | `"0" \| "1" \| "2" \| "3"` | `"1"`   | Button size                       |
-| `children` | `ReactNode`                       | -       | Content of the option             |
+| `children` | `ReactNode`                | -       | Content of the option             |
 
 ## Usage Patterns
 
@@ -318,8 +325,8 @@ export const ConditionalSegmentedControl = ({ userRole, permissions }) => {
 ### Loading State
 
 ```tsx
-import { SegmentedControl } from "@telegraph/segmented-control";
 import { Box } from "@telegraph/layout";
+import { SegmentedControl } from "@telegraph/segmented-control";
 
 export const SegmentedControlWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -594,7 +601,7 @@ export const ProjectSettingsForm = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/segmented-control)
-- [Radix UI Toggle Group](https://www.radix-ui.com/primitives/docs/components/toggle-group)
+- [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group)
 
 ## Contributing
 

--- a/packages/segmented-control/package.json
+++ b/packages/segmented-control/package.json
@@ -32,8 +32,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",
     "@telegraph/truncate": "workspace:^",

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.helpers.ts
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.helpers.ts
@@ -1,0 +1,84 @@
+type SegmentedControlType = "single" | "multiple";
+type SegmentedControlValue<
+  T extends SegmentedControlType = SegmentedControlType,
+> = T extends "multiple" ? string[] : string;
+type AnySegmentedControlValue = SegmentedControlValue<SegmentedControlType>;
+
+const ROVING_FOCUS_KEYS = [
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "End",
+  "Home",
+];
+
+const PRIVATE_VALUE_PREFIX = "__tgph_segmented_control_value__";
+const EMPTY_STRING_VALUE = `${PRIVATE_VALUE_PREFIX}empty`;
+const ESCAPED_VALUE_PREFIX = `${PRIVATE_VALUE_PREFIX}escaped__`;
+
+const getBaseToggleValue = (value: string) => {
+  if (value === "") {
+    // Base UI ToggleGroup treats empty string as no value, but Telegraph has
+    // historically allowed it as a real option value.
+    return EMPTY_STRING_VALUE;
+  }
+
+  if (value.startsWith(PRIVATE_VALUE_PREFIX)) {
+    // Escape caller values that look like our sentinel values so round-tripping
+    // never turns a real user value into an internal marker.
+    return `${ESCAPED_VALUE_PREFIX}${value}`;
+  }
+
+  return value;
+};
+
+const getLegacyToggleValue = (value: string) => {
+  if (value === EMPTY_STRING_VALUE) {
+    // Decode the sentinel back to the public Telegraph value shape.
+    return "";
+  }
+
+  if (value.startsWith(ESCAPED_VALUE_PREFIX)) {
+    // Remove only the escape prefix, leaving the caller's original private-looking
+    // value intact.
+    return value.slice(ESCAPED_VALUE_PREFIX.length);
+  }
+
+  return value;
+};
+
+const getBaseToggleGroupValue = (
+  value: AnySegmentedControlValue | undefined,
+): readonly string[] | undefined => {
+  if (value === undefined) {
+    // Leave undefined alone so Base UI can stay uncontrolled.
+    return undefined;
+  }
+
+  return Array.isArray(value)
+    ? value.map(getBaseToggleValue)
+    : [getBaseToggleValue(value)];
+};
+
+const getLegacyToggleGroupValue = (
+  type: SegmentedControlType,
+  value: string[],
+): AnySegmentedControlValue => {
+  // Base UI always reports an array; Telegraph's single mode reports one value.
+  return type === "multiple"
+    ? value.map(getLegacyToggleValue)
+    : getLegacyToggleValue(value[0] ?? "");
+};
+
+export {
+  ROVING_FOCUS_KEYS,
+  getBaseToggleValue,
+  getBaseToggleGroupValue,
+  getLegacyToggleGroupValue,
+};
+export type {
+  AnySegmentedControlValue,
+  SegmentedControlType,
+  SegmentedControlValue,
+};

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box, Stack } from "@telegraph/layout";
 import { AlignCenter, AlignLeft, AlignRight } from "lucide-react";
-import React from "react";
+import { type ComponentProps, useState } from "react";
 
 import { SegmentedControl as TelegraphSegmentedControl } from "./SegmentedControl";
 
@@ -21,45 +21,54 @@ const meta: Meta<typeof TelegraphSegmentedControl.Root> = {
 };
 
 type Story = StoryObj<typeof TelegraphSegmentedControl.Root>;
+type SegmentedControlRootProps = ComponentProps<
+  typeof TelegraphSegmentedControl.Root
+>;
 
 export default meta;
 
-export const Default: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState("left");
-    return (
-      <Box maxW="140">
-        <TelegraphSegmentedControl.Root
-          value={value}
-          onValueChange={setValue}
-          {...args}
+const DefaultStory = (args: SegmentedControlRootProps) => {
+  const [value, setValue] = useState("left");
+
+  return (
+    <Box maxW="140">
+      <TelegraphSegmentedControl.Root
+        value={value}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue(nextValue);
+          }
+        }}
+        {...args}
+      >
+        <TelegraphSegmentedControl.Option
+          value="left"
+          icon={{ icon: AlignLeft, "aria-hidden": true }}
         >
-          <TelegraphSegmentedControl.Option
-            value="left"
-            icon={{ icon: AlignLeft, "aria-hidden": true }}
-          >
-            Left
-          </TelegraphSegmentedControl.Option>
-          <TelegraphSegmentedControl.Option
-            value="center"
-            icon={{ icon: AlignCenter, "aria-hidden": true }}
-          >
-            Center
-          </TelegraphSegmentedControl.Option>
-          <TelegraphSegmentedControl.Option
-            value="right"
-            icon={{ icon: AlignRight, "aria-hidden": true }}
-          >
-            Right
-          </TelegraphSegmentedControl.Option>
-        </TelegraphSegmentedControl.Root>
-      </Box>
-    );
-  },
+          Left
+        </TelegraphSegmentedControl.Option>
+        <TelegraphSegmentedControl.Option
+          value="center"
+          icon={{ icon: AlignCenter, "aria-hidden": true }}
+        >
+          Center
+        </TelegraphSegmentedControl.Option>
+        <TelegraphSegmentedControl.Option
+          value="right"
+          icon={{ icon: AlignRight, "aria-hidden": true }}
+        >
+          Right
+        </TelegraphSegmentedControl.Option>
+      </TelegraphSegmentedControl.Root>
+    </Box>
+  );
 };
 
-const optionsList = [
+export const Default: Story = {
+  render: (args) => <DefaultStory {...args} />,
+};
+
+const OPTIONS_LIST = [
   { value: "Workflow", label: "Workflow" },
   { value: "Recipient", label: "Recipient" },
   { value: "Actor", label: "Actor" },
@@ -85,53 +94,62 @@ const optionsList = [
   { value: "Call", label: "Call" },
 ];
 
-export const Scrollable: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value1, setValue1] = React.useState("Workflow");
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value2, setValue2] = React.useState("Task");
-    return (
-      <Stack
-        maxW="80"
-        h="80"
-        border="px"
-        rounded="3"
-        p="4"
-        direction="column"
-        gap="4"
+const ScrollableStory = (args: SegmentedControlRootProps) => {
+  const [value1, setValue1] = useState("Workflow");
+  const [value2, setValue2] = useState("Task");
+
+  return (
+    <Stack
+      maxW="80"
+      h="80"
+      border="px"
+      rounded="3"
+      p="4"
+      direction="column"
+      gap="4"
+    >
+      <TelegraphSegmentedControl.Root
+        size="1"
+        value={value1}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue1(nextValue);
+          }
+        }}
+        {...args}
       >
-        <TelegraphSegmentedControl.Root
-          size="1"
-          value={value1}
-          onValueChange={setValue1}
-          {...args}
-        >
-          {optionsList.map((option) => (
-            <TelegraphSegmentedControl.Option
-              key={option.value}
-              value={option.value}
-            >
-              {option.label}
-            </TelegraphSegmentedControl.Option>
-          ))}
-        </TelegraphSegmentedControl.Root>
-        <TelegraphSegmentedControl.Root
-          size="1"
-          value={value2}
-          onValueChange={setValue2}
-          {...args}
-        >
-          {optionsList.map((option) => (
-            <TelegraphSegmentedControl.Option
-              key={option.value}
-              value={option.value}
-            >
-              {option.label}
-            </TelegraphSegmentedControl.Option>
-          ))}
-        </TelegraphSegmentedControl.Root>
-      </Stack>
-    );
-  },
+        {OPTIONS_LIST.map((option) => (
+          <TelegraphSegmentedControl.Option
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </TelegraphSegmentedControl.Option>
+        ))}
+      </TelegraphSegmentedControl.Root>
+      <TelegraphSegmentedControl.Root
+        size="1"
+        value={value2}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue2(nextValue);
+          }
+        }}
+        {...args}
+      >
+        {OPTIONS_LIST.map((option) => (
+          <TelegraphSegmentedControl.Option
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </TelegraphSegmentedControl.Option>
+        ))}
+      </TelegraphSegmentedControl.Root>
+    </Stack>
+  );
+};
+
+export const Scrollable: Story = {
+  render: (args) => <ScrollableStory {...args} />,
 };

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,385 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { SegmentedControl } from "./SegmentedControl";
+
+class ResizeObserverMock implements ResizeObserver {
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+}
+
+const SegmentedControlFixture = ({
+  defaultValue = "left",
+}: {
+  defaultValue?: string;
+}) => {
+  return (
+    <SegmentedControl.Root defaultValue={defaultValue}>
+      <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+      <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      <SegmentedControl.Option value="right" disabled>
+        Right
+      </SegmentedControl.Option>
+    </SegmentedControl.Root>
+  );
+};
+
+describe("SegmentedControl", () => {
+  beforeAll(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the default option with Telegraph state attributes", () => {
+    render(<SegmentedControlFixture />);
+
+    const activeOption = screen.getByRole("button", { name: "Left" });
+
+    expect(activeOption).toHaveAttribute("data-tgph-segmented-control-option");
+    expect(activeOption).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(activeOption).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("supports controlled single values and legacy string callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("left");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+          <SegmentedControl.Option value="center">
+            Center
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Center" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("center");
+    expect(screen.getByRole("button", { name: "Center" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+  });
+
+  it("does not clear a controlled single value when the active option is clicked again", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root value="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Left" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("does not clear an uncontrolled single value when the active option is clicked again", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Left" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("supports an empty string as a controlled single value", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("left");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="">None</SegmentedControl.Option>
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "None" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("");
+    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+  });
+
+  it("does not collide with option values that match the empty-string sentinel", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const emptyStringSentinel = "__tgph_segmented_control_value__empty";
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="">None</SegmentedControl.Option>
+          <SegmentedControl.Option value={emptyStringSentinel}>
+            Sentinel
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Sentinel" }));
+
+    expect(onValueChange).toHaveBeenCalledWith(emptyStringSentinel);
+    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+    expect(screen.getByRole("button", { name: "Sentinel" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("supports controlled multiple values and legacy array callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState(["left"]);
+
+      return (
+        <SegmentedControl.Root
+          type="multiple"
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string[]);
+          }}
+        >
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+          <SegmentedControl.Option value="center">
+            Center
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Center" }));
+
+    expect(onValueChange).toHaveBeenCalledWith(["left", "center"]);
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Center" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("does not activate disabled options", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root value="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="right" disabled>
+          Right
+        </SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Right" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("visually and functionally disables every option when the root is disabled", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root
+        defaultValue="left"
+        disabled
+        onValueChange={onValueChange}
+      >
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const centerOption = screen.getByRole("button", { name: "Center" });
+
+    expect(leftOption).toBeDisabled();
+    expect(leftOption).toHaveAttribute("data-tgph-button-state", "disabled");
+    expect(centerOption).toBeDisabled();
+    expect(centerOption).toHaveAttribute("data-tgph-button-state", "disabled");
+
+    await user.click(centerOption);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("moves focus with arrow keys by default", async () => {
+    const user = userEvent.setup();
+
+    render(<SegmentedControlFixture />);
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const centerOption = screen.getByRole("button", { name: "Center" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(centerOption).toHaveFocus();
+  });
+
+  it("loops focus with arrow keys by default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left">
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+        <SegmentedControl.Option value="right">Right</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const rightOption = screen.getByRole("button", { name: "Right" });
+
+    rightOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("honors loop=false for arrow-key focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" loop={false}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("preserves legacy opt-out support for roving focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" rovingFocus={false}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("forwards tgphRef through Base UI render props", () => {
+    const rootRef = createRef<HTMLDivElement>();
+    const optionRef = createRef<HTMLButtonElement>();
+
+    render(
+      <SegmentedControl.Root
+        data-testid="segmented-control-root"
+        defaultValue="left"
+        tgphRef={rootRef}
+      >
+        <SegmentedControl.Option value="left" tgphRef={optionRef}>
+          Left
+        </SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    expect(rootRef.current).toBe(screen.getByTestId("segmented-control-root"));
+    expect(optionRef.current).toBe(
+      screen.getByRole("button", { name: "Left" }),
+    );
+  });
+});

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -1,46 +1,139 @@
-import * as ToggleGroup from "@radix-ui/react-toggle-group";
+import {
+  DirectionProvider,
+  type TextDirection,
+} from "@base-ui/react/direction-provider";
+import { Toggle as BaseToggle } from "@base-ui/react/toggle";
+import { ToggleGroup as BaseToggleGroup } from "@base-ui/react/toggle-group";
 import { Button } from "@telegraph/button";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { useComposedRefs } from "@telegraph/compose-refs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+  useControllableState,
+} from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { useTruncate } from "@telegraph/truncate";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import { div as MotionDiv } from "motion/react-m";
-import React from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type Dispatch,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  type SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  type AnySegmentedControlValue,
+  ROVING_FOCUS_KEYS,
+  type SegmentedControlType,
+  type SegmentedControlValue,
+  getBaseToggleGroupValue,
+  getBaseToggleValue,
+  getLegacyToggleGroupValue,
+} from "./SegmentedControl.helpers";
 
 // Use a tolerance of 1px to account for subpixel rendering and floating-point precision
 const SCROLL_TOLERANCE = 1;
 const SCROLL_OFFSET = 24;
 
-const SegmentedControlContextState = React.createContext<{
-  value?: React.ComponentProps<typeof ToggleGroup.Root>["value"];
-  size?: React.ComponentProps<typeof Button.Root>["size"];
+type BaseToggleGroupProps = ComponentPropsWithoutRef<typeof BaseToggleGroup>;
+type SegmentedControlOptionStatus = "active" | "inactive";
+type SegmentedControlRootKeyDownEvent = KeyboardEvent<HTMLDivElement> & {
+  preventBaseUIHandler?: () => void;
+};
+type SegmentedControlChangeValue<
+  T extends SegmentedControlType,
+  Value extends AnySegmentedControlValue,
+> = T extends "multiple"
+  ? string[]
+  : Extract<Value, string> extends never
+    ? string
+    : Extract<Value, string>;
+type SegmentedControlValueChangeHandler<
+  T extends SegmentedControlType,
+  Value extends AnySegmentedControlValue,
+> = {
+  bivarianceHack(value: SegmentedControlChangeValue<T, Value>): void;
+}["bivarianceHack"];
+
+const SegmentedControlContextState = createContext<{
+  disabled?: boolean;
+  size?: ComponentPropsWithoutRef<typeof Button.Root>["size"];
   showScrollButtons?: boolean;
   activeOptionRef?: HTMLButtonElement | null;
-  setActiveOptionRef?: React.Dispatch<
-    React.SetStateAction<HTMLButtonElement | null>
-  >;
+  setActiveOptionRef?: Dispatch<SetStateAction<HTMLButtonElement | null>>;
 }>({
-  value: "",
+  disabled: false,
   size: "1",
   showScrollButtons: false,
   activeOptionRef: null,
   setActiveOptionRef: () => {},
 });
 
-export type RootProps = Omit<
-  React.ComponentProps<typeof ToggleGroup.Root>,
-  "type"
+export type RootProps<
+  T extends SegmentedControlType = "single",
+  Value extends AnySegmentedControlValue = SegmentedControlValue<T>,
+> = Omit<
+  BaseToggleGroupProps,
+  | "children"
+  | "className"
+  | "defaultValue"
+  | "disabled"
+  | "loopFocus"
+  | "multiple"
+  | "onKeyDown"
+  | "onValueChange"
+  | "orientation"
+  | "render"
+  | "style"
+  | "value"
 > &
-  TgphComponentProps<typeof Stack> & {
-    type?: React.ComponentProps<typeof ToggleGroup.Root>["type"];
-    size?: React.ComponentProps<typeof Button.Root>["size"];
+  Omit<TgphComponentProps<typeof Stack>, "defaultValue" | "dir"> & {
+    defaultValue?: Value;
+    dir?: TextDirection;
+    disabled?: boolean;
+    loop?: boolean;
+    onValueChange?: SegmentedControlValueChangeHandler<T, Value>;
+    orientation?: BaseToggleGroupProps["orientation"];
+    rovingFocus?: boolean;
     scrollControls?: "arrows" | "none";
+    size?: ComponentPropsWithoutRef<typeof Button.Root>["size"];
+    type?: T;
+    value?: Value;
   };
 
-const Root = ({
-  // ToggleGroup.Root Props
-  type = "single",
+type SegmentedControlDirectionProviderProps = {
+  children: ReactNode;
+  dir?: TextDirection;
+};
+
+const SegmentedControlDirectionProvider = ({
+  children,
+  dir,
+}: SegmentedControlDirectionProviderProps) => {
+  if (!dir) {
+    return <>{children}</>;
+  }
+
+  return <DirectionProvider direction={dir}>{children}</DirectionProvider>;
+};
+
+const Root = <
+  T extends SegmentedControlType = "single",
+  Value extends AnySegmentedControlValue = SegmentedControlValue<T>,
+>({
+  type: typeProp,
   size = "1",
   scrollControls = "arrows",
   value,
@@ -50,28 +143,88 @@ const Root = ({
   rovingFocus,
   orientation,
   dir,
-  loop,
+  loop = true,
   children,
+  onKeyDown,
+  tgphRef,
   ...props
-}: RootProps) => {
-  const containerId = React.useId();
+}: RootProps<T, Value>) => {
+  const containerId = useId();
 
   // Automatically show the scroll buttons when the content of the
   // segmented control is too wide to fit within the container.
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const composedContainerRef = useComposedRefs(
+    tgphRef as Ref<HTMLDivElement> | undefined,
+    containerRef,
+  );
   const { truncated } = useTruncate({ tgphRef: containerRef });
-  const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
+  const scrollButtonRef = useRef<HTMLButtonElement>(null);
   const showScrollButtons = scrollControls === "arrows" && truncated;
+  // Only load the motion/measurement work once overflow is detected.
+  const shouldRenderScrollButtons = showScrollButtons;
+  const type = typeProp ?? "single";
+  const isMultiple = type === "multiple";
+  // Encode Telegraph values before they reach Base UI so empty strings and
+  // private-looking values can round-trip safely through ToggleGroup.
+  const [currentValue, setCurrentValue] = useControllableState<
+    AnySegmentedControlValue | undefined
+  >({
+    prop: value,
+    defaultProp: defaultValue,
+    onChange: onValueChange as
+      | ((nextValue: AnySegmentedControlValue | undefined) => void)
+      | undefined,
+  });
+  const baseValue = getBaseToggleGroupValue(currentValue) ?? [];
+  const handleValueChange = useCallback<
+    NonNullable<BaseToggleGroupProps["onValueChange"]>
+  >(
+    (nextValue) => {
+      if (!isMultiple && nextValue.length === 0) {
+        // Radix single ToggleGroup did not let the active option clear itself.
+        return;
+      }
+
+      // Base UI always emits arrays; convert back to Telegraph's single or
+      // multiple public value shape before notifying consumers.
+      setCurrentValue(
+        getLegacyToggleGroupValue(type, nextValue) as AnySegmentedControlValue,
+      );
+    },
+    [isMultiple, setCurrentValue, type],
+  );
+  const handleKeyDown = useCallback(
+    (event: SegmentedControlRootKeyDownEvent) => {
+      onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        event.preventBaseUIHandler?.();
+        return;
+      }
+
+      if (rovingFocus !== false) {
+        return;
+      }
+
+      if (ROVING_FOCUS_KEYS.includes(event.key)) {
+        // `rovingFocus={false}` used to leave arrow keys to the page/caller, so
+        // block Base UI's default roving handler after user code has run.
+        event.preventBaseUIHandler?.();
+      }
+    },
+    [onKeyDown, rovingFocus],
+  );
 
   // We store the active option ref as a state value so that we can respond to it
   // changing via an effect vs doing complicated ref status chasing.
   const [activeOptionRef, setActiveOptionRef] =
-    React.useState<HTMLButtonElement | null>(null);
-  const [scrollStatus, setScrollStatus] = React.useState<
+    useState<HTMLButtonElement | null>(null);
+  const [scrollStatus, setScrollStatus] = useState<
     "flushLeft" | "flushRight" | "middle" | null
   >(null);
 
-  const onScrollClick = React.useCallback((direction: "left" | "right") => {
+  const onScrollClick = useCallback((direction: "left" | "right") => {
     if (!containerRef.current) return;
 
     // We get the currentWidth so that we can scroll a meaningful amount.
@@ -90,7 +243,7 @@ const Root = ({
   }, []);
 
   // Derive what the `scrollStatus` should be based on the current scroll position.
-  const deriveScrollStatus = React.useCallback(
+  const deriveScrollStatus = useCallback(
     (
       currentScrollPosition: number,
     ): "flushLeft" | "flushRight" | "middle" | null => {
@@ -118,14 +271,14 @@ const Root = ({
   );
 
   // Update the `scrollStatus` on mount and each time the container is scrolled.
-  const handleScroll = React.useCallback(() => {
+  const handleScroll = useCallback(() => {
     if (!containerRef.current) return;
     const newScrollPosition = containerRef.current.scrollLeft;
     const newScrollStatus = deriveScrollStatus(newScrollPosition);
     setScrollStatus(newScrollStatus);
   }, [deriveScrollStatus]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
 
@@ -138,8 +291,8 @@ const Root = ({
   }, [handleScroll]);
 
   // When the active option is changed, ensure that it is in view.
-  const [hasRan, setHasRan] = React.useState(false);
-  React.useEffect(() => {
+  const [hasRan, setHasRan] = useState(false);
+  useEffect(() => {
     if (showScrollButtons && activeOptionRef) {
       const optionOffsetLeft = activeOptionRef.offsetLeft;
       // Determine what the scroll status would be if the active option was scrolled into view.
@@ -160,7 +313,7 @@ const Root = ({
       containerRef.current?.scrollTo({
         left: newScrollPosition,
         // If this is the first time we've run this effect, we choose to scroll to the active
-        // option instantly. This avoid animating to that value on mount.
+        // option instantly. This avoids animating to that value on mount.
         behavior: hasRan ? "smooth" : "instant",
       });
 
@@ -178,49 +331,46 @@ const Root = ({
     >
       <SegmentedControlContextState.Provider
         value={{
-          value,
           size,
+          disabled,
           showScrollButtons,
           activeOptionRef,
           setActiveOptionRef,
         }}
       >
-        {/* @ts-expect-error: radix's type props doesn't seem to be typed correctly, could be a bug? */}
-        <ToggleGroup.Root
-          asChild={true}
-          type={type}
-          value={value}
-          defaultValue={defaultValue}
-          onValueChange={onValueChange}
-          disabled={disabled}
-          rovingFocus={rovingFocus}
-          orientation={orientation}
-          dir={dir}
-          loop={loop}
-        >
-          <RefToTgphRef>
-            <Stack
-              id={containerId}
-              bg="gray-3"
-              rounded="2"
-              align="center"
-              justify="space-between"
-              // We use overflow hidden here to totally hide any overflow while also
-              // hiding any scroll bars. The buttons that appear when the container is truncated
-              // control the scroll. This means we don't need to worry about the browser's default
-              // scroll bar overlapping the segmented control.
-              overflow={showScrollButtons ? "hidden" : "visible"}
-              position="relative"
-              tgphRef={containerRef}
-              {...props}
-            >
-              {children}
-            </Stack>
-          </RefToTgphRef>
-        </ToggleGroup.Root>
+        <SegmentedControlDirectionProvider dir={dir}>
+          <BaseToggleGroup
+            value={baseValue}
+            onValueChange={handleValueChange}
+            disabled={disabled}
+            multiple={isMultiple}
+            orientation={orientation}
+            loopFocus={loop}
+            render={createTgphBaseUIRender(
+              <Stack
+                id={containerId}
+                bg="gray-3"
+                rounded="2"
+                align="center"
+                justify="space-between"
+                // We use overflow hidden here to totally hide any overflow while also
+                // hiding any scroll bars. The buttons that appear when the container is truncated
+                // control the scroll. This means we don't need to worry about the browser's default
+                // scroll bar overlapping the segmented control.
+                overflow={showScrollButtons ? "hidden" : "visible"}
+                position="relative"
+                dir={dir}
+                tgphRef={composedContainerRef}
+                onKeyDown={handleKeyDown}
+                {...props}
+              >
+                {children}
+              </Stack>,
+            )}
+          />
+        </SegmentedControlDirectionProvider>
       </SegmentedControlContextState.Provider>
-      {/* We only load any of the truncation logic when the container is truncated. */}
-      {showScrollButtons && (
+      {shouldRenderScrollButtons && (
         <LazyMotion features={domAnimation}>
           <Box
             key="left-scroll-button"
@@ -286,7 +436,7 @@ const Root = ({
 };
 
 const ButtonStyleProps: Record<
-  string,
+  SegmentedControlOptionStatus,
   TgphComponentProps<typeof Button.Root>
 > = {
   active: {
@@ -299,49 +449,73 @@ const ButtonStyleProps: Record<
   },
 };
 
-export type OptionProps = React.ComponentProps<typeof ToggleGroup.Item> &
-  TgphComponentProps<typeof Button>;
+export type OptionProps = Omit<TgphComponentProps<typeof Button>, "value"> & {
+  value: string;
+};
 
-const Option = ({
-  // ToggleGroup.Item Props
-  value,
+type OptionButtonProps = Omit<OptionProps, "value"> & {
+  buttonRef: RefObject<HTMLButtonElement | null>;
+  status: SegmentedControlOptionStatus;
+};
+
+const OptionButton = ({
+  buttonRef,
   disabled,
-  // Button Props
   size = "1",
+  status,
   style,
+  tgphRef,
   ...props
-}: OptionProps) => {
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const { setActiveOptionRef, ...context } = React.useContext(
+}: OptionButtonProps) => {
+  const { setActiveOptionRef, ...context } = useContext(
     SegmentedControlContextState,
   );
-  const status = context.value === value ? "active" : "inactive";
   const derivedSize = context.size ?? size;
+  const derivedDisabled = Boolean(context.disabled || disabled);
+  const composedButtonRef = useComposedRefs(
+    tgphRef as Ref<HTMLButtonElement> | undefined,
+    buttonRef,
+  );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (status === "active") {
       setActiveOptionRef?.(buttonRef.current);
     }
-  }, [status, setActiveOptionRef]);
+  }, [buttonRef, status, setActiveOptionRef]);
 
   return (
-    <ToggleGroup.Item asChild={true} value={value} disabled={disabled}>
-      <RefToTgphRef>
-        <Button
-          size={derivedSize}
-          {...ButtonStyleProps[status]}
-          style={{
-            // Make the button take up all availabel space
-            flexGrow: 1,
-            ...style,
-          }}
-          data-tgph-segmented-control-option
-          data-tgph-segmented-control-option-status={status}
-          tgphRef={buttonRef}
+    <Button
+      size={derivedSize}
+      disabled={derivedDisabled}
+      {...ButtonStyleProps[status]}
+      style={{
+        flexGrow: 1,
+        ...style,
+      }}
+      data-tgph-segmented-control-option
+      data-tgph-segmented-control-option-status={status}
+      tgphRef={composedButtonRef}
+      {...props}
+    />
+  );
+};
+
+const Option = ({ value, disabled, ...props }: OptionProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <BaseToggle
+      value={getBaseToggleValue(value)}
+      disabled={disabled}
+      render={createTgphBaseUIRender((state) => (
+        <OptionButton
+          buttonRef={buttonRef}
+          disabled={state.disabled || disabled}
+          status={state.pressed ? "active" : "inactive"}
           {...props}
         />
-      </RefToTgphRef>
-    </ToggleGroup.Item>
+      ))}
+    />
   );
 };
 

--- a/packages/segmented-control/vitest.config.mts
+++ b/packages/segmented-control/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "segmented-control",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -69,22 +69,35 @@ export const CountrySelector = () => {
 - Advanced filtering
 - Multi-select with complex UI
 
+## Implementation Notes
+
+Select is a lightweight wrapper around `@telegraph/combobox`. It inherits the
+migrated Combobox popup, portal, focus, and dismissal behavior, which is backed
+by Base UI through Telegraph primitives.
+
+The public Select API remains unchanged. Single-select usage closes after
+selection, while multi-select usage stays open; this behavior is inferred from
+whether `value` or `defaultValue` is an array. `triggerProps`, `contentProps`,
+and `optionsProps` continue to pass through to the underlying Combobox parts.
+
+Select does not depend on Radix directly.
+
 ## API Reference
 
 ### `<Select.Root>`
 
 The main select container component.
 
-| Prop            | Type                                  | Default       | Description                             |
-| --------------- | ------------------------------------- | ------------- | --------------------------------------- |
-| `value`         | `string \| string[]`                  | `undefined`   | Selected value(s)                       |
-| `onValueChange` | `(value: string \| string[]) => void` | `undefined`   | Called when selection changes           |
-| `size`          | `"0" \| "1" \| "2" \| "3"`           | `"1"`         | Size of the trigger button              |
-| `placeholder`   | `string`                              | `undefined`   | Placeholder text when no value selected |
-| `disabled`      | `boolean`                             | `false`       | Whether the select is disabled          |
-| `triggerProps`  | `ComboboxTriggerProps`                | `undefined`   | Props passed to the trigger button      |
-| `contentProps`  | `ComboboxContentProps`                | `undefined`   | Props passed to the dropdown content    |
-| `optionsProps`  | `ComboboxOptionsProps`                | `undefined`   | Props passed to the options container   |
+| Prop            | Type                                  | Default     | Description                             |
+| --------------- | ------------------------------------- | ----------- | --------------------------------------- |
+| `value`         | `string \| string[]`                  | `undefined` | Selected value(s)                       |
+| `onValueChange` | `(value: string \| string[]) => void` | `undefined` | Called when selection changes           |
+| `size`          | `"0" \| "1" \| "2" \| "3"`            | `"1"`       | Size of the trigger button              |
+| `placeholder`   | `string`                              | `undefined` | Placeholder text when no value selected |
+| `disabled`      | `boolean`                             | `false`     | Whether the select is disabled          |
+| `triggerProps`  | `ComboboxTriggerProps`                | `undefined` | Props passed to the trigger button      |
+| `contentProps`  | `ComboboxContentProps`                | `undefined` | Props passed to the dropdown content    |
+| `optionsProps`  | `ComboboxOptionsProps`                | `undefined` | Props passed to the options container   |
 
 ### `<Select.Option>`
 
@@ -383,8 +396,8 @@ export const ConditionalSelect = ({ userRole, permissions }) => {
 ### Loading State
 
 ```tsx
-import { Select } from "@telegraph/select";
 import { Box } from "@telegraph/layout";
+import { Select } from "@telegraph/select";
 
 export const SelectWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -677,6 +690,7 @@ export const CountryRegionSelector = () => {
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/select)
 - [Combobox Component](../combobox/README.md) - Full-featured dropdown with search
+- [Base UI Menu](https://base-ui.com/react/components/menu/)
 
 ## Contributing
 

--- a/packages/select/src/Select/Select.test.tsx
+++ b/packages/select/src/Select/Select.test.tsx
@@ -1,0 +1,283 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Select } from "./Select";
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const queryPortalElement = (selector: string) =>
+  document.querySelector(selector);
+const queryPortalElements = (selector: string) =>
+  document.querySelectorAll(selector);
+
+const getOptionByText = (text: string) => {
+  return Array.from(queryPortalElements("[data-tgph-combobox-option]")).find(
+    (option) => option.textContent === text,
+  ) as HTMLElement | undefined;
+};
+
+const options = [
+  { value: "email", label: "Email" },
+  { value: "sms", label: "SMS" },
+  { value: "push", label: "Push" },
+];
+
+const renderSelectOptions = () => {
+  return options.map((option) => (
+    <Select.Option key={option.value} value={option.value}>
+      {option.label}
+    </Select.Option>
+  ));
+};
+
+const ControlledSingleSelect = ({
+  onValueChange,
+}: {
+  onValueChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useState("email");
+
+  const handleValueChange = (nextValue: string) => {
+    setValue(nextValue);
+    onValueChange?.(nextValue);
+  };
+
+  return (
+    <Select.Root value={value} onValueChange={handleValueChange}>
+      {renderSelectOptions()}
+    </Select.Root>
+  );
+};
+
+const ControlledMultiSelect = ({
+  onValueChange,
+}: {
+  onValueChange?: (value: Array<string>) => void;
+}) => {
+  const [value, setValue] = useState<Array<string>>(["email"]);
+
+  const handleValueChange = (nextValue: Array<string>) => {
+    setValue(nextValue);
+    onValueChange?.(nextValue);
+  };
+
+  return (
+    <Select.Root value={value} onValueChange={handleValueChange}>
+      {renderSelectOptions()}
+    </Select.Root>
+  );
+};
+
+describe("Select", () => {
+  it("is accessible", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select.Root defaultValue="email">{renderSelectOptions()}</Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expectToHaveNoViolations(await axe(container));
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expectToHaveNoViolations(
+      await axe(document.body, {
+        rules: {
+          region: { enabled: false },
+        },
+      }),
+    );
+  });
+
+  it("supports keyboard selection, Escape dismissal, and focus return", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root onValueChange={onValueChange}>
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector(
+      "[data-tgph-combobox-trigger]",
+    ) as HTMLElement;
+
+    trigger.focus();
+    await user.keyboard("[ArrowDown]");
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expect(document.activeElement).toHaveTextContent("Email");
+
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => expect(trigger).toHaveTextContent("Email"));
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onValueChange).toHaveBeenLastCalledWith("email");
+
+    trigger.focus();
+    await user.keyboard("[ArrowDown]");
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expect(document.activeElement).toHaveTextContent("Email");
+
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("false"),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
+  it("selects a controlled single value and closes after selection", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ControlledSingleSelect onValueChange={onValueChange} />,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveTextContent("Email");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("SMS")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("SMS"));
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onValueChange).toHaveBeenLastCalledWith("sms");
+  });
+
+  it("keeps controlled multi-select open after selection", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ControlledMultiSelect onValueChange={onValueChange} />,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveTextContent("Email");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("SMS")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("EmailSMS"));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onValueChange).toHaveBeenLastCalledWith(["email", "sms"]);
+  });
+
+  it("derives multi-select behavior from an uncontrolled array defaultValue", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root defaultValue={["email"]} onValueChange={onValueChange}>
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("Push")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("EmailPush"));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onValueChange).toHaveBeenLastCalledWith(["email", "push"]);
+  });
+
+  it("passes trigger, content, and options props through to Combobox", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select.Root
+        defaultValue="email"
+        triggerProps={{ "data-select-trigger": true }}
+        contentProps={{ "data-select-content": true }}
+        optionsProps={{ "data-select-options": true, maxHeight: "64" }}
+      >
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveAttribute("data-select-trigger", "true");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    const content = queryPortalElement("[data-tgph-combobox-content]");
+    const optionList = queryPortalElement('[role="listbox"]');
+
+    expect(content).toHaveAttribute("data-select-content", "true");
+    expect(optionList).toHaveAttribute("data-select-options", "true");
+    expect(optionList).toHaveStyle({
+      "--max-height": "var(--tgph-spacing-64)",
+    });
+  });
+
+  it("uses option children as the Combobox option label", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root defaultValue="email" onValueChange={onValueChange}>
+        <Select.Option value="email">Email</Select.Option>
+        <Select.Option value="sms">SMS label from children</Select.Option>
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await user.click(getOptionByText("SMS label from children")!);
+
+    await waitFor(() =>
+      expect(trigger).toHaveTextContent("SMS label from children"),
+    );
+    expect(onValueChange).toHaveBeenLastCalledWith("sms");
+  });
+
+  it("does not select disabled options", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root value="email" onValueChange={onValueChange}>
+        <Select.Option value="email">Email</Select.Option>
+        <Select.Option value="sms" disabled>
+          SMS
+        </Select.Option>
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await user.click(getOptionByText("SMS")!);
+
+    expect(trigger).toHaveTextContent("Email");
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.test.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.test.ts
@@ -54,6 +54,24 @@ describe("getStyleProp", () => {
       "--display": "block",
     });
   });
+  it("passes raw values through when the css var allows them", () => {
+    const { styleProp } = getStyleProp({
+      props: {
+        maxHeight: "400px",
+      },
+      cssVars: {
+        maxHeight: {
+          cssVar: "--max-height",
+          value: "var(--tgph-spacing-VARIABLE)",
+          allowRawValue: true,
+        },
+      },
+    });
+
+    expect(styleProp).toStrictEqual({
+      "--max-height": "400px",
+    });
+  });
   it("when no values are passed empty objects are returned", () => {
     const { styleProp, otherProps } = getStyleProp({
       props: {},

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
@@ -1,3 +1,5 @@
+import tokenSource from "@telegraph/tokens";
+
 type Direction =
   | "x"
   | "y"
@@ -16,6 +18,7 @@ type Axis = "x" | "y" | "both";
 export type CssVarProp = {
   cssVar: string;
   value: string;
+  allowRawValue?: boolean;
   direction?: Direction;
   axis?: Axis;
 };
@@ -259,6 +262,17 @@ type GetStylePropParams<CssVars, Props> = {
   cssVars: CssVars;
 };
 
+const isSpacingTokenValue = (propValue: string): boolean => {
+  const normalizedValue = propValue.startsWith("-")
+    ? propValue.slice(1)
+    : propValue;
+
+  return Object.prototype.hasOwnProperty.call(
+    tokenSource.tokens.spacing,
+    normalizedValue,
+  );
+};
+
 // Resolves a single prop value against its matching CssVarProp definition.
 // Returns the mapped CSS variable value string, handling negative spacing.
 const resolveValue = (
@@ -266,6 +280,10 @@ const resolveValue = (
   propValue: string,
 ): string => {
   const isNegative = typeof propValue === "string" && propValue.startsWith("-");
+
+  if (matchingCssVar.allowRawValue && !isSpacingTokenValue(propValue)) {
+    return propValue;
+  }
 
   if (isNegative) {
     const positiveValue = propValue.slice(1);

--- a/packages/style-engine/tsconfig.json
+++ b/packages/style-engine/tsconfig.json
@@ -4,15 +4,9 @@
   "display": "@telegraph/style-engine",
   "compilerOptions": {
     "outDir": "dist",
+    "types": ["node"],
     "rootDir": "src"
   },
-  "include": [
-    "src/**/*"
-  ],
-  "exclude": [
-    "src/**/*.test.tsx",
-    "src/**/*.test.ts",
-    "dist",
-    "node_modules"
-  ]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts", "dist", "node_modules"]
 }

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -69,28 +69,38 @@ export const BasicTabs = () => (
 );
 ```
 
+## Implementation Notes
+
+Tabs are backed by Base UI Tabs primitives and keep the Telegraph public API,
+data attributes, styling hooks, and `tgphRef` behavior stable for existing
+consumers.
+
+Controlled tab values can be `null` when no tab is selected, such as when the
+current/default value no longer matches a rendered tab.
+
 ## API Reference
 
 ### `<Tabs>`
 
 The root container component that provides tab state management and context.
 
-| Prop            | Type                         | Default        | Description                                   |
-| --------------- | ---------------------------- | -------------- | --------------------------------------------- |
-| `defaultValue`  | `string`                     | `undefined`    | ID of the initially active tab (uncontrolled) |
-| `value`         | `string`                     | `undefined`    | Currently active tab ID (controlled)          |
-| `onValueChange` | `(value: string) => void`    | `undefined`    | Called when the active tab changes            |
-| `disabled`      | `boolean`                    | `false`        | Disables all tabs when true                   |
-| `orientation`   | `"horizontal" \| "vertical"` | `"horizontal"` | Layout orientation                            |
-| `dir`           | `"ltr" \| "rtl"`             | `"ltr"`        | Text direction                                |
+| Prop            | Type                              | Default        | Description                                   |
+| --------------- | --------------------------------- | -------------- | --------------------------------------------- |
+| `defaultValue`  | `string`                          | `undefined`    | ID of the initially active tab (uncontrolled) |
+| `value`         | `string`                          | `undefined`    | Currently active tab ID (controlled)          |
+| `onValueChange` | `(value: string) => void`         | `undefined`    | Called when the active tab changes            |
+| `disabled`      | `boolean`                         | `false`        | Disables all tabs when true                   |
+| `orientation`   | `"horizontal" \| "vertical"`      | `"horizontal"` | Layout orientation                            |
+| `dir`           | `"ltr" \| "rtl"`                  | `"ltr"`        | Text direction                                |
 
 ### `<Tabs.List>`
 
 Container for tab buttons that manages keyboard navigation.
 
-| Prop   | Type      | Default | Description                                              |
-| ------ | --------- | ------- | -------------------------------------------------------- |
-| `loop` | `boolean` | `true`  | Whether keyboard navigation loops from last to first tab |
+| Prop              | Type      | Default | Description                                                  |
+| ----------------- | --------- | ------- | ------------------------------------------------------------ |
+| `loop`            | `boolean` | `true`  | Whether keyboard navigation loops from last to first tab     |
+| `activateOnFocus` | `boolean` | `true`  | Whether arrow-key focus also activates the newly focused tab |
 
 ### `<Tabs.Tab>`
 
@@ -124,8 +134,11 @@ Content panel associated with a specific tab.
 | Prop                   | Type               | Default  | Description                                       |
 | ---------------------- | ------------------ | -------- | ------------------------------------------------- |
 | `value`                | `string`           | -        | **Required.** ID of the tab this panel belongs to |
-| `forceMount`           | `boolean`          | `false`  | Whether to force mounting when tab is inactive    |
+| `forceMount`           | `boolean`          | `false`  | Whether to keep the panel mounted when inactive   |
 | `forceBackgroundMount` | `"once" \| "none"` | `"none"` | Background mounting strategy for performance      |
+
+Inactive kept panels remain mounted for compatibility, but are hidden from
+layout and assistive technology until their tab is active.
 
 ## Usage Patterns
 
@@ -199,7 +212,7 @@ import { Tabs } from "@telegraph/tabs";
 import { useState } from "react";
 
 export const ControlledTabs = () => {
-  const [activeTab, setActiveTab] = useState("tab1");
+  const [activeTab, setActiveTab] = useState<string | null>("tab1");
 
   return (
     <div>
@@ -306,7 +319,7 @@ export const OptimizedTabs = () => (
       <LargeDataTable />
     </Tabs.Panel>
 
-    {/* Render once on component mount */}
+    {/* Keep mounted in the background when inactive */}
     <Tabs.Panel value="charts" forceBackgroundMount="once">
       <ExpensiveCharts />
     </Tabs.Panel>
@@ -325,7 +338,7 @@ export const DynamicTabs = () => {
     { id: "tab1", title: "Tab 1", content: "Content 1" },
     { id: "tab2", title: "Tab 2", content: "Content 2" },
   ]);
-  const [activeTab, setActiveTab] = useState("tab1");
+  const [activeTab, setActiveTab] = useState<string | null>("tab1");
 
   const addTab = () => {
     const newId = `tab${tabs.length + 1}`;
@@ -344,8 +357,8 @@ export const DynamicTabs = () => {
     const newTabs = tabs.filter((tab) => tab.id !== tabId);
     setTabs(newTabs);
 
-    if (activeTab === tabId && newTabs.length > 0) {
-      setActiveTab(newTabs[0].id);
+    if (activeTab === tabId) {
+      setActiveTab(newTabs[0]?.id ?? null);
     }
   };
 
@@ -396,7 +409,7 @@ export const FormTabs = () => {
     preferences: { theme: "light", notifications: true },
     billing: { plan: "free", cardNumber: "" },
   });
-  const [currentTab, setCurrentTab] = useState("personal");
+  const [currentTab, setCurrentTab] = useState<string | null>("personal");
 
   const updateFormData = (section: string, data: any) => {
     setFormData((prev) => ({
@@ -602,7 +615,7 @@ import { BarChart, Bell, Settings, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export const DashboardTabs = () => {
-  const [activeTab, setActiveTab] = useState("overview");
+  const [activeTab, setActiveTab] = useState<string | null>("overview");
   const [notifications, setNotifications] = useState(3);
 
   // Simulate notification updates
@@ -693,7 +706,7 @@ import { useState } from "react";
 
 export const MediaLibrary = () => {
   const [selectedFiles, setSelectedFiles] = useState([]);
-  const [currentTab, setCurrentTab] = useState("documents");
+  const [currentTab, setCurrentTab] = useState<string | null>("documents");
 
   const fileTypes = {
     documents: {
@@ -769,7 +782,7 @@ export const MediaLibrary = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/tabs)
-- [Radix UI Tabs](https://www.radix-ui.com/primitives/docs/components/tabs) - Base primitive
+- [Base UI Tabs](https://base-ui.com/react/components/tabs) - Base primitive
 
 ## Contributing
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -32,7 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-tabs": "^1.1.13",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -1,28 +1,24 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
 } from "@telegraph/helpers";
 import { MenuItem } from "@telegraph/menu";
-import React from "react";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
 
-/**
- * Props for the Tab component
- * @property {string} value - Unique identifier for the tab
- * @property {React.ReactNode} children - Content to display in the tab
- * @property {boolean} disabled - Whether this tab is disabled
- * @property {() => void} onClick - Additional onClick handler
- * @property {TabIconProps} leadingIcon - Icon to display on the left side of the tab
- * @property {TabIconProps} trailingIcon - Icon to display on the right side of the tab
- */
+type BaseTabRenderProps = ComponentPropsWithoutRef<"button"> & {
+  ref?: Ref<HTMLElement>;
+};
+
+type BaseTabState = {
+  active: boolean;
+};
+
 export type TabProps<T extends TgphElement = "button"> = {
   value: string;
 } & TgphComponentProps<typeof MenuItem<T>>;
 
-/**
- * Tab component that uses RadixTabs.Trigger with MenuItem styling
- */
 const Tab = <T extends TgphElement = "button">({
   disabled = false,
   value,
@@ -47,39 +43,46 @@ const Tab = <T extends TgphElement = "button">({
     : icon
       ? ({ ...defaultIconProps, ...icon } as const)
       : undefined;
+  const combinedTrailingIcon = trailingIcon
+    ? ({ ...defaultIconProps, ...trailingIcon } as const)
+    : undefined;
+  const menuItemProps = props as TgphComponentProps<typeof MenuItem<T>>;
+  // Base UI renders a native button by default; only opt out when Telegraph's
+  // polymorphic `as` prop means MenuItem owns the element type.
+  const nativeButton = !props.as || props.as === "button";
 
   return (
-    <RadixTabs.Trigger
+    <BaseTabs.Tab
       value={value}
       disabled={disabled}
       onClick={onClick}
-      asChild
-    >
-      <RefToTgphRef>
-        <MenuItem
-          leadingIcon={combinedLeadingIcon}
-          trailingIcon={
-            trailingIcon && { ...defaultIconProps, ...trailingIcon }
-          }
-          disabled={disabled}
-          py="4"
-          px="2"
-          fontWeight="medium"
-          position="relative"
-          data-tgph-tab=""
-          gap="2"
-          color="gray"
-          size="1"
-          // Important for styling the active color
-          textProps={{
-            "data-tgph-tab-text": "",
-          }}
-          {...props}
-        >
-          {children}
-        </MenuItem>
-      </RefToTgphRef>
-    </RadixTabs.Trigger>
+      nativeButton={nativeButton}
+      render={createTgphBaseUIRender<BaseTabRenderProps, BaseTabState>(
+        (state) => (
+          <MenuItem<T>
+            leadingIcon={combinedLeadingIcon}
+            trailingIcon={combinedTrailingIcon}
+            disabled={disabled}
+            py="4"
+            px="2"
+            fontWeight="medium"
+            position="relative"
+            data-tgph-tab=""
+            data-state={state.active ? "active" : "inactive"}
+            gap="2"
+            color="gray"
+            size="1"
+            // Important for styling the active color
+            textProps={{
+              "data-tgph-tab-text": "",
+            }}
+            {...menuItemProps}
+          >
+            {children}
+          </MenuItem>
+        ),
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/TabList/TabList.tsx
+++ b/packages/tabs/src/TabList/TabList.tsx
@@ -1,19 +1,28 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
-import React from "react";
+import { type ComponentProps } from "react";
 
-export type TabListProps = TgphComponentProps<typeof Stack> &
-  React.ComponentProps<typeof RadixTabs.List>;
+type BaseTabsListProps = ComponentProps<typeof BaseTabs.List>;
+export type TabListProps = TgphComponentProps<typeof Stack> & {
+  activateOnFocus?: BaseTabsListProps["activateOnFocus"];
+  loop?: BaseTabsListProps["loopFocus"];
+};
 
-/**
- * Container component for Tab components
- * Renders a Radix TabsList
- */
-const TabList = ({ children, loop = true, ...props }: TabListProps) => {
+const TabList = ({
+  children,
+  loop = true,
+  activateOnFocus = true,
+  ...props
+}: TabListProps) => {
   return (
-    <RadixTabs.List asChild loop={loop}>
-      <RefToTgphRef>
+    <BaseTabs.List
+      activateOnFocus={activateOnFocus}
+      loopFocus={loop}
+      render={createTgphBaseUIRender(
         <Stack
           flexDirection={"row"}
           spacing="2"
@@ -26,9 +35,9 @@ const TabList = ({ children, loop = true, ...props }: TabListProps) => {
           {...props}
         >
           {children}
-        </Stack>
-      </RefToTgphRef>
-    </RadixTabs.List>
+        </Stack>,
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/Tabs/TabPanel.tsx
+++ b/packages/tabs/src/Tabs/TabPanel.tsx
@@ -1,17 +1,24 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
-import React from "react";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
 
-export type TabPanelProps = TgphComponentProps<typeof Box> &
-  React.ComponentProps<typeof RadixTabs.Content> & {
-    forceBackgroundMount?: "once" | "none";
-  };
+type BasePanelRenderProps = ComponentPropsWithoutRef<"div"> & {
+  ref?: Ref<HTMLDivElement>;
+};
+type BasePanelState = {
+  hidden: boolean;
+};
 
-/**
- * Content panel associated with a Tab
- * Only renders when its associated tab is active
- */
+export type TabPanelProps = TgphComponentProps<typeof Box> & {
+  value: string;
+  forceMount?: boolean;
+  forceBackgroundMount?: "once" | "none";
+};
+
 const TabPanel = ({
   value,
   children,
@@ -19,32 +26,35 @@ const TabPanel = ({
   forceBackgroundMount = "none",
   ...props
 }: TabPanelProps) => {
-  const shouldForceMount = forceBackgroundMount === "once" || forceMount;
+  // Radix `forceMount` and Telegraph `forceBackgroundMount="once"` both kept
+  // inactive panels mounted; Base UI exposes that behavior as `keepMounted`.
+  const shouldKeepMounted = forceBackgroundMount === "once" || forceMount;
 
   return (
-    <RadixTabs.Content value={value} forceMount={shouldForceMount} asChild>
-      <RefToTgphRef>
-        <Box
-          data-tgph-tab-panel=""
-          {...props}
-          style={{
-            ...(shouldForceMount && {
-              visibility: "var(--radix-tabs-content-visibility, visible)",
-              overflow: "var(--radix-tabs-content-overflow, visible)",
-              height: "var(--radix-tabs-content-height, auto)",
-            }),
-            ...props.style,
-          }}
-          aria-hidden={
-            shouldForceMount
-              ? "var(--radix-tabs-content-aria-hidden, false)"
-              : undefined
-          }
-        >
-          {children}
-        </Box>
-      </RefToTgphRef>
-    </RadixTabs.Content>
+    <BaseTabs.Panel
+      value={value}
+      keepMounted={shouldKeepMounted}
+      render={createTgphBaseUIRender<BasePanelRenderProps, BasePanelState>(
+        (state) => (
+          <Box
+            data-tgph-tab-panel=""
+            data-state={state.hidden ? "inactive" : "active"}
+            {...props}
+            style={{
+              ...(shouldKeepMounted && {
+                visibility: state.hidden ? "hidden" : "visible",
+                overflow: state.hidden ? "hidden" : "visible",
+                height: state.hidden ? 0 : "auto",
+              }),
+              ...props.style,
+            }}
+            aria-hidden={shouldKeepMounted && state.hidden ? true : undefined}
+          >
+            {children}
+          </Box>
+        ),
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/Tabs/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs/Tabs.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Tabs } from "../index";
+
+const TabsFixture = () => {
+  return (
+    <Tabs defaultValue="tab1">
+      <Tabs.List>
+        <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+        <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        <Tabs.Tab value="tab3" disabled>
+          Disabled Tab
+        </Tabs.Tab>
+      </Tabs.List>
+
+      <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      <Tabs.Panel value="tab3">Disabled panel</Tabs.Panel>
+    </Tabs>
+  );
+};
+
+describe("Tabs", () => {
+  it("renders the default tab with Telegraph and Radix-compatible state attributes", () => {
+    render(<TabsFixture />);
+
+    const activeTab = screen.getByRole("tab", { name: "First Tab" });
+
+    expect(activeTab).toHaveAttribute("data-tgph-tab", "");
+    expect(activeTab).toHaveAttribute("data-active", "");
+    expect(activeTab).toHaveAttribute("data-state", "active");
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
+  });
+
+  it("supports controlled values and change callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledTabs = () => {
+      const [value, setValue] = useState("tab1");
+
+      return (
+        <Tabs
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue);
+          }}
+        >
+          <Tabs.List>
+            <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+            <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+          <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+        </Tabs>
+      );
+    };
+
+    render(<ControlledTabs />);
+
+    await user.click(screen.getByRole("tab", { name: "Second Tab" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("tab2");
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("does not forward Base UI-only cleared selection changes", async () => {
+    const onValueChange = vi.fn();
+
+    render(
+      <Tabs defaultValue="missing-tab" onValueChange={onValueChange}>
+        <Tabs.List>
+          <Tabs.Tab value="tab1" disabled>
+            First Tab
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    await waitFor(() => {
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not auto-select a tab when no default or controlled value is provided", () => {
+    render(
+      <Tabs>
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tab", { name: "First Tab" })).toHaveAttribute(
+      "data-state",
+      "inactive",
+    );
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "inactive",
+    );
+    expect(screen.queryByRole("tabpanel")).not.toBeInTheDocument();
+  });
+
+  it("does not activate disabled tabs", async () => {
+    const user = userEvent.setup();
+
+    render(<TabsFixture />);
+
+    const disabledTab = screen.getByRole("tab", { name: "Disabled Tab" });
+    await user.click(disabledTab);
+
+    expect(disabledTab).toHaveAttribute("data-disabled", "");
+    expect(screen.getByRole("tab", { name: "First Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
+  });
+
+  it("activates tabs with arrow-key focus by default", async () => {
+    const user = userEvent.setup();
+
+    render(<TabsFixture />);
+
+    screen.getByRole("tab", { name: "First Tab" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("respects disabled keyboard looping", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="tab2">
+        <Tabs.List loop={false}>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    screen.getByRole("tab", { name: "Second Tab" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("keeps forceBackgroundMount panels mounted and hidden while inactive", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="tab1">
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2" forceBackgroundMount="once">
+          Second panel
+        </Tabs.Panel>
+      </Tabs>,
+    );
+
+    const inactivePanel = screen
+      .getByText("Second panel")
+      .closest("[data-tgph-tab-panel]");
+
+    expect(inactivePanel).toHaveAttribute("data-state", "inactive");
+    expect(inactivePanel).toHaveAttribute("hidden");
+    expect(inactivePanel).toHaveAttribute("aria-hidden", "true");
+    expect(inactivePanel).toHaveStyle({
+      height: "0px",
+      overflow: "hidden",
+      visibility: "hidden",
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Second Tab" }));
+
+    expect(inactivePanel).toHaveAttribute("data-state", "active");
+    expect(inactivePanel).not.toHaveAttribute("hidden");
+    expect(inactivePanel).not.toHaveAttribute("aria-hidden");
+    expect(inactivePanel).toHaveStyle({
+      height: "auto",
+      overflow: "visible",
+      visibility: "visible",
+    });
+  });
+
+  it("forwards tgphRef through Base UI render props", () => {
+    const rootRef = createRef<HTMLDivElement>();
+    const tabRef = createRef<HTMLButtonElement>();
+
+    render(
+      <Tabs defaultValue="tab1" data-testid="tabs-root" tgphRef={rootRef}>
+        <Tabs.List>
+          <Tabs.Tab value="tab1" tgphRef={tabRef}>
+            First Tab
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    expect(rootRef.current).toBe(screen.getByTestId("tabs-root"));
+    expect(tabRef.current).toBe(screen.getByRole("tab", { name: "First Tab" }));
+  });
+});

--- a/packages/tabs/src/Tabs/Tabs.tsx
+++ b/packages/tabs/src/Tabs/Tabs.tsx
@@ -1,35 +1,62 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
-import React from "react";
+import { type ComponentProps } from "react";
 
-export type TabsProps = TgphComponentProps<typeof Box> &
-  React.ComponentProps<typeof RadixTabs.Root>;
+type BaseTabsRootProps = ComponentProps<typeof BaseTabs.Root>;
+type TabsValue = string;
+type TabsValueChangeHandler<Value extends TabsValue> = {
+  bivarianceHack(value: Value): void;
+}["bivarianceHack"];
 
-/**
- * Root component for Tabs
- * Provides context for tab state management and renders child components
- */
-const Tabs = ({
+export type TabsProps<Value extends TabsValue = string> = TgphComponentProps<
+  typeof Box
+> & {
+  defaultValue?: Value;
+  orientation?: BaseTabsRootProps["orientation"];
+  value?: Value;
+  onValueChange?: TabsValueChangeHandler<Value>;
+};
+
+const Tabs = <Value extends TabsValue = string>({
   children,
   defaultValue,
   value,
   onValueChange,
+  orientation,
   ...props
-}: TabsProps) => {
+}: TabsProps<Value>) => {
+  // Base UI uses `null` for "no tab selected"; keep defaultValue undefined
+  // when controlled so React does not see both controlled and default values.
+  const baseDefaultValue =
+    defaultValue ?? (value === undefined ? null : undefined);
+  const handleValueChange: BaseTabsRootProps["onValueChange"] | undefined =
+    onValueChange
+      ? (nextValue) => {
+          // Base UI can report `null` when it cannot resolve an active tab.
+          // Radix-backed Telegraph tabs only notified consumers with string
+          // tab values, so keep that Base UI state internal for compatibility.
+          if (typeof nextValue === "string") {
+            onValueChange(nextValue as Value);
+          }
+        }
+      : undefined;
+
   return (
-    <RadixTabs.Root
-      defaultValue={defaultValue}
+    <BaseTabs.Root
+      defaultValue={baseDefaultValue}
       value={value}
-      onValueChange={onValueChange}
-      asChild
-    >
-      <RefToTgphRef>
+      onValueChange={handleValueChange}
+      orientation={orientation}
+      render={createTgphBaseUIRender(
         <Box data-tgph-tabs="" {...props}>
           {children}
-        </Box>
-      </RefToTgphRef>
-    </RadixTabs.Root>
+        </Box>,
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/default.css
+++ b/packages/tabs/src/default.css
@@ -1,10 +1,11 @@
 /* Active tab style - orange underline */
-[data-tgph-tab][data-state="active"]::after {
+[data-tgph-tab][data-state="active"]::after,
+[data-tgph-tab][data-active]::after {
   animation: tabActivate 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   background-color: var(--tgph-accent-9, #ff4f00);
   bottom: calc(var(--tgph-spacing-1) * -1);
   border-radius: 1px;
-  content: '';
+  content: "";
   height: 1px;
   left: 0;
   position: absolute;
@@ -25,34 +26,30 @@
 }
 
 /* Active tab text and icon color */
-[data-tgph-tab][data-state="active"] [data-tgph-tab-text] {
-  color: var(--tgph-accent-11, #D13415);
+[data-tgph-tab][data-state="active"] [data-tgph-tab-text],
+[data-tgph-tab][data-active] [data-tgph-tab-text] {
+  color: var(--tgph-accent-11, #d13415);
 }
 
 /* Active tab icon color */
-[data-tgph-tab][data-state="active"] [data-tgph-tab-icon] {
-  color: var(--tgph-accent-10, #DD4425);
+[data-tgph-tab][data-state="active"] [data-tgph-tab-icon],
+[data-tgph-tab][data-active] [data-tgph-tab-icon] {
+  color: var(--tgph-accent-10, #dd4425);
 }
 
 /* Disabled tab icon color */
 [data-tgph-tab][data-disabled] [data-tgph-tab-icon] {
-  color: var(--tgph-gray-7, #CDCED6);
+  color: var(--tgph-gray-7, #cdced6);
 }
 
 /* Disabled tab text color */
 [data-tgph-tab][data-disabled] [data-tgph-tab-text] {
-  color: var(--tgph-gray-9, #8B8D98);
+  color: var(--tgph-gray-9, #8b8d98);
 }
 
-/* Background rendering styles for TabPanel */
+/* Background rendering styles for force-mounted TabPanel */
 [data-tgph-tab-panel][data-state="inactive"] {
-  --radix-tabs-content-visibility: hidden;
-  --radix-tabs-content-overflow: hidden;
-  --radix-tabs-content-height: 0;
-}
-
-[data-tgph-tab-panel][data-state="active"] {
-  --radix-tabs-content-visibility: visible;
-  --radix-tabs-content-overflow: visible;
-  --radix-tabs-content-height: auto;
+  visibility: hidden;
+  overflow: hidden;
+  height: 0;
 }

--- a/packages/tag/README.md
+++ b/packages/tag/README.md
@@ -71,16 +71,16 @@ export const TagExamples = () => (
 
 The main tag component with built-in interactive features.
 
-| Prop         | Type                | Default          | Description                         |
-| ------------ | ------------------- | ---------------- | ----------------------------------- |
-| `size`       | `"0" \| "1" \| "2"` | `"1"`            | Size of the tag                     |
-| `color`      | `TagColor`          | `"default"`      | Color scheme of the tag             |
-| `variant`    | `"soft" \| "solid"` | `"soft"`         | Visual style variant                |
-| `icon`       | `IconProps`         | `undefined`      | Icon to display at the start        |
-| `onRemove`   | `() => void`        | `undefined`      | Makes tag removable with X button   |
-| `onCopy`     | `(event: React.MouseEvent<HTMLButtonElement>) => void` | `undefined` | Adds copy button functionality |
-| `textToCopy` | `string`            | `undefined`      | Text to copy to clipboard |
-| `textProps`  | `TextProps`         | `{ maxW: "40" }` | Props passed to the text component  |
+| Prop         | Type                                                   | Default          | Description                        |
+| ------------ | ------------------------------------------------------ | ---------------- | ---------------------------------- |
+| `size`       | `"0" \| "1" \| "2"`                                    | `"1"`            | Size of the tag                    |
+| `color`      | `TagColor`                                             | `"default"`      | Color scheme of the tag            |
+| `variant`    | `"soft" \| "solid"`                                    | `"soft"`         | Visual style variant               |
+| `icon`       | `IconProps`                                            | `undefined`      | Icon to display at the start       |
+| `onRemove`   | `() => void`                                           | `undefined`      | Makes tag removable with X button  |
+| `onCopy`     | `(event: React.MouseEvent<HTMLButtonElement>) => void` | `undefined`      | Adds copy button functionality     |
+| `textToCopy` | `string`                                               | `undefined`      | Text to copy to clipboard          |
+| `textProps`  | `TextProps`                                            | `{ maxW: "40" }` | Props passed to the text component |
 
 #### TagColor Type
 
@@ -499,7 +499,7 @@ export const AnimatedTags = ({ tags, onRemove }) => (
 ### ARIA Attributes
 
 - Icons include proper `alt` attributes or `aria-hidden="true"`
-- Copy button includes tooltip with descriptive text
+- Copy button includes descriptive text through the Base UI-backed `@telegraph/tooltip` package
 - Remove button includes clear action description
 - Motion respects `prefers-reduced-motion` preference
 
@@ -539,19 +539,19 @@ Icon component with contextual styling.
 
 Remove button component.
 
-| Prop      | Type         | Default                     | Description               |
-| --------- | ------------ | --------------------------- | ------------------------- |
-| `onClick` | `(event: React.MouseEvent<HTMLButtonElement>) => void` | - | Click handler for removal |
-| `icon`    | `IconProps`  | `{ icon: X, alt: "close" }` | Button icon configuration |
+| Prop      | Type                                                   | Default                     | Description               |
+| --------- | ------------------------------------------------------ | --------------------------- | ------------------------- |
+| `onClick` | `(event: React.MouseEvent<HTMLButtonElement>) => void` | -                           | Click handler for removal |
+| `icon`    | `IconProps`                                            | `{ icon: X, alt: "close" }` | Button icon configuration |
 
 ### `<Tag.CopyButton>`
 
 Copy functionality button with animation.
 
-| Prop         | Type         | Default | Description               |
-| ------------ | ------------ | ------- | ------------------------- |
-| `onClick`    | `(event: React.MouseEvent<HTMLButtonElement>) => void` | - | Additional click handler |
-| `textToCopy` | `string`     | -       | Text to copy to clipboard |
+| Prop         | Type                                                   | Default | Description               |
+| ------------ | ------------------------------------------------------ | ------- | ------------------------- |
+| `onClick`    | `(event: React.MouseEvent<HTMLButtonElement>) => void` | -       | Additional click handler  |
+| `textToCopy` | `string`                                               | -       | Text to copy to clipboard |
 
 ## Examples
 

--- a/packages/tag/src/Tag/Tag.test.tsx
+++ b/packages/tag/src/Tag/Tag.test.tsx
@@ -1,5 +1,6 @@
-import { render } from "@testing-library/react";
-import { describe, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
 import { Tag } from "./Tag";
@@ -21,6 +22,20 @@ describe("Tag", () => {
     );
     const results = await axe(container);
     expectToHaveNoViolations(results);
+  });
+
+  it("shows the copy affordance tooltip through the migrated Tooltip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tag size="2" color="default" onCopy={() => {}}>
+        Copyable
+      </Tag>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Copy text" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Copy text");
   });
 
   describe("type inheritance", () => {

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -16,7 +16,14 @@ import { clsx } from "clsx";
 import { Check, Copy, X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type MouseEvent,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 import { COLOR, SIZE, SPACING, VARIANT, cssVars } from "./Tag.constants";
 
@@ -31,7 +38,7 @@ export type RootProps<T extends TgphElement = "span"> =
     Omit<TgphComponentProps<typeof Stack>, "as" | "tgphRef"> &
     RootBaseProps;
 
-const TagContext = React.createContext<Required<RootBaseProps>>({
+const TagContext = createContext<Required<RootBaseProps>>({
   size: "1",
   color: "default",
   variant: "soft",
@@ -90,7 +97,7 @@ const Text = <T extends TgphElement = "span">({
   style,
   ...props
 }: TextProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   return (
     <TelegraphText
       as={as}
@@ -121,11 +128,11 @@ export type CopyButtonProps = TgphComponentProps<
 };
 
 const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
 
-  const [copied, setCopied] = React.useState(false);
+  const [copied, setCopied] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (copied) {
       const timeout = setTimeout(() => setCopied(false), 2000);
       return () => clearTimeout(timeout);
@@ -136,8 +143,8 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
     <LazyMotion features={domAnimation}>
       <Tooltip label="Copy text">
         <TelegraphButton.Root
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            // Still run onClick incase the consumer wants to do something else
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            // Still run onClick in case the consumer wants to do something else
             onClick?.(event);
             setCopied(true);
             if (textToCopy) {
@@ -162,8 +169,9 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
             animate={{ y: copied ? 0 : "150%", opacity: copied ? 1 : 1 }}
             transition={{ duration: 0.15, type: "spring", bounce: 0 }}
             icon={Check}
-            alt="Copied text"
-            aria-hidden={!copied}
+            {...(copied
+              ? { alt: "Copied text" }
+              : { "aria-hidden": true as const })}
           />
           <TelegraphButton.Icon
             as={motion.span}
@@ -172,8 +180,9 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
             transition={{ duration: 0.15, type: "spring", bounce: 0 }}
             icon={Copy}
             position="absolute"
-            alt="Copy text"
-            aria-hidden={copied}
+            {...(copied
+              ? { "aria-hidden": true as const }
+              : { alt: "Copy text" })}
           />
         </TelegraphButton.Root>
       </Tooltip>
@@ -182,7 +191,7 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
 };
 
 const Button = <T extends TgphElement>({ ...props }: ButtonProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   return (
     <TelegraphButton
       size={context.size}
@@ -207,7 +216,7 @@ const Icon = <T extends TgphElement = "span">({
   "aria-hidden": ariaHidden,
   ...props
 }: IconProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   const a11yProps = !alt ? { "aria-hidden": ariaHidden } : { alt };
   return (
     <TelegraphIcon
@@ -223,12 +232,12 @@ const Icon = <T extends TgphElement = "span">({
 
 export type DefaultProps<T extends TgphElement = "span"> = PolymorphicProps<T> &
   TgphComponentProps<typeof Root<T>> & {
-    icon?: React.ComponentProps<typeof TelegraphIcon>;
-    textProps?: React.ComponentProps<typeof Text>;
+    icon?: ComponentProps<typeof TelegraphIcon>;
+    textProps?: ComponentProps<typeof Text>;
     onRemove?: () => void;
   } & ( // Optionally allow textToCopy only when onCopy is defined
     | {
-        onCopy: (event: React.MouseEvent<HTMLButtonElement>) => void;
+        onCopy: (event: MouseEvent<HTMLButtonElement>) => void;
         textToCopy?: string;
       }
     | {

--- a/packages/textarea/src/TextArea/TextArea.test.tsx
+++ b/packages/textarea/src/TextArea/TextArea.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { describe, it } from "vitest";
+
+import { TextArea } from "./TextArea";
+
+describe("TextArea", () => {
+  describe("type inheritance", () => {
+    it("accepts the textarea as prop for backwards compatibility", () => {
+      const withTextareaAs = <TextArea as="textarea" />;
+      void withTextareaAs;
+    });
+  });
+});

--- a/packages/textarea/src/TextArea/TextArea.tsx
+++ b/packages/textarea/src/TextArea/TextArea.tsx
@@ -17,7 +17,9 @@ const deriveState = ({
   return "default";
 };
 
-type TextAreaTextProps = Omit<TextProps<"textarea">, "as">;
+type TextAreaTextProps = Omit<TextProps<"textarea">, "as"> & {
+  as?: "textarea";
+};
 
 type TextAreaBaseProps = {
   size?: Size;
@@ -31,6 +33,7 @@ type TextAreaBaseProps = {
 type TextAreaProps = TextAreaBaseProps & TextAreaTextProps;
 
 const TextArea = ({
+  as = "textarea",
   size = "2",
   variant = "outline",
   resize = "both",
@@ -43,7 +46,7 @@ const TextArea = ({
 
   return (
     <Text
-      as="textarea"
+      as={as}
       data-tgph-textarea
       data-tgph-textarea-state={derivedState}
       data-tgph-textarea-variant={variant}

--- a/packages/toggle/README.md
+++ b/packages/toggle/README.md
@@ -65,6 +65,12 @@ The default Toggle component provides a simple API for common use cases.
 
 Additionally, all native HTML input attributes are supported (`aria-label`, `aria-describedby`, etc.)
 
+`Toggle` owns its controlled/uncontrolled state and visually hidden input
+styling locally and no longer depends on Radix. It still renders a native
+checkbox for form submission, validation, keyboard interaction, and screen
+reader semantics while the visible switch, label, and indicator remain Telegraph
+components.
+
 ### Composition API
 
 For advanced use cases, use the composition API:

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -32,8 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/toggle/src/Toggle/Toggle.test.tsx
+++ b/packages/toggle/src/Toggle/Toggle.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { FormEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
@@ -209,7 +210,11 @@ describe("Toggle", () => {
     );
     const label = screen.getByText("Enable notifications");
     expect(label).toBeInTheDocument();
-    // Label exists for screen readers but is visually hidden
+    expect(label).toHaveStyle({
+      position: "absolute",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    });
   });
 
   it("supports custom aria-label", () => {
@@ -230,6 +235,28 @@ describe("Toggle", () => {
     );
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveAttribute("name", "notifications");
+  });
+
+  it("submits the native checkbox value with forms", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const formData = new FormData(event.currentTarget);
+      expect(formData.get("notifications")).toBe("on");
+    });
+
+    render(
+      <form onSubmit={handleSubmit}>
+        <Toggle.Default label="Enable notifications" name="notifications" />
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    await user.click(screen.getByText("Enable notifications"));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("applies checked state to visual toggle", () => {

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -1,17 +1,23 @@
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button } from "@telegraph/button";
-import type {
-  PolymorphicPropsWithTgphRef,
-  TgphComponentProps,
-  TgphElement,
+import {
+  type PolymorphicPropsWithTgphRef,
+  type TgphComponentProps,
+  type TgphElement,
+  VisuallyHidden,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
 import { Stack } from "@telegraph/layout";
 import { Tag } from "@telegraph/tag";
 import { Text } from "@telegraph/typography";
 import { CheckCircle2, Circle } from "lucide-react";
-import React, { Fragment } from "react";
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useId,
+  useRef,
+} from "react";
 
 import {
   INDICATOR_SIZE_MAP,
@@ -33,7 +39,7 @@ type InternalContextType = {
   "aria-label"?: string;
 };
 
-const ToggleContext = React.createContext<InternalContextType>({
+const ToggleContext = createContext<InternalContextType>({
   size: "2",
   value: false,
   disabled: false,
@@ -83,7 +89,7 @@ const Root = <T extends TgphElement = "div">({
     onChange: onValueChangeProp,
   });
 
-  const generatedId = React.useId();
+  const generatedId = useId();
   const id = idProp || generatedId;
   const labelId = `${id}-label`;
 
@@ -125,14 +131,13 @@ const Root = <T extends TgphElement = "div">({
 export type SwitchProps = TgphComponentProps<typeof Button.Root>;
 
 const Switch = ({ as, className, style, ...props }: SwitchProps) => {
-  const context = React.useContext(ToggleContext);
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const context = useContext(ToggleContext);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { iconSize, ...sizeConfig } = TOGGLE_SIZE_MAP[context.size];
 
   return (
     <Stack position="relative" align="center">
-      {/* Hidden native checkbox for accessibility */}
-      <VisuallyHidden.Root>
+      <VisuallyHidden>
         <input
           type="checkbox"
           id={context.id}
@@ -146,8 +151,7 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
           aria-label={context["aria-label"]}
           data-tgph-toggle-input
         />
-      </VisuallyHidden.Root>
-      {/* Visual toggle */}
+      </VisuallyHidden>
       <Button.Root
         as="label"
         className={className}
@@ -203,33 +207,50 @@ const Label = <T extends TgphElement = "label">({
   style,
   ...props
 }: LabelProps<T>) => {
-  const context = React.useContext(ToggleContext);
-  const Wrapper = hidden ? VisuallyHidden.Root : Fragment;
+  const context = useContext(ToggleContext);
+
+  if (hidden) {
+    return (
+      <VisuallyHidden asChild>
+        <Text
+          as={(as || "label") as T}
+          htmlFor={context.id}
+          id={context.labelId}
+          size={LABEL_SIZE_MAP[context.size]}
+          data-tgph-toggle-label
+          data-tgph-toggle-disabled={context.disabled}
+          style={{
+            cursor: context.disabled ? "not-allowed" : "pointer",
+            ...style,
+          }}
+          {...props}
+        />
+      </VisuallyHidden>
+    );
+  }
 
   return (
-    <Wrapper asChild>
-      <Text
-        as={(as || "label") as T}
-        htmlFor={context.id}
-        id={context.labelId}
-        size={LABEL_SIZE_MAP[context.size]}
-        data-tgph-toggle-label
-        data-tgph-toggle-disabled={context.disabled}
-        style={{
-          cursor: context.disabled ? "not-allowed" : "pointer",
-          ...style,
-        }}
-        {...props}
-      />
-    </Wrapper>
+    <Text
+      as={(as || "label") as T}
+      htmlFor={context.id}
+      id={context.labelId}
+      size={LABEL_SIZE_MAP[context.size]}
+      data-tgph-toggle-label
+      data-tgph-toggle-disabled={context.disabled}
+      style={{
+        cursor: context.disabled ? "not-allowed" : "pointer",
+        ...style,
+      }}
+      {...props}
+    />
   );
 };
 
 export type IndicatorProps<T extends TgphElement = "span"> = TgphComponentProps<
   typeof Tag<T>
 > & {
-  enabledContent?: React.ReactNode;
-  disabledContent?: React.ReactNode;
+  enabledContent?: ReactNode;
+  disabledContent?: ReactNode;
 };
 
 const Indicator = <T extends TgphElement = "span">({
@@ -240,9 +261,8 @@ const Indicator = <T extends TgphElement = "span">({
   children,
   ...props
 }: IndicatorProps<T>) => {
-  const context = React.useContext(ToggleContext);
+  const context = useContext(ToggleContext);
 
-  // Determine what content to show
   const content =
     children || (context.value ? enabledContent : disabledContent);
   const size = INDICATOR_SIZE_MAP[context.size];
@@ -266,7 +286,7 @@ const Indicator = <T extends TgphElement = "span">({
 };
 
 export type DefaultProps<T extends TgphElement = "div"> = RootProps<T> & {
-  label?: React.ReactNode;
+  label?: ReactNode;
   labelProps?: Omit<LabelProps<"label">, "as">;
   indicator?: boolean;
   indicatorProps?: Omit<IndicatorProps<"span">, "as">;

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -50,15 +50,19 @@ import "@telegraph/tokens/light.css";
 ```tsx
 // Using tokens in JavaScript
 import telegraphTokens from "@telegraph/tokens";
+import cssVariablesMap from "@telegraph/tokens/css-variables-map";
+import flattenedCssVariablesMap from "@telegraph/tokens/flattened-css-variables-map";
 
 const { tokens } = telegraphTokens;
+const blueBackground = cssVariablesMap.color["blue-3"];
+const compactGap = flattenedCssVariablesMap.spacing["2"];
 
 const MyComponent = () => (
   <div
     style={{
-      background: tokens["--tgph-blue-3"],
+      background: blueBackground,
       color: tokens["--tgph-blue-11"],
-      padding: tokens["--tgph-spacing-4"],
+      padding: compactGap,
       borderRadius: tokens["--tgph-radius-2"],
       fontSize: tokens["--tgph-font-size-2"],
     }}
@@ -110,8 +114,8 @@ Telegraph uses a semantic color system with 12-step scales for each color, provi
 
 Consistent spacing system based on a 4px grid with exponential scaling.
 
-| Token             | Value  | Rem       | Usage                          |
-| ----------------- | ------ | --------- | ------------------------------ |
+| Token               | Value  | Rem       | Usage                          |
+| ------------------- | ------ | --------- | ------------------------------ |
 | `--tgph-spacing-1`  | `4px`  | `0.25rem` | Minimal spacing, tight layouts |
 | `--tgph-spacing-2`  | `8px`  | `0.5rem`  | Small gaps, compact components |
 | `--tgph-spacing-3`  | `12px` | `0.75rem` | Component padding              |

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -22,12 +22,16 @@
       "default": "./dist/css/dark.css"
     },
     "./css-variables-map": {
-      "import": "./dist/json/tokens.json",
-      "default": "./dist/json/tokens.json"
+      "types": "./dist/types/css-variables-map.d.ts",
+      "import": "./dist/esm/css-variables-map.mjs",
+      "require": "./dist/cjs/css-variables-map.js",
+      "default": "./dist/cjs/css-variables-map.js"
     },
     "./flattened-css-variables-map": {
-      "import": "./dist/json/flattened-tokens.json",
-      "default": "./dist/json/flattened-tokens.json"
+      "types": "./dist/types/flattened-css-variables-map.d.ts",
+      "import": "./dist/esm/flattened-css-variables-map.mjs",
+      "require": "./dist/cjs/flattened-css-variables-map.js",
+      "default": "./dist/cjs/flattened-css-variables-map.js"
     },
     "./breakpoints": {
       "default": "./dist/css/breakpoints.css"

--- a/packages/tokens/scripts/generate-css-var-map.js
+++ b/packages/tokens/scripts/generate-css-var-map.js
@@ -95,22 +95,56 @@ const flattenTokens = (obj) => {
   return result;
 };
 
-/**
- * Saves the generated mapping to a JSON file.
- * @param {String} name - The name of the file (without extension).
- * @param {Object} tokens - The object containing the mappings to save.
- */
-const saveMapping = async (name, tokens) => {
+const toReadonlyTypeLiteral = (value, indentLevel = 0) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "string";
+  }
+
+  const currentIndent = "  ".repeat(indentLevel);
+  const childIndent = "  ".repeat(indentLevel + 1);
+  const properties = Object.entries(value).map(
+    ([key, childValue]) =>
+      `${childIndent}readonly ${JSON.stringify(key)}: ${toReadonlyTypeLiteral(childValue, indentLevel + 1)};`,
+  );
+
+  return `{\n${properties.join("\n")}\n${currentIndent}}`;
+};
+
+const createModuleDeclaration = (exportName, tokens) =>
+  `declare const ${exportName}: ${toReadonlyTypeLiteral(tokens)};\nexport default ${exportName};\n`;
+
+// Saves the generated mapping to JSON, JS module, and type declaration files.
+const saveMapping = async ({ jsonName, moduleName, tokens, exportName }) => {
   try {
-    // Define the directory path where the mappings will be saved
-    const distDirPath = path.join(__dirname, "../dist/json");
-    // Ensure the directory exists (create it if not)
-    await mkdir(distDirPath, { recursive: true });
-    // Write the mappings to a JSON file
-    await writeFile(
-      path.join(distDirPath, `./${name}.json`),
-      JSON.stringify(tokens),
-    );
+    const serializedTokens = JSON.stringify(tokens);
+    const moduleDeclaration = createModuleDeclaration(exportName, tokens);
+    const distDirPath = path.join(__dirname, "../dist");
+
+    await Promise.all([
+      mkdir(path.join(distDirPath, "json"), { recursive: true }),
+      mkdir(path.join(distDirPath, "esm"), { recursive: true }),
+      mkdir(path.join(distDirPath, "cjs"), { recursive: true }),
+      mkdir(path.join(distDirPath, "types"), { recursive: true }),
+    ]);
+
+    await Promise.all([
+      writeFile(
+        path.join(distDirPath, "json", `${jsonName}.json`),
+        serializedTokens,
+      ),
+      writeFile(
+        path.join(distDirPath, "esm", `${moduleName}.mjs`),
+        `const tokens = ${serializedTokens};\n\nexport default tokens;\n`,
+      ),
+      writeFile(
+        path.join(distDirPath, "cjs", `${moduleName}.js`),
+        `module.exports = ${serializedTokens};\n`,
+      ),
+      writeFile(
+        path.join(distDirPath, "types", `${moduleName}.d.ts`),
+        moduleDeclaration,
+      ),
+    ]);
   } catch (e) {
     console.error("There was an error while saving a file.\n", e);
   }
@@ -142,9 +176,20 @@ const main = async (funcArgs) => {
 
     const flattenedTokens = flattenTokens(tgph.tokens);
 
-    // Save the generated mappings
-    saveMapping("tokens", tokens);
-    saveMapping("flattened-tokens", flattenedTokens);
+    await Promise.all([
+      saveMapping({
+        jsonName: "tokens",
+        moduleName: "css-variables-map",
+        tokens,
+        exportName: "cssVariablesMap",
+      }),
+      saveMapping({
+        jsonName: "flattened-tokens",
+        moduleName: "flattened-css-variables-map",
+        tokens: flattenedTokens,
+        exportName: "flattenedCssVariablesMap",
+      }),
+    ]);
   } catch (e) {
     console.error(
       "Provide a correct argument - a relative path to design tokens.\n",

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -82,7 +82,7 @@ The main tooltip component that wraps content and provides contextual informatio
 | `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
 | `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
 | `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                          |
-| `triggerRef`              | `RefObject<HTMLButtonElement>`           | `undefined` | Ref forwarded to the rendered trigger element                |
+| `triggerRef`              | `RefObject<HTMLElement \| null>`         | `undefined` | Ref forwarded to the rendered trigger element                |
 | `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
 | `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
 | `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -70,7 +70,9 @@ The main tooltip component that wraps content and provides contextual informatio
 
 | Prop                      | Type                                     | Default     | Description                                                  |
 | ------------------------- | ---------------------------------------- | ----------- | ------------------------------------------------------------ |
-| `label`                   | `string \| ReactNode`                    | -           | **Required.** Content to display in the tooltip              |
+| `label`                   | `string \| ReactNode`                    | `undefined` | Content to display in the tooltip                            |
+| `labelProps`              | `TgphComponentProps<typeof Stack>`       | `undefined` | Props to pass to the rendered tooltip content                |
+| `enabled`                 | `boolean`                                | `true`      | Whether the tooltip can open                                 |
 | `side`                    | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`  | Preferred placement side                                     |
 | `align`                   | `"start" \| "center" \| "end"`           | `"center"`  | Alignment relative to the trigger                            |
 | `sideOffset`              | `number`                                 | `4`         | Distance from the trigger element                            |
@@ -79,6 +81,8 @@ The main tooltip component that wraps content and provides contextual informatio
 | `skipDelayDuration`       | `number`                                 | -           | Skip delay if another tooltip was recently shown             |
 | `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
 | `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
+| `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                          |
+| `triggerRef`              | `RefObject<HTMLButtonElement>`           | `undefined` | Ref forwarded to the rendered trigger element                |
 | `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
 | `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
 | `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |
@@ -185,11 +189,7 @@ When wrapping elements inside a `Select` or `Combobox` (where DOM focus moves to
 import { Tooltip } from "@telegraph/tooltip";
 
 export const ListItemTooltip = ({ item }) => (
-  <Tooltip
-    label={item.description}
-    disableFocusOpen
-    delayDuration={500}
-  >
+  <Tooltip label={item.description} disableFocusOpen delayDuration={500}>
     <li>{item.name}</li>
   </Tooltip>
 );
@@ -469,6 +469,12 @@ export const NestedTooltips = () => (
 );
 ```
 
+## Implementation Notes
+
+`Tooltip` is implemented with [Base UI Tooltip](https://base-ui.com/react/components/tooltip) primitives and a Telegraph-rendered content surface. The public API keeps the long-standing Telegraph/Radix-style prop names, including `delayDuration`, `skipDelayDuration`, `disableHoverableContent`, `forceMount`, `onEscapeKeyDown`, and `onPointerDownOutside`.
+
+The portaled tooltip content renders with `className="tgph"`, `role="tooltip"`, `data-state`, and `data-tgph-appearance="dark"`, and the trigger is linked with `aria-describedby` while the tooltip is open. Telegraph trigger refs continue to work through `triggerRef` and `tgphRef`-compatible children.
+
 ## Accessibility
 
 - ✅ **Keyboard Navigation**: Full keyboard support with proper focus management
@@ -518,8 +524,8 @@ export const BasicExample = () => (
 ### Advanced Example
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Button } from "@telegraph/button";
+import { Tag } from "@telegraph/tag";
 import { Tooltip } from "@telegraph/tooltip";
 import { Calendar, Mail, MapPin, User } from "lucide-react";
 
@@ -576,8 +582,8 @@ export const UserProfileTooltip = ({ user }) => (
 ### Real-world Example
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Button } from "@telegraph/button";
+import { Tag } from "@telegraph/tag";
 import { Tooltip } from "@telegraph/tooltip";
 import {
   Bell,
@@ -729,7 +735,7 @@ export const ApplicationHeader = ({ user, notifications }) => (
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/tooltip)
-- [Radix UI Tooltip](https://www.radix-ui.com/primitives/docs/components/tooltip) - Base primitive
+- [Base UI Tooltip](https://base-ui.com/react/components/tooltip) - Base primitive
 - [Popover Component](../popover/README.md) - Related overlay component
 
 ## Contributing

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -32,8 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-tooltip": "^1.2.8",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/appearance": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/tooltip/src/Tooltip/Tooltip.constants.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.constants.ts
@@ -2,13 +2,10 @@ import type { OverrideAppearance } from "@telegraph/appearance";
 import type { Required, TgphComponentProps } from "@telegraph/helpers";
 import type { Stack } from "@telegraph/layout";
 
-type Appearance = Required<
+export type Appearance = Required<
   TgphComponentProps<typeof OverrideAppearance>
 >["appearance"];
 
-// Set any appearance specifics props for the content.
-// For example, a light appearance tooltip should stand out
-// from the background of the page.
 export const TooltipContentProps: Record<
   Appearance,
   TgphComponentProps<typeof Stack>

--- a/packages/tooltip/src/Tooltip/Tooltip.helpers.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.helpers.ts
@@ -1,0 +1,5 @@
+export const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;

--- a/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
@@ -1,11 +1,17 @@
-import React from "react";
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 type TooltipGroupContextState = {
   groupOpen: boolean;
   setGroupOpen?: (open: boolean) => void;
 };
 
-const TooltipContext = React.createContext<TooltipGroupContextState>({
+const TooltipContext = createContext<TooltipGroupContextState>({
   groupOpen: false,
   setGroupOpen: () => {},
 });
@@ -16,31 +22,24 @@ type UseTooltipGroupParams = {
 };
 
 const useTooltipGroup = ({ open, delay = 600 }: UseTooltipGroupParams) => {
-  const context = React.useContext(TooltipContext);
+  const context = useContext(TooltipContext);
 
-  // If the open prop is set to true, we set the groupOpen state to true
-  // If the open prop is set to false, we set the groupOpen state to false after a delay
-  // to ensure that another tooltip is not opened while this one is closed.
-  React.useEffect(() => {
-    let timer: NodeJS.Timeout | null = null;
-    if (context.setGroupOpen) {
-      if (open === true) {
-        context.setGroupOpen(true);
-      }
-
-      if (open === false) {
-        timer = setTimeout(() => {
-          if (context.setGroupOpen) {
-            context.setGroupOpen(false);
-          }
-        }, delay);
-      }
+  useEffect(() => {
+    if (!context.setGroupOpen) {
+      return;
     }
 
+    if (open === true) {
+      context.setGroupOpen(true);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      context.setGroupOpen?.(false);
+    }, delay);
+
     return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
+      clearTimeout(timer);
     };
   }, [open, context, delay]);
 
@@ -50,11 +49,11 @@ const useTooltipGroup = ({ open, delay = 600 }: UseTooltipGroupParams) => {
 };
 
 type TooltipGroupProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const TooltipGroupProvider = ({ children }: TooltipGroupProviderProps) => {
-  const [groupOpen, setGroupOpen] = React.useState<boolean>(false);
+  const [groupOpen, setGroupOpen] = useState<boolean>(false);
 
   return (
     <TooltipContext.Provider value={{ groupOpen, setGroupOpen }}>

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -28,13 +28,17 @@ const meta: Meta = {
         type: "select",
       },
     },
-    appearance: {
-      options: ["light", "dark"],
+    enabled: {
       control: {
-        type: "select",
+        type: "boolean",
       },
     },
-    enabled: {
+    open: {
+      control: {
+        type: "boolean",
+      },
+    },
+    defaultOpen: {
       control: {
         type: "boolean",
       },
@@ -50,7 +54,6 @@ const meta: Meta = {
     side: "bottom",
     align: "center",
     enabled: true,
-    appearance: "dark",
   },
 };
 
@@ -59,6 +62,23 @@ export default meta;
 type Story = StoryObj<TgphComponentProps<typeof TelegraphTooltip>>;
 
 export const Default: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center">
+        <TelegraphTooltip {...args}>
+          <Button color="blue">Hover me</Button>
+        </TelegraphTooltip>
+      </Stack>
+    );
+  },
+};
+
+export const Open: Story = {
+  args: {
+    defaultOpen: true,
+    delayDuration: 0,
+    skipAnimation: true,
+  },
   render: ({ ...args }) => {
     return (
       <Stack w="full" my="10" align="center" justify="center">

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@telegraph/button";
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -283,6 +284,21 @@ describe("Tooltip", () => {
       transformOrigin: "var(--transform-origin)",
     });
     expect(container).not.toContainElement(content);
+  });
+
+  it("renders string labels around Telegraph triggers without dropping typography props", async () => {
+    render(
+      <Tooltip defaultOpen label="Telegraph trigger context" skipAnimation>
+        <Button>Hover target</Button>
+      </Tooltip>,
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Telegraph trigger context",
+    );
+    expect(
+      screen.getByRole("button", { name: "Hover target" }),
+    ).toHaveAttribute("data-state", "open");
   });
 
   it("preserves existing trigger descriptions when linking the tooltip", async () => {

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,33 @@
-import { describe, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Tooltip } from "./Tooltip";
 import type { TooltipProps } from "./Tooltip";
+import { TooltipGroupProvider } from "./Tooltip.hooks";
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Tooltip", () => {
   describe("type inheritance", () => {
@@ -9,7 +36,6 @@ describe("Tooltip", () => {
         label: "Tooltip text",
         side: "top",
         enabled: true,
-        appearance: "dark",
         children: null,
       };
       void validProps;
@@ -24,6 +50,16 @@ describe("Tooltip", () => {
       void propsWithDisableFocusOpen;
     });
 
+    it("accepts legacy wrapper passthrough props", () => {
+      const validProps: TooltipProps = {
+        label: "Tooltip text",
+        asChild: true,
+        style: { zIndex: 9999 },
+        children: null,
+      };
+      void validProps;
+    });
+
     it("rejects unknown props on type level", () => {
       // @ts-expect-error unknown prop rejected on TooltipProps
       const invalidProp: TooltipProps = {
@@ -33,5 +69,306 @@ describe("Tooltip", () => {
       };
       void invalidProp;
     });
+  });
+
+  it("opens and closes on hover in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Tooltip
+        label="Helpful context"
+        delayDuration={0}
+        onOpenChange={onOpenChange}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute("data-state", "closed");
+
+    await user.hover(trigger);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Helpful context",
+    );
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.unhover(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute("data-state", "closed");
+    });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledTooltip = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Tooltip
+          label="Controlled context"
+          delayDuration={0}
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      );
+    };
+
+    render(<ControlledTooltip />);
+
+    await user.hover(screen.getByRole("button", { name: "Hover target" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Controlled context",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("keeps disabled tooltips closed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip
+        defaultOpen
+        enabled={false}
+        label="Hidden context"
+        delayDuration={0}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hover target" }));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("dismisses with Escape", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Tooltip
+          defaultOpen
+          label="Dismissible context"
+          onEscapeKeyDown={onEscapeKeyDown}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      </>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses with outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Tooltip
+          defaultOpen
+          label="Dismissible context"
+          onPointerDownOutside={onPointerDownOutside}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      </>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the tooltip open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Tooltip
+        defaultOpen
+        label="Persistent context"
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onOpenChange={onOpenChange}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("prevents focus-triggered opens when disableFocusOpen is true", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip
+        label="Focus context"
+        delayDuration={0}
+        disableFocusOpen
+        skipAnimation
+      >
+        <TestButton>Focus target</TestButton>
+      </Tooltip>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "Focus target" })).toHaveFocus();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = render(
+      <Tooltip
+        defaultOpen
+        label="Styled context"
+        labelProps={{ "data-testid": "tooltip-content" }}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("data-tgph-appearance", "dark");
+    expect(content).toHaveAttribute("role", "tooltip");
+    expect(trigger).toHaveAttribute("aria-describedby", content.id);
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("preserves existing trigger descriptions when linking the tooltip", async () => {
+    render(
+      <Tooltip
+        defaultOpen
+        label="Described context"
+        labelProps={{ "data-testid": "tooltip-content" }}
+        skipAnimation
+      >
+        <TestButton aria-describedby="existing-description">
+          Hover target
+        </TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+
+    expect(
+      screen.getByRole("button", { name: "Hover target" }),
+    ).toHaveAttribute("aria-describedby", `existing-description ${content.id}`);
+  });
+
+  it("keeps the trigger description linked when labelProps includes an id", async () => {
+    render(
+      <Tooltip
+        defaultOpen
+        label="Described context"
+        labelProps={{
+          "data-testid": "tooltip-content",
+          id: "custom-tooltip-id",
+        }}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(content).not.toHaveAttribute("id", "custom-tooltip-id");
+    expect(trigger).toHaveAttribute("aria-describedby", content.id);
+  });
+
+  it("forwards trigger refs through tgphRef-compatible children", async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+
+    render(
+      <Tooltip
+        defaultOpen
+        label="Ref context"
+        triggerRef={triggerRef}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(triggerRef.current).toBe(trigger);
+  });
+
+  it("opens grouped tooltips without delay after another tooltip is open", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipGroupProvider>
+        <Tooltip
+          defaultOpen
+          label="First context"
+          delayDuration={1000}
+          skipAnimation
+        >
+          <TestButton>First target</TestButton>
+        </Tooltip>
+        <Tooltip label="Second context" delayDuration={1000} skipAnimation>
+          <TestButton>Second target</TestButton>
+        </Tooltip>
+      </TooltipGroupProvider>,
+    );
+
+    await screen.findByText("First context");
+    await user.hover(screen.getByRole("button", { name: "Second target" }));
+
+    expect(await screen.findByText("Second context")).toBeInTheDocument();
   });
 });

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -1,51 +1,132 @@
-import * as RadixTooltip from "@radix-ui/react-tooltip";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type RefObject,
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useId,
+  useState,
+} from "react";
 
+import { NO_COLLISION_AVOIDANCE } from "./Tooltip.helpers";
 import { useTooltipGroup } from "./Tooltip.hooks";
 
+type BaseTooltipRootProps = ComponentPropsWithoutRef<typeof BaseTooltip.Root>;
+type BaseTooltipProviderProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Provider
+>;
+type BaseTooltipTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Trigger
+>;
+type BaseTooltipPortalProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Portal
+>;
+type BaseTooltipPositionerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Positioner
+>;
+type BaseTooltipPopupProps = ComponentPropsWithoutRef<typeof BaseTooltip.Popup>;
+
+type BaseTooltipTriggerFocusEvent = Parameters<
+  NonNullable<BaseTooltipTriggerProps["onFocus"]>
+>[0];
+
+type TooltipPopupRenderState = {
+  open: boolean;
+};
+
+type LegacyTooltipProviderProps = Omit<
+  BaseTooltipProviderProps,
+  "children" | "delay" | "timeout"
+> & {
+  delayDuration?: BaseTooltipProviderProps["delay"];
+  skipDelayDuration?: BaseTooltipProviderProps["timeout"];
+};
+
+type LegacyTooltipRootProps = Omit<
+  BaseTooltipRootProps,
+  | "children"
+  | "defaultOpen"
+  | "disableHoverablePopup"
+  | "disabled"
+  | "onOpenChange"
+  | "open"
+> & {
+  defaultOpen?: BaseTooltipRootProps["defaultOpen"];
+  disableHoverableContent?: BaseTooltipRootProps["disableHoverablePopup"];
+  onOpenChange?: (open: boolean) => void;
+  open?: BaseTooltipRootProps["open"];
+};
+
+type LegacyTooltipPositionerProps = Omit<
+  BaseTooltipPositionerProps,
+  "children" | "className" | "render" | "style"
+> & {
+  avoidCollisions?: boolean;
+  hideWhenDetached?: boolean;
+};
+
+type LegacyTooltipPopupProps = Omit<
+  BaseTooltipPopupProps,
+  "children" | "className" | "render" | "style"
+> & {
+  "aria-label"?: BaseTooltipPopupProps["aria-label"];
+  forceMount?: BaseTooltipPortalProps["keepMounted"];
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (
+    event: MouseEvent | PointerEvent | TouchEvent,
+  ) => void;
+};
+
 export type TooltipBaseProps<T extends TgphElement = "div"> = {
-  label: string | React.ReactNode;
+  children?: ReactNode;
+  label: ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
-  /**
-   * When `true`, prevents focus events from instantly opening the tooltip.
-   * Useful when a parent component (e.g. Select/Combobox) moves DOM focus on
-   * hover, which would otherwise bypass `delayDuration` via Radix's composed
-   * `onFocus` handler.
-   * @default false
-   */
+  asChild?: boolean;
+  // When true, prevents focus events from instantly opening the tooltip. This
+  // preserves delayed hover behavior when Select/Combobox move DOM focus on hover.
   disableFocusOpen?: boolean;
-
   skipAnimation?: boolean;
-  triggerRef?: React.RefObject<HTMLButtonElement>;
+  style?: TgphComponentProps<typeof Stack<T>>["style"];
+  triggerRef?: RefObject<HTMLButtonElement>;
 };
 
 export type TooltipProps<T extends TgphElement = "div"> =
-  React.ComponentPropsWithoutRef<typeof RadixTooltip.Root> &
-    React.ComponentPropsWithoutRef<typeof RadixTooltip.Provider> &
-    React.ComponentPropsWithoutRef<typeof RadixTooltip.Content> &
+  LegacyTooltipProviderProps &
+    LegacyTooltipRootProps &
+    LegacyTooltipPositionerProps &
+    LegacyTooltipPopupProps &
     TooltipBaseProps<T>;
 
 const Tooltip = <T extends TgphElement = "div">({
-  // Radix Tooltip Provider Props
   delayDuration = 400,
   skipDelayDuration,
+  closeDelay,
   disableHoverableContent,
-  // Radix Tooltip Root Props
   defaultOpen: defaultOpenProp,
   open: openProp,
   onOpenChange: onOpenChangeProp,
-  // Radix Tooltip Content Props
+  onOpenChangeComplete,
+  actionsRef,
+  handle,
+  trackCursorAxis,
+  triggerId,
+  defaultTriggerId,
   "aria-label": ariaLabel,
   onEscapeKeyDown,
   onPointerDownOutside,
@@ -54,161 +135,247 @@ const Tooltip = <T extends TgphElement = "div">({
   sideOffset = 4,
   align = "center",
   alignOffset,
+  anchor,
+  positionMethod,
   avoidCollisions,
+  collisionAvoidance,
   collisionBoundary,
   collisionPadding,
   arrowPadding,
   sticky,
+  disableAnchorTracking,
   hideWhenDetached,
-  skipAnimation,
-  // Label Props
   label,
   labelProps,
-  // Telegraph Props
   enabled = true,
   disableFocusOpen = false,
-
+  skipAnimation,
+  style,
   triggerRef,
+  id,
   children,
 }: TooltipProps<T>) => {
-  const [open, setOpen] = useControllableState({
-    prop: openProp,
-    onChange: onOpenChangeProp,
-    defaultProp: defaultOpenProp ?? false,
+  const generatedTooltipId = useId();
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(
+    defaultOpenProp ?? false,
+  );
+  // Base UI does not ship the Radix controllable-state helper, so keep the old
+  // controlled/uncontrolled behavior local to Tooltip.
+  const controlled = openProp !== undefined;
+  const open = controlled ? openProp : uncontrolledOpen;
+  // `enabled={false}` has historically forced the tooltip closed even when a
+  // controlled caller still passes `open`.
+  const resolvedOpen = enabled === false ? false : open;
+  const { groupOpen } = useTooltipGroup({
+    open: Boolean(resolvedOpen),
+    delay: delayDuration,
   });
-  const { groupOpen } = useTooltipGroup({ open: !!open, delay: delayDuration });
 
-  const areAnyChildrenElementsDisabled = React.Children.toArray(children).some(
+  const areAnyChildrenElementsDisabled = Children.toArray(children).some(
     (child) => {
-      if (React.isValidElement(child)) {
+      if (isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
         return childProps.disabled;
       }
+
       return false;
     },
   );
 
+  // Disabled trigger children do not reliably emit hover/focus timing events,
+  // so match the previous Radix behavior by removing the delay in that case.
   const derivedDelayDuration =
     groupOpen || areAnyChildrenElementsDisabled ? 0 : delayDuration;
-
-  const shouldAnimate = !groupOpen;
-
-  const deriveAnimationBasedOnSide = (side: TooltipProps<T>["side"]) => {
-    const ANIMATION_OFFSET = 5;
-    if (side === "top") {
-      return {
-        y: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "bottom") {
-      return {
-        y: ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "left") {
-      return {
-        x: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "right") {
-      return {
-        x: ANIMATION_OFFSET,
-      };
-    }
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  const popupLabelProps = labelProps as
+    | TgphComponentProps<typeof Stack>
+    | undefined;
+  const { style: labelStyle, ...popupLabelRestProps } = popupLabelProps ?? {};
+  const popupStyle = {
+    transformOrigin: "var(--transform-origin)",
+    ...style,
+    ...labelStyle,
   };
+  const shouldAnimate = !groupOpen;
+  const tooltipId = id ?? generatedTooltipId;
+  const triggerDataState = resolvedOpen ? "open" : "closed";
+  const existingAriaDescribedBy = isValidElement(children)
+    ? ((children.props as Record<string, unknown>)["aria-describedby"] as
+        | string
+        | undefined)
+    : undefined;
+  // Preserve any caller-provided description id while appending the tooltip id
+  // only while the tooltip is actually exposed.
+  const triggerAriaDescribedBy =
+    [existingAriaDescribedBy, resolvedOpen ? tooltipId : undefined]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  const handleOpenChange = useCallback<
+    NonNullable<BaseTooltipRootProps["onOpenChange"]>
+  >(
+    (nextOpen, eventDetails) => {
+      if (
+        !nextOpen &&
+        callLegacyDismissHandlers(eventDetails, {
+          onEscapeKeyDown,
+          onPointerDownOutside,
+        })
+      ) {
+        // Legacy Radix dismissal handlers could cancel close; translate that
+        // prevention back to Base UI's eventDetails cancel API.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (!controlled) {
+        // Controlled callers receive the callback below but keep ownership of
+        // the actual open value.
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChangeProp?.(nextOpen);
+    },
+    [controlled, onEscapeKeyDown, onOpenChangeProp, onPointerDownOutside],
+  );
+
+  const handleFocus = useCallback(
+    (event: BaseTooltipTriggerFocusEvent) => {
+      if (disableFocusOpen) {
+        // Base UI composes focus open internally, so prevent both the DOM event
+        // and Base UI's handler to preserve the old opt-out prop.
+        event.preventDefault();
+        event.preventBaseUIHandler();
+      }
+    },
+    [disableFocusOpen],
+  );
 
   return (
     <LazyMotion features={domAnimation}>
-      <RadixTooltip.Provider
-        delayDuration={derivedDelayDuration}
-        skipDelayDuration={skipDelayDuration}
-        disableHoverableContent={disableHoverableContent}
+      <BaseTooltip.Provider
+        delay={derivedDelayDuration}
+        closeDelay={closeDelay}
+        timeout={skipDelayDuration}
       >
-        <RadixTooltip.Root
-          open={enabled === false ? false : open}
-          onOpenChange={setOpen}
+        <BaseTooltip.Root
+          actionsRef={actionsRef}
+          defaultTriggerId={defaultTriggerId}
+          disabled={enabled === false}
+          disableHoverablePopup={disableHoverableContent}
+          handle={handle}
+          onOpenChange={handleOpenChange}
+          onOpenChangeComplete={onOpenChangeComplete}
+          open={resolvedOpen}
+          trackCursorAxis={trackCursorAxis}
+          triggerId={triggerId}
         >
-          <RadixTooltip.Trigger asChild={true} ref={triggerRef}>
-            <RefToTgphRef
-              {...(disableFocusOpen
-                ? { onFocus: (e: React.FocusEvent) => e.preventDefault() }
-                : {})}
+          {isValidElement(children) ? (
+            <BaseTooltip.Trigger
+              aria-describedby={triggerAriaDescribedBy}
+              data-state={triggerDataState}
+              delay={derivedDelayDuration}
+              onFocus={handleFocus}
+              ref={triggerRef}
+              render={createTgphBaseUIRender(
+                cloneElement(children, {
+                  "aria-describedby": triggerAriaDescribedBy,
+                  "data-state": triggerDataState,
+                } as Record<string, unknown>),
+              )}
+            />
+          ) : (
+            <BaseTooltip.Trigger
+              aria-describedby={triggerAriaDescribedBy}
+              data-state={triggerDataState}
+              delay={derivedDelayDuration}
+              onFocus={handleFocus}
+              ref={triggerRef}
             >
               {children}
-            </RefToTgphRef>
-          </RadixTooltip.Trigger>
-          <RadixTooltip.Portal>
-            <RadixTooltip.Content
-              aria-label={ariaLabel}
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={onPointerDownOutside}
-              forceMount={forceMount}
-              side={side}
-              sideOffset={sideOffset}
+            </BaseTooltip.Trigger>
+          )}
+          <BaseTooltip.Portal keepMounted={forceMount}>
+            <BaseTooltip.Positioner
               align={align}
               alignOffset={alignOffset}
-              avoidCollisions={avoidCollisions}
+              anchor={anchor}
+              arrowPadding={arrowPadding}
+              collisionAvoidance={resolvedCollisionAvoidance}
               collisionBoundary={collisionBoundary}
               collisionPadding={collisionPadding}
-              arrowPadding={arrowPadding}
+              disableAnchorTracking={disableAnchorTracking}
+              positionMethod={positionMethod}
+              side={side}
+              sideOffset={sideOffset}
               sticky={sticky}
-              hideWhenDetached={hideWhenDetached}
-              style={{
-                zIndex: `var(--tgph-zIndex-tooltip)`,
-              }}
+              style={(state) =>
+                getBaseUIPositionerVisibilityStyle({
+                  anchorHidden: state.anchorHidden,
+                  hideWhenDetached,
+                  zIndex: "var(--tgph-zIndex-tooltip)",
+                })
+              }
             >
-              <Stack
-                as={motion.div}
-                // Add tgph class so that this always works in portals
-                className="tgph"
-                initial={
-                  shouldAnimate && !skipAnimation
-                    ? {
-                        opacity: 0,
-                        scale: 0.8,
-                        ...deriveAnimationBasedOnSide(side),
+              <BaseTooltip.Popup
+                aria-label={ariaLabel}
+                id={tooltipId}
+                render={createTgphBaseUIRender(
+                  (state: TooltipPopupRenderState) => (
+                    <Stack
+                      as={motion.div}
+                      className="tgph"
+                      initial={
+                        shouldAnimate && !skipAnimation
+                          ? {
+                              opacity: 0,
+                              scale: 0.8,
+                              ...getBaseUIMotionOffset(side),
+                            }
+                          : {}
                       }
-                    : {}
-                }
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                  x: 0,
-                  y: 0,
-                }}
-                transition={{
-                  duration: 0.1,
-                  type: "spring",
-                  bounce: 0,
-                }}
-                bg="surface-1"
-                shadow="2"
-                rounded="3"
-                py="1_5"
-                px="2"
-                align="center"
-                justify="center"
-                style={{
-                  transformOrigin:
-                    "var(--radix-tooltip-content-transform-origin)",
-                }}
-                {...(labelProps ?? {})}
-              >
-                {typeof label === "string" ? (
-                  <Text as="span" size="1">
-                    {label}
-                  </Text>
-                ) : (
-                  label
+                      animate={{
+                        opacity: 1,
+                        scale: 1,
+                        x: 0,
+                        y: 0,
+                      }}
+                      transition={{
+                        duration: 0.1,
+                        type: "spring",
+                        bounce: 0,
+                      }}
+                      bg="surface-1"
+                      data-state={state.open ? "open" : "closed"}
+                      data-tgph-appearance="dark"
+                      shadow="2"
+                      rounded="3"
+                      py="1_5"
+                      px="2"
+                      align="center"
+                      justify="center"
+                      style={popupStyle}
+                      {...popupLabelRestProps}
+                      id={tooltipId}
+                      role="tooltip"
+                    >
+                      {typeof label === "string" ? (
+                        <Text as="span" size="1">
+                          {label}
+                        </Text>
+                      ) : (
+                        label
+                      )}
+                    </Stack>
+                  ),
                 )}
-              </Stack>
-            </RadixTooltip.Content>
-          </RadixTooltip.Portal>
-        </RadixTooltip.Root>
-      </RadixTooltip.Provider>
+              />
+            </BaseTooltip.Positioner>
+          </BaseTooltip.Portal>
+        </BaseTooltip.Root>
+      </BaseTooltip.Provider>
     </LazyMotion>
   );
 };

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
 import {
   Children,
+  type ComponentPropsWithRef,
   type ComponentPropsWithoutRef,
   type ReactNode,
   type RefObject,
@@ -31,6 +32,9 @@ type BaseTooltipProviderProps = ComponentPropsWithoutRef<
   typeof BaseTooltip.Provider
 >;
 type BaseTooltipTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Trigger
+>;
+type BaseTooltipTriggerPropsWithRef = ComponentPropsWithRef<
   typeof BaseTooltip.Trigger
 >;
 type BaseTooltipPortalProps = ComponentPropsWithoutRef<
@@ -72,17 +76,23 @@ type LegacyTooltipRootProps = Omit<
   open?: BaseTooltipRootProps["open"];
 };
 
-type LegacyTooltipPositionerProps = Omit<
-  BaseTooltipPositionerProps,
-  "children" | "className" | "render" | "style"
+type LegacyTooltipPositionerProps = Partial<
+  Omit<
+    BaseTooltipPositionerProps,
+    "align" | "children" | "className" | "render" | "side" | "style"
+  >
 > & {
+  align?: BaseTooltipPositionerProps["align"];
   avoidCollisions?: boolean;
   hideWhenDetached?: boolean;
+  side?: BaseTooltipPositionerProps["side"];
 };
 
-type LegacyTooltipPopupProps = Omit<
-  BaseTooltipPopupProps,
-  "children" | "className" | "render" | "style"
+type LegacyTooltipPopupProps = Partial<
+  Omit<
+    BaseTooltipPopupProps,
+    "align" | "children" | "className" | "render" | "side" | "style"
+  >
 > & {
   "aria-label"?: BaseTooltipPopupProps["aria-label"];
   forceMount?: BaseTooltipPortalProps["keepMounted"];
@@ -94,7 +104,7 @@ type LegacyTooltipPopupProps = Omit<
 
 export type TooltipBaseProps<T extends TgphElement = "div"> = {
   children?: ReactNode;
-  label: ReactNode;
+  label?: ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
   asChild?: boolean;
@@ -103,7 +113,7 @@ export type TooltipBaseProps<T extends TgphElement = "div"> = {
   disableFocusOpen?: boolean;
   skipAnimation?: boolean;
   style?: TgphComponentProps<typeof Stack<T>>["style"];
-  triggerRef?: RefObject<HTMLButtonElement>;
+  triggerRef?: RefObject<HTMLElement | null>;
 };
 
 export type TooltipProps<T extends TgphElement = "div"> =
@@ -212,6 +222,8 @@ const Tooltip = <T extends TgphElement = "div">({
     [existingAriaDescribedBy, resolvedOpen ? tooltipId : undefined]
       .filter(Boolean)
       .join(" ") || undefined;
+  const resolvedTriggerRef =
+    triggerRef as BaseTooltipTriggerPropsWithRef["ref"];
 
   const handleOpenChange = useCallback<
     NonNullable<BaseTooltipRootProps["onOpenChange"]>
@@ -278,7 +290,7 @@ const Tooltip = <T extends TgphElement = "div">({
               data-state={triggerDataState}
               delay={derivedDelayDuration}
               onFocus={handleFocus}
-              ref={triggerRef}
+              ref={resolvedTriggerRef}
               render={createTgphBaseUIRender(
                 cloneElement(children, {
                   "aria-describedby": triggerAriaDescribedBy,
@@ -292,7 +304,7 @@ const Tooltip = <T extends TgphElement = "div">({
               data-state={triggerDataState}
               delay={derivedDelayDuration}
               onFocus={handleFocus}
-              ref={triggerRef}
+              ref={resolvedTriggerRef}
             >
               {children}
             </BaseTooltip.Trigger>

--- a/packages/tooltip/vitest.config.mts
+++ b/packages/tooltip/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "tooltip",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/truncate/README.md
+++ b/packages/truncate/README.md
@@ -72,13 +72,13 @@ A text component that automatically truncates content with an ellipsis and shows
 
 A component that conditionally shows a tooltip only when its content is truncated.
 
-| Prop              | Type                                 | Default     | Description                                                                   |
-| ----------------- | ------------------------------------ | ----------- | ----------------------------------------------------------------------------- |
-| `label`           | `string \| ReactNode`                | `undefined` | The text to show in the tooltip. If not provided, will use the content's text |
-| `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                               |
-| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                     |
+| Prop              | Type                                 | Default     | Description                                                                                |
+| ----------------- | ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
+| `label`           | `string \| ReactNode`                | `undefined` | The text to show in the tooltip. When provided, it takes precedence over the child content |
+| `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                                            |
+| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                                  |
 
-`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It continues to pass tooltip props through unchanged and only enables the tooltip when `useTruncate` detects overflow.
+`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It measures the wrapped child with `useTruncate`, passes that same element ref to Tooltip as the trigger, and only enables the tooltip when overflow is detected. Tooltip props continue to pass through unchanged, including focus and hover behavior such as `disableFocusOpen`.
 
 ### `useTruncate`
 

--- a/packages/truncate/README.md
+++ b/packages/truncate/README.md
@@ -62,11 +62,11 @@ const CustomTruncatedComponent = () => {
 
 A text component that automatically truncates content with an ellipsis and shows a tooltip when truncated.
 
-| Prop           | Type                               | Default     | Description                                                     |
-| -------------- | ---------------------------------- | ----------- | --------------------------------------------------------------- |
-| `maxWidth`     | `string`                           | `undefined` | Maximum width of the text container                             |
-| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>` | `undefined` | Props to pass to the underlying TooltipIfTruncated component |
-| `...TextProps` | `TgphComponentProps<typeof Text>`  | -           | All props from [@telegraph/typography](../typography/README.md) |
+| Prop           | Type                                                     | Default     | Description                                                     |
+| -------------- | -------------------------------------------------------- | ----------- | --------------------------------------------------------------- |
+| `maxWidth`     | `string`                                                 | `undefined` | Maximum width of the text container                             |
+| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>` | `undefined` | Props to pass to the underlying TooltipIfTruncated component    |
+| `...TextProps` | `TgphComponentProps<typeof Text>`                        | -           | All props from [@telegraph/typography](../typography/README.md) |
 
 ### `<TooltipIfTruncated>`
 
@@ -78,16 +78,18 @@ A component that conditionally shows a tooltip only when its content is truncate
 | `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                               |
 | `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                     |
 
+`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It continues to pass tooltip props through unchanged and only enables the tooltip when `useTruncate` detects overflow.
+
 ### `useTruncate`
 
 A hook that detects whether an element's content is truncated.
 
 #### Parameters
 
-| Name     | Type                                        | Description                                                           |
-| -------- | ------------------------------------------- | --------------------------------------------------------------------- |
+| Name     | Type                                                | Description                                                           |
+| -------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `params` | `{ tgphRef: React.RefObject<HTMLElement \| null> }` | A ref to the element to check for truncation                          |
-| `deps`   | `React.DependencyList`                      | Optional dependencies to re-run the truncation check when they change |
+| `deps`   | `React.DependencyList`                              | Optional dependencies to re-run the truncation check when they change |
 
 #### Returns
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -1,0 +1,84 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipIfTruncated } from "./TooltipIfTruncated";
+
+type TestTriggerProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const TestTrigger = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestTriggerProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get() {
+      return Number(this.getAttribute("data-scroll-width") ?? 0);
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return Number(this.getAttribute("data-client-width") ?? 0);
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("TooltipIfTruncated", () => {
+  it("shows the tooltip when the child is truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Long value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Long value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Long value");
+  });
+
+  it("keeps the tooltip disabled when the child is not truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="80" data-client-width="100">
+          Short value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Short value" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -64,6 +64,88 @@ describe("TooltipIfTruncated", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Long value");
   });
 
+  it("uses the explicit label when provided", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated
+        delayDuration={0}
+        label="Explicit tooltip label"
+        skipAnimation
+      >
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Visible value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Visible value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Explicit tooltip label",
+    );
+  });
+
+  it("uses React element child content as the tooltip label", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          <span>Element value</span>
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Element value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Element value",
+    );
+  });
+
+  it("opens from focus when truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Focus value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "Focus value" })).toHaveFocus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Focus value");
+  });
+
+  it("can suppress focus-triggered open while preserving hover", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} disableFocusOpen skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Hover only
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover only" });
+
+    await user.tab();
+
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    await user.hover(trigger);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Hover only");
+  });
+
   it("keeps the tooltip disabled when the child is not truncated", async () => {
     const user = userEvent.setup();
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -5,7 +5,7 @@ import {
 } from "@telegraph/helpers";
 import { Tooltip } from "@telegraph/tooltip";
 import { Text } from "@telegraph/typography";
-import React from "react";
+import { type ReactNode, type RefObject, isValidElement, useRef } from "react";
 
 import { useTruncate } from "../useTruncate";
 
@@ -19,31 +19,30 @@ const TooltipIfTruncated = ({
   children,
   ...props
 }: TooltipIfTruncatedProps) => {
-  const truncateRef = React.useRef<HTMLButtonElement>(null);
+  const truncateRef = useRef<HTMLButtonElement>(null);
   const { truncated } = useTruncate(
-    { tgphRef: truncateRef as React.RefObject<HTMLElement> },
+    { tgphRef: truncateRef as RefObject<HTMLElement> },
     [children],
   );
 
-  // We extract the text so that we can properly wrap it in the Text component
-  const textToDisplayInTooltip = React.useMemo(() => {
+  const textToDisplayInTooltip = (() => {
     if (typeof children === "string") return children;
-    if (React.isValidElement(children)) {
+    if (isValidElement(children)) {
       const childProps = children.props as Record<string, unknown>;
       return childProps.children;
     }
     return label;
-  }, [children, label]);
+  })();
 
   return (
     <Tooltip
       label={
         <Text as="span" size="1">
-          {textToDisplayInTooltip as React.ReactNode}
+          {textToDisplayInTooltip as ReactNode}
         </Text>
       }
       enabled={truncated}
-      triggerRef={truncateRef as React.RefObject<HTMLButtonElement>}
+      triggerRef={truncateRef as RefObject<HTMLButtonElement>}
       {...props}
     >
       <RefToTgphRef>{children}</RefToTgphRef>

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -5,7 +5,7 @@ import {
 } from "@telegraph/helpers";
 import { Tooltip } from "@telegraph/tooltip";
 import { Text } from "@telegraph/typography";
-import { type ReactNode, type RefObject, isValidElement, useRef } from "react";
+import { type ReactNode, isValidElement, useRef } from "react";
 
 import { useTruncate } from "../useTruncate";
 
@@ -19,19 +19,16 @@ const TooltipIfTruncated = ({
   children,
   ...props
 }: TooltipIfTruncatedProps) => {
-  const truncateRef = useRef<HTMLButtonElement>(null);
-  const { truncated } = useTruncate(
-    { tgphRef: truncateRef as RefObject<HTMLElement> },
-    [children],
-  );
+  const truncateRef = useRef<HTMLElement>(null);
+  const { truncated } = useTruncate({ tgphRef: truncateRef }, [children]);
 
   const textToDisplayInTooltip = (() => {
+    if (label !== undefined) return label;
     if (typeof children === "string") return children;
     if (isValidElement(children)) {
       const childProps = children.props as Record<string, unknown>;
       return childProps.children;
     }
-    return label;
   })();
 
   return (
@@ -42,7 +39,7 @@ const TooltipIfTruncated = ({
         </Text>
       }
       enabled={truncated}
-      triggerRef={truncateRef as RefObject<HTMLButtonElement>}
+      triggerRef={truncateRef}
       {...props}
     >
       <RefToTgphRef>{children}</RefToTgphRef>

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -46,6 +46,7 @@ This configuration provides optimized Vite settings specifically tailored for Te
 - **TypeScript Support**: Proper TypeScript configuration and path resolution
 - **Asset Handling**: Optimized asset processing and public path configuration
 - **Plugin Integration**: Pre-configured plugins for Telegraph development
+- **Dependency Externalization**: Package dependencies, peer dependencies, dev dependencies, and their subpath imports stay external in library builds
 
 ## API Reference
 

--- a/packages/vite-config/src/vite-config.ts
+++ b/packages/vite-config/src/vite-config.ts
@@ -32,6 +32,18 @@ const nodeBuiltins = [
   ...builtinModules.map((name) => `node:${name}`),
 ];
 
+const isPackageImport = (id: string, packageName: string) => {
+  return id === packageName || id.startsWith(`${packageName}/`);
+};
+
+const isExternalDependency = (id: string) => {
+  return allDependencies.some((dependency) => isPackageImport(id, dependency));
+};
+
+const isNodeBuiltin = (id: string) => {
+  return nodeBuiltins.some((builtin) => isPackageImport(id, builtin));
+};
+
 const buildTimeInfo = {
   format: "es",
 };
@@ -59,7 +71,9 @@ export default {
       },
     },
     rolldownOptions: {
-      external: [...allDependencies, ...nodeBuiltins],
+      external: (id: string) => {
+        return isExternalDependency(id) || isNodeBuiltin(id);
+      },
       output: {
         assetFileNames: (assetInfo: Rollup.PreRenderedAsset) => {
           if (assetInfo?.name?.endsWith(".css")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,36 +3551,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tooltip@npm:^1.2.8":
-  version: 1.2.8
-  resolution: "@radix-ui/react-tooltip@npm:1.2.8"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/de0cbae9c571a00671f160928d819e59502f59be8749f536ab4b180181d9d70aee3925a5b2555f8f32d0bea622bc35f65b70ca7ff0449e4844f891302310cc48
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-use-callback-ref@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
@@ -3680,25 +3650,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/851d09a816f44282e0e9e2147b1b571410174cc048703a50c4fa54d672de994fd1dfff1da9d480ecfd12c77ae8f48d74f01adaf668f074156b8cd0043c6c21d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-visually-hidden@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.3"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/cf86a37f1cbee50a964056f3dc4f6bb1ee79c76daa321f913aa20ff3e1ccdfafbf2b114d7bb616aeefc7c4b895e6ca898523fdb67710d89bd5d8edb739a0d9b6
   languageName: node
   linkType: hard
 
@@ -4913,10 +4864,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/tooltip@workspace:packages/tooltip"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-tooltip": "npm:^1.2.8"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
     "@telegraph/appearance": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,34 +3481,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-radio-group@npm:^1.3.8":
-  version: 1.3.8
-  resolution: "@radix-ui/react-radio-group@npm:1.3.8"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    "@radix-ui/react-use-previous": "npm:1.1.1"
-    "@radix-ui/react-use-size": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/23af8e8b833da1fc4aa4e67c3607dedee4fc5b39278d2e2b820bec7f7b3c0891b006a8a35c57ba436ddf18735bbd8dad9a598d14632a328753a875fde447975c
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-roving-focus@npm:1.1.11":
   version: 1.1.11
   resolution: "@radix-ui/react-roving-focus@npm:1.1.11"
@@ -3711,19 +3683,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-previous@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-previous@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/52f1089d941491cd59b7f52a5679a14e9381711419a0557ce0f3bc9a4c117078224efec54dcced41a3653a13a386a7b6ec75435d61a273e8b9f5d00235f2b182
   languageName: node
   linkType: hard
 
@@ -4733,10 +4692,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/radio@workspace:packages/radio"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-radio-group": "npm:^1.3.8"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,52 +3505,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toggle-group@npm:^1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-toggle-group@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-toggle": "npm:1.1.10"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c8cbccda3e25754ed9f3145c67792df2d5d0ee1a910bde6dc07c4577ab508d4b939f145569d4e2af5b17dc4a5c701473380d8695248f8620cf0a372c05b8e958
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-toggle@npm:1.1.10":
-  version: 1.1.10
-  resolution: "@radix-ui/react-toggle@npm:1.1.10"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/5406cdf5dd7299ae6cfdb4865dc5fd43ca3c475ebcd4e86830bd296d734255b61f749c9bde452ebfaad126033f92dd1112ee9d95982344ffad34491238dcc9b1
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-use-callback-ref@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
@@ -4636,10 +4590,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/segmented-control@workspace:packages/segmented-control"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-toggle-group": "npm:^1.1.11"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,6 +581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.29.2":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.22.15":
   version: 7.24.0
   resolution: "@babel/template@npm:7.24.0"
@@ -740,6 +747,51 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@base-ui/react@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "@base-ui/react@npm:1.5.0"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@base-ui/utils": "npm:0.2.9"
+    "@floating-ui/react-dom": "npm:^2.1.8"
+    "@floating-ui/utils": "npm:^0.2.11"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@date-fns/tz": ^1.2.0
+    "@types/react": ^17 || ^18 || ^19
+    date-fns: ^4.0.0
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@date-fns/tz":
+      optional: true
+    "@types/react":
+      optional: true
+    date-fns:
+      optional: true
+  checksum: 10c0/ba0f00149d7500d39e0e790b4b6cf19c002f4281508b6076ed1e367ca9a4946eb345e98d4c0dd0ab8e1613807bdcac9d9ad07f6c6d19c3b243a022bb30cbb61b
+  languageName: node
+  linkType: hard
+
+"@base-ui/utils@npm:0.2.9":
+  version: 0.2.9
+  resolution: "@base-ui/utils@npm:0.2.9"
+  dependencies:
+    "@babel/runtime": "npm:^7.29.2"
+    "@floating-ui/utils": "npm:^0.2.11"
+    reselect: "npm:^5.1.1"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    "@types/react": ^17 || ^18 || ^19
+    react: ^17 || ^18 || ^19
+    react-dom: ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10c0/169a67fb6a4d86d3ce9fb12bc1e8cb02a67ad3d16872c81798cd6a532c9277383c4066c88356a9813499a87b93b4bf255ea035ea3c6f7298c52adeb1e8e846ce
   languageName: node
   linkType: hard
 
@@ -1750,6 +1802,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.7.5":
+  version: 1.7.5
+  resolution: "@floating-ui/core@npm:1.7.5"
+  dependencies:
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^1.6.1":
   version: 1.6.3
   resolution: "@floating-ui/dom@npm:1.6.3"
@@ -1757,6 +1818,16 @@ __metadata:
     "@floating-ui/core": "npm:^1.0.0"
     "@floating-ui/utils": "npm:^0.2.0"
   checksum: 10c0/d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:^1.7.6":
+  version: 1.7.6
+  resolution: "@floating-ui/dom@npm:1.7.6"
+  dependencies:
+    "@floating-ui/core": "npm:^1.7.5"
+    "@floating-ui/utils": "npm:^0.2.11"
+  checksum: 10c0/5c098e0d7b58c9bc769f276cca1766994c2c9c70c92d091a61bba8b3e9be53c011e0a79a8457fc2fb2f3d91697a26eb52e0a4962ef936dc963b45f58613c212f
   languageName: node
   linkType: hard
 
@@ -1772,10 +1843,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/react-dom@npm:^2.1.8":
+  version: 2.1.8
+  resolution: "@floating-ui/react-dom@npm:2.1.8"
+  dependencies:
+    "@floating-ui/dom": "npm:^1.7.6"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
+  languageName: node
+  linkType: hard
+
 "@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
   version: 0.2.1
   resolution: "@floating-ui/utils@npm:0.2.1"
   checksum: 10c0/ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
+  languageName: node
+  linkType: hard
+
+"@floating-ui/utils@npm:^0.2.11":
+  version: 0.2.11
+  resolution: "@floating-ui/utils@npm:0.2.11"
+  checksum: 10c0/f4bcea1559bdbb721ecc8e8ead423ac58d6a5b6e70b602cf0810ba6ad4ed1c77211b207faa88b278a9042f0c743133de08a203ed6741c1b6443423332884d5b3
   languageName: node
   linkType: hard
 
@@ -4386,6 +4476,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/helpers@workspace:packages/helpers"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@telegraph/prettier-config": "workspace:^"
@@ -12490,6 +12581,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"reselect@npm:^5.1.1":
+  version: 5.2.0
+  resolution: "reselect@npm:5.2.0"
+  checksum: 10c0/d0a8497e404b25a769fe792eacae88b9b576c30870450cd243d76ec9427d91a59c4a2cc00d824d283448b444c4c698a8f961d771c8ae39c759313afb31950e2e
+  languageName: node
+  linkType: hard
+
 "resolve-from@npm:^4.0.0":
   version: 4.0.0
   resolution: "resolve-from@npm:4.0.0"
@@ -14455,7 +14553,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"use-sync-external-store@npm:^1.5.0":
+"use-sync-external-store@npm:^1.5.0, use-sync-external-store@npm:^1.6.0":
   version: 1.6.0
   resolution: "use-sync-external-store@npm:1.6.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -4773,8 +4773,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slot@npm:1.2.4, @radix-ui/react-slot@npm:^1.2.4":
+"@radix-ui/react-slot@npm:1.2.4":
   version: 1.2.4
   resolution: "@radix-ui/react-slot@npm:1.2.4"
   dependencies:
@@ -4316,7 +4316,7 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-slot": "npm:^1.2.4"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
@@ -4524,7 +4524,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-slot": "npm:^1.2.4"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,38 +3148,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "@radix-ui/react-dialog@npm:1.1.15"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/2f2c88e3c281acaea2fd9b96fa82132d59177d3aa5da2e7c045596fd4028e84e44ac52ac28f4f236910605dd7d9338c2858ba44a9ced2af2e3e523abbfd33014
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-direction@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-direction@npm:1.1.1"
@@ -3247,27 +3215,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.8"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.4"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/ce316ffa868ca618a581e0154ca3385c2726d73632a9b32f2fa61d8fa611c1331685b1de44de3605822785bc3e79a612399177e0e78b4923bf35b0203f5b3167
   languageName: node
   linkType: hard
 
@@ -4461,14 +4408,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/modal@workspace:packages/modal"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-dialog": "npm:^1.1.15"
-    "@radix-ui/react-focus-scope": "npm:^1.1.8"
-    "@radix-ui/react-portal": "npm:^1.1.10"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,39 +3322,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-popover@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "@radix-ui/react-popover@npm:1.1.15"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c1c76b5e5985b128d03b621424fb453f769931d497759a1977734d303007da9f970570cf3ea1f6968ab609ab4a97f384168bff056197bd2d3d422abea0e3614b
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-popper@npm:1.2.8":
   version: 1.2.8
   resolution: "@radix-ui/react-popper@npm:1.2.8"
@@ -4636,10 +4603,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/popover@workspace:packages/popover"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-popover": "npm:^1.1.15"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,32 +3566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tabs@npm:^1.1.13":
-  version: 1.1.13
-  resolution: "@radix-ui/react-tabs@npm:1.1.13"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/a3c78cd8c30dcb95faf1605a8424a1a71dab121dfa6e9c0019bb30d0f36d882762c925b17596d4977990005a255d8ddc0b7454e4f83337fe557b45570a2d8058
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-toggle-group@npm:^1.1.11":
   version: 1.1.11
   resolution: "@radix-ui/react-toggle-group@npm:1.1.11"
@@ -4883,9 +4857,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/tabs@workspace:packages/tabs"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-tabs": "npm:^1.1.13"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,31 +1793,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
-  dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 10c0/667a68036f7dd5ed19442c7792a6002ca02d1799221c4396691bbe0b6008b48f6ccad581225e81fa266bb91232f6c66838a5f825f554217e1ec886178b93381b
-  languageName: node
-  linkType: hard
-
 "@floating-ui/core@npm:^1.7.5":
   version: 1.7.5
   resolution: "@floating-ui/core@npm:1.7.5"
   dependencies:
     "@floating-ui/utils": "npm:^0.2.11"
   checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
-  languageName: node
-  linkType: hard
-
-"@floating-ui/dom@npm:^1.6.1":
-  version: 1.6.3
-  resolution: "@floating-ui/dom@npm:1.6.3"
-  dependencies:
-    "@floating-ui/core": "npm:^1.0.0"
-    "@floating-ui/utils": "npm:^0.2.0"
-  checksum: 10c0/d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
   languageName: node
   linkType: hard
 
@@ -1831,18 +1812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^2.0.0":
-  version: 2.0.8
-  resolution: "@floating-ui/react-dom@npm:2.0.8"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-  peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-  checksum: 10c0/4d87451e2dcc54b4753a0d81181036e47821cfd0d4c23f7e9c31590c7c91fb15fb0a5a458969a5ddabd61601eca5875ebd4e40bff37cee31f373b8f1ccc64518
-  languageName: node
-  linkType: hard
-
 "@floating-ui/react-dom@npm:^2.1.8":
   version: 2.1.8
   resolution: "@floating-ui/react-dom@npm:2.1.8"
@@ -1852,13 +1821,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
-  languageName: node
-  linkType: hard
-
-"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: 10c0/ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
   languageName: node
   linkType: hard
 
@@ -3074,512 +3036,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/primitive@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/primitive@npm:1.1.3"
-  checksum: 10c0/88860165ee7066fa2c179f32ffcd3ee6d527d9dcdc0e8be85e9cb0e2c84834be8e3c1a976c74ba44b193f709544e12f54455d892b28e32f0708d89deda6b9f1d
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-arrow@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-arrow@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c3b46766238b3ee2a394d8806a5141432361bf1425110c9f0dcf480bda4ebd304453a53f294b5399c6ee3ccfcae6fd544921fd01ddc379cf5942acdd7168664b
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-collection@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-collection@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/fa321a7300095508491f75414f02b243f0c3f179dc0728cfd115e2ea9f6f48f1516532b59f526d9ac81bbab63cd98a052074b4703ec0b9428fac945ebabec5fd
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-compose-refs@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/d36a9c589eb75d634b9b139c80f916aadaf8a68a7c1c4b8c6c6b88755af1a92f2e343457042089f04cc3f23073619d08bb65419ced1402e9d4e299576d970771
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-context@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@radix-ui/react-context@npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/cece731f8cc25d494c6589cc681e5c01a93867d895c75889973afa1a255f163c286e390baa7bc028858eaabe9f6b57270d0ca6377356f652c5557c1c7a41ccce
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-direction@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-direction@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/7a89d9291f846a3105e45f4df98d6b7a08f8d7b30acdcd253005dc9db107ee83cbbebc9e47a9af1e400bcd47697f1511ceab23a399b0da854488fc7220482ac9
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-dismissable-layer@npm:1.1.11, @radix-ui/react-dismissable-layer@npm:^1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c825572a64073c4d3853702029979f6658770ffd6a98eabc4984e1dee1b226b4078a2a4dc7003f96475b438985e9b21a58e75f51db74dd06848dcae1f2d395dc
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-guards@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/0bab65eb8d7e4f72f685d63de7fbba2450e3cb15ad6a20a16b42195e9d335c576356f5a47cb58d1ffc115393e46d7b14b12c5d4b10029b0ec090861255866985
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-id@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-id@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/7d12e76818763d592c331277ef62b197e2e64945307e650bd058f0090e5ae48bbd07691b23b7e9e977901ef4eadcb3e2d5eaeb17a13859083384be83fc1292c7
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-menu@npm:^2.1.16":
-  version: 2.1.16
-  resolution: "@radix-ui/react-menu@npm:2.1.16"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-collection": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/27516b2b987fa9181c4da8645000af8f60691866a349d7a46b9505fa7d2e9d92b9e364db4f7305d08e9e57d0e1afc8df8354f8ee3c12aa05c0100c16b0e76c27
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-popper@npm:1.2.8":
-  version: 1.2.8
-  resolution: "@radix-ui/react-popper@npm:1.2.8"
-  dependencies:
-    "@floating-ui/react-dom": "npm:^2.0.0"
-    "@radix-ui/react-arrow": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-    "@radix-ui/react-use-rect": "npm:1.1.1"
-    "@radix-ui/react-use-size": "npm:1.1.1"
-    "@radix-ui/rect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/48e3f13eac3b8c13aca8ded37d74db17e1bb294da8d69f142ab6b8719a06c3f90051668bed64520bf9f3abdd77b382ce7ce209d056bb56137cecc949b69b421c
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-portal@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-portal@npm:1.1.9"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/45b432497c722720c72c493a29ef6085bc84b50eafe79d48b45c553121b63e94f9cdb77a3a74b9c49126f8feb3feee009fe400d48b7759d3552396356b192cd7
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-portal@npm:^1.1.10":
-  version: 1.1.10
-  resolution: "@radix-ui/react-portal@npm:1.1.10"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.4"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c8f77e2c9413f654f5232045888898eaac88d8d0515714c8ecdc25eea0dc20667639a1ead1528bfbb591ac9ae599de006879859ccb4c2b5c088b49f1af3a9c1a
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-presence@npm:1.1.5":
-  version: 1.1.5
-  resolution: "@radix-ui/react-presence@npm:1.1.5"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/d0e61d314250eeaef5369983cb790701d667f51734bafd98cf759072755562018052c594e6cdc5389789f4543cb0a4d98f03ff4e8f37338d6b5bf51a1700c1d1
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-primitive@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@radix-ui/react-primitive@npm:2.1.3"
-  dependencies:
-    "@radix-ui/react-slot": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-primitive@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@radix-ui/react-primitive@npm:2.1.4"
-  dependencies:
-    "@radix-ui/react-slot": "npm:1.2.4"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/90d687b222a25975371ed1f9f08648d75237214b8dec4cbaf09ec9ac951339b17421278f1aff2fb7c5672ba8bd03774a94904efdba73805dd5cc947ce5be8c4a
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-roving-focus@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-roving-focus@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-collection": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/2cd43339c36e89a3bf1db8aab34b939113dfbde56bf3a33df2d74757c78c9489b847b1962f1e2441c67e41817d120cb6177943e0f655f47bc1ff8e44fd55b1a2
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-slot@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@radix-ui/react-slot@npm:1.2.3"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-slot@npm:1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-slot@npm:1.2.4"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/8b719bb934f1ae5ac0e37214783085c17c2f1080217caf514c1c6cc3d9ca56c7e19d25470b26da79aa6e605ab36589edaade149b76f5fc0666f1063e2fc0a0dc
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-callback-ref@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/5f6aff8592dea6a7e46589808912aba3fb3b626cf6edd2b14f01638b61dbbe49eeb9f67cd5601f4c15b2fb547b9a7e825f7c4961acd4dd70176c969ae405f8d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-controllable-state@npm:1.2.2, @radix-ui/react-use-controllable-state@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
-  dependencies:
-    "@radix-ui/react-use-effect-event": "npm:0.0.2"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f55c4b06e895293aed4b44c9ef26fb24432539f5346fcd6519c7745800535b571058685314e83486a45bf61dc83887e24826490d3068acc317fb0a9010516e63
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-effect-event@npm:0.0.2":
-  version: 0.0.2
-  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/e84ff72a3e76c5ae9c94941028bb4b6472f17d4104481b9eab773deab3da640ecea035e54da9d6f4df8d84c18ef6913baf92b7511bee06930dc58bd0c0add417
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-escape-keydown@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/bff53be99e940fef1d3c4df7d560e1d9133182e5a98336255d3063327d1d3dd4ec54a95dc5afe15cca4fb6c184f0a956c70de2815578c318cf995a7f9beabaa1
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-layout-effect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-rect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-rect@npm:1.1.1"
-  dependencies:
-    "@radix-ui/rect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/271711404c05c589c8dbdaa748749e7daf44bcc6bffc9ecd910821c3ebca0ee245616cf5b39653ce690f53f875c3836fd3f36f51ab1c628273b6db599eee4864
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-size@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-size@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/851d09a816f44282e0e9e2147b1b571410174cc048703a50c4fa54d672de994fd1dfff1da9d480ecfd12c77ae8f48d74f01adaf668f074156b8cd0043c6c21d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-visually-hidden@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.4"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.4"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/cca313cd3268f483612da1ab91c4cca55a54d24963dd543154f2d043bfdca21a96ab0582152ae473de44769474867d5433dbadae799a42932e6204fd2d5fa889
-  languageName: node
-  linkType: hard
-
-"@radix-ui/rect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/rect@npm:1.1.1"
-  checksum: 10c0/0dac4f0f15691199abe6a0e067821ddd9d0349c0c05f39834e4eafc8403caf724106884035ae91bbc826e10367e6a5672e7bec4d4243860fa7649de246b1f60b
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.15"
@@ -4118,11 +3574,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-dismissable-layer": "npm:^1.1.11"
-    "@radix-ui/react-menu": "npm:^2.1.16"
-    "@radix-ui/react-portal": "npm:^1.1.10"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
@@ -6235,15 +5686,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-hidden@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "aria-hidden@npm:1.2.4"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  checksum: 10c0/8abcab2e1432efc4db415e97cb3959649ddf52c8fc815d7384f43f3d3abf56f1c12852575d00df9a8927f421d7e0712652dd5f8db244ea57634344e29ecfc74a
-  languageName: node
-  linkType: hard
-
 "aria-query@npm:5.3.0, aria-query@npm:^5.0.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -7376,13 +6818,6 @@ __metadata:
   version: 4.0.1
   resolution: "detect-newline@npm:4.0.1"
   checksum: 10c0/1cc1082e88ad477f30703ae9f23bd3e33816ea2db6a35333057e087d72d466f5a777809b71f560118ecff935d2c712f5b59e1008a8b56a900909d8fd4621c603
-  languageName: node
-  linkType: hard
-
-"detect-node-es@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "detect-node-es@npm:1.1.0"
-  checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
   languageName: node
   linkType: hard
 
@@ -8939,13 +8374,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
-  languageName: node
-  linkType: hard
-
-"get-nonce@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "get-nonce@npm:1.0.1"
-  checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
   languageName: node
   linkType: hard
 
@@ -12102,57 +11530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-remove-scroll-bar@npm:^2.3.7":
-  version: 2.3.8
-  resolution: "react-remove-scroll-bar@npm:2.3.8"
-  dependencies:
-    react-style-singleton: "npm:^2.2.2"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/9a0675c66cbb52c325bdbfaed80987a829c4504cefd8ff2dd3b6b3afc9a1500b8ec57b212e92c1fb654396d07bbe18830a8146fe77677d2a29ce40b5e1f78654
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll@npm:^2.6.3":
-  version: 2.6.3
-  resolution: "react-remove-scroll@npm:2.6.3"
-  dependencies:
-    react-remove-scroll-bar: "npm:^2.3.7"
-    react-style-singleton: "npm:^2.2.3"
-    tslib: "npm:^2.1.0"
-    use-callback-ref: "npm:^1.3.3"
-    use-sidecar: "npm:^1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/068e9704ff26816fffc4c8903e2c6c8df7291ee08615d7c1ab0cf8751f7080e2c5a5d78ef5d908b11b9cfc189f176d312e44cb02ea291ca0466d8283b479b438
-  languageName: node
-  linkType: hard
-
-"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "react-style-singleton@npm:2.2.3"
-  dependencies:
-    get-nonce: "npm:^1.0.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/841938ff16d16a6b76895f4cb2e1fea957e5fe3b30febbf03a54892dae1c9153f2383e231dea0b3ba41192ad2f2849448fa859caccd288943bce32639e971bee
-  languageName: node
-  linkType: hard
-
 "react@npm:^19.2.6":
   version: 19.2.6
   resolution: "react@npm:19.2.6"
@@ -13776,7 +13153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.1, tslib@npm:^2.4.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
@@ -14266,37 +13643,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"use-callback-ref@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "use-callback-ref@npm:1.3.3"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f887488c6e6075cdad4962979da1714b217bcb1ee009a9e57ce9a844bcfc4c3a99e93983dfc2e5af9e0913824d24e730090ff255e902c516dcb58d2d3837e01c
-  languageName: node
-  linkType: hard
-
-"use-sidecar@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "use-sidecar@npm:1.1.3"
-  dependencies:
-    detect-node-es: "npm:^1.1.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/161599bf921cfaa41c85d2b01c871975ee99260f3e874c2d41c05890d41170297bdcf314bc5185e7a700de2034ac5b888e3efc8e9f35724f4918f53538d717c9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4478,11 +4478,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/menu@workspace:packages/menu"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-menu": "npm:^2.1.16"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## Summary

- Migrates the published Telegraph primitives that were still backed by Radix onto Base UI or Telegraph-owned compatibility helpers.
- Preserves the existing public component APIs, visual output, `tgphRef` support, and React 18 consumer compatibility.
- Adds the shared compatibility layer that keeps Base UI render/ref behavior behind Telegraph's existing component contracts.
- Updates affected package READMEs, adds changesets, and expands tests around the high-risk compatibility paths.

## What changed

- Added the shared Base UI foundation in `@telegraph/helpers`, including `createTgphBaseUIRender`, Base UI compatibility helpers, `TgphSlot`, `VisuallyHidden`, `useControllableState`, and ref composition coverage.
- Reworked `RefToTgphRef`/slot behavior so migrated primitives keep accepting `tgphRef`, `as`, `asChild`, render props, and legacy ref patterns.
- Migrated Tabs, RadioCards, Popover, Tooltip, Menu, SegmentedControl, Modal, and Combobox behavior onto Base UI primitives while retaining Telegraph styling and public props.
- Removed remaining Radix utility dependencies from Toggle and Appearance paths by moving the needed compatibility behavior into Telegraph-owned helpers.
- Added regression coverage for Select after the Combobox migration, including portal, keyboard, and axe paths.
- Preserved consumer compatibility found during downstream validation:
  - `Button` accepts inferred click handlers whose return types are wider than `void`.
  - `TextArea` continues accepting `as="textarea"`.
  - `Box` supports `direction` and raw size values such as `maxH="400px"`.
  - style-engine raw size passthrough still maps token values to Telegraph CSS variables.
- Exported token map wrappers so ESM/CJS consumers can import token maps without JSON import-attribute failures.
- Updated READMEs for affected packages and added patch changesets for all migrated/validated packages.

```mermaid
flowchart TD
  api["Telegraph public component API"] --> compat["Telegraph compatibility helpers"]
  compat --> refs["tgphRef + composed refs"]
  compat --> slot["TgphSlot / asChild support"]
  compat --> render["createTgphBaseUIRender"]
  render --> baseui["Base UI primitives"]
  baseui --> styles["Telegraph CSS + style-engine props"]
  styles --> consumers["Storybook, Control, JavaScript SDK, and Docs consumers"]
```

## Component migration map

| Package | Previous backing | New backing | Notes |
| --- | --- | --- | --- |
| `@telegraph/helpers` | Radix Slot/ref assumptions | Telegraph compatibility layer + Base UI bridge | Centralizes `tgphRef`, render, slot, and visually hidden behavior. |
| `@telegraph/appearance` | Radix Slot dependency | Telegraph `TgphSlot` | Keeps appearance provider behavior stable. |
| `@telegraph/tabs` | Radix Tabs | Base UI Tabs | Preserves selected state, value changes, refs, and existing styles. |
| `@telegraph/radio` | Radix Radio Group | Base UI Radio Group | Preserves RadioCards API and compatibility edge cases. |
| `@telegraph/popover` | Radix Popover | Base UI Popover | Preserves placement, close animations, dismiss behavior, and styles. |
| `@telegraph/tooltip` | Radix Tooltip | Base UI Tooltip | Preserves legacy passthrough props and TooltipIfTruncated behavior. |
| `@telegraph/menu` | Radix Dropdown Menu | Base UI Menu | Preserves nested items, keyboard behavior, submenu behavior, and MenuItem API. |
| `@telegraph/segmented-control` | Radix Toggle Group | Base UI Toggle Group | Preserves selection behavior and focus looping expectations. |
| `@telegraph/toggle` | Radix state helpers | Telegraph state/helpers | Removes Radix utility dependency while keeping toggle state semantics. |
| `@telegraph/modal` | Radix Dialog | Base UI Dialog | Preserves stacking, dismiss behavior, focus management, and modal API. |
| `@telegraph/combobox` | Radix/cmdk-style behavior | Base UI Combobox | Rewrites option/value handling around Base UI while preserving labels and selection behavior. |
| `@telegraph/select` | Existing public Select behavior | Regression coverage over migrated dependencies | Verifies Select still works after Combobox/Base UI changes. |
| `@telegraph/truncate` | Tooltip-backed truncation | Migrated Tooltip-backed truncation | Documents label precedence and verifies truncation tooltips. |

## Why

- The Base UI migration goal is to fully remove Radix from Telegraph's published component surface without forcing downstream apps to rewrite existing usage.
- Base UI has different render/ref/event contracts than Radix, so the shared helper layer keeps those differences contained instead of leaking them into every package.

## Compatibility notes

- Existing `tgphRef` usage should continue to work on migrated components.
- React 18 consumers remain supported; the migration avoids React 19-only ref patterns.
- Public prop names and styling hooks are kept backward compatible unless the previous behavior depended on unpublished internals.
- `@telegraph/filter` is intentionally out of scope because it is not published.

## Validation

- Ran focused package tests across helpers, tabs, radio, popover, tooltip, menu, segmented-control, modal, combobox, select, truncate, button, layout, textarea, and style-engine changes.
- Ran changed package lint/build checks and `yarn build:packages` against the full folded stack.
- Ran Storybook visual and functional comparisons against the pre-migration published Storybook for migrated components.
- Validated downstream consumers with packed local Telegraph packages:
  - Control app worktree checks and browser smoke testing.
  - JavaScript SDK/examples package build, type-check, lint, test, integration test, and Next example builds.
  - Docs site type-check, lint, production build, and in-app browser smoke testing across API pages, feedback, search, Ask AI, tabs, SDK select, and mobile sidebar paths.
- CI and BugBot were green across the approved stack before folding. This PR will rerun CI against the folded branch.

## Folded PRs

- Folded into this PR: #838, #839, #840, #841, #842, #843, #844, #845, #846, #847, #848, and #849.
