### PR TITLE
refactor(base-ui): add compatibility primitives

### DIFF
--- a/.changeset/silver-slots-merge.md
+++ b/.changeset/silver-slots-merge.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/appearance": patch
+"@telegraph/helpers": minor
+"@telegraph/input": patch
+---
+
+Replace Radix Slot usage in Appearance and Input with Telegraph helpers, and add shared `TgphSlot`, `VisuallyHidden`, and `useControllableState` exports for migrated components. Explicit appearance overrides now remain pinned instead of being overwritten by document-level appearance observer updates.

--- a/packages/appearance/README.md
+++ b/packages/appearance/README.md
@@ -82,11 +82,19 @@ import { Appearance } from "@telegraph/appearance";
 </Appearance>;
 ```
 
-| Prop         | Type                | Default                   | Description                                    |
-| ------------ | ------------------- | ------------------------- | ---------------------------------------------- |
-| `appearance` | `"light" \| "dark"` | `undefined`               | Specific appearance to apply (uses current global appearance when omitted) |
-| `inverted`   | `boolean`           | `false`                   | Whether to invert the current appearance       |
-| `asChild`    | `boolean`           | `false`                   | Render as child element instead of div wrapper |
+| Prop         | Type                | Default     | Description                                                                           |
+| ------------ | ------------------- | ----------- | ------------------------------------------------------------------------------------- |
+| `appearance` | `"light" \| "dark"` | `undefined` | Specific appearance to apply (uses current global appearance when omitted)            |
+| `inverted`   | `boolean`           | `false`     | Whether to invert the current appearance                                              |
+| `asChild`    | `boolean`           | `false`     | Merge appearance props into a single child element instead of rendering a div wrapper |
+
+```tsx
+import { Appearance } from "@telegraph/appearance";
+
+<Appearance appearance="dark" asChild>
+  <section>This section receives data-tgph-appearance directly</section>
+</Appearance>;
+```
 
 #### `<InvertedAppearance>`
 

--- a/packages/appearance/package.json
+++ b/packages/appearance/package.json
@@ -32,7 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4"
+    "@telegraph/helpers": "workspace:^"
   },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.5",

--- a/packages/appearance/src/useAppearance.test.tsx
+++ b/packages/appearance/src/useAppearance.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  Appearance,
+  InvertedAppearance,
+  OverrideAppearance,
+} from "./useAppearance";
+
+describe("Appearance", () => {
+  it("applies appearance data attributes to the default wrapper", () => {
+    render(
+      <Appearance appearance="dark" data-testid="appearance">
+        Content
+      </Appearance>,
+    );
+
+    expect(screen.getByTestId("appearance")).toHaveAttribute(
+      "data-tgph-appearance",
+      "dark",
+    );
+  });
+
+  it("merges props into the child when asChild is true", async () => {
+    const childClick = vi.fn();
+    const slotClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <Appearance
+        appearance="dark"
+        asChild
+        className="appearance"
+        data-testid="appearance-button"
+        onClick={slotClick}
+      >
+        <button className="child" onClick={childClick} type="button">
+          Toggle
+        </button>
+      </Appearance>,
+    );
+
+    const button = screen.getByTestId("appearance-button");
+    await user.click(button);
+
+    expect(button).toHaveClass("appearance");
+    expect(button).toHaveClass("child");
+    expect(button).toHaveAttribute("data-tgph-appearance", "dark");
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(slotClick).toHaveBeenCalledOnce();
+  });
+
+  it("applies explicit and inverted appearance data attributes", () => {
+    render(
+      <>
+        <OverrideAppearance appearance="light" data-testid="override" />
+        <InvertedAppearance appearance="light" data-testid="inverted" />
+      </>,
+    );
+
+    expect(screen.getByTestId("override")).toHaveAttribute(
+      "data-tgph-appearance",
+      "light",
+    );
+    expect(screen.getByTestId("inverted")).toHaveAttribute(
+      "data-tgph-appearance",
+      "dark",
+    );
+  });
+});

--- a/packages/appearance/src/useAppearance.tsx
+++ b/packages/appearance/src/useAppearance.tsx
@@ -1,5 +1,10 @@
-import { Slot } from "@radix-ui/react-slot";
-import React from "react";
+import { TgphSlot } from "@telegraph/helpers";
+import {
+  type ComponentPropsWithoutRef,
+  type PropsWithChildren,
+  useEffect,
+  useState,
+} from "react";
 
 type Appearance = "light" | "dark";
 
@@ -7,9 +12,9 @@ type UseAppearanceParams = {
   appearanceOverride?: Appearance;
 };
 
-const useAppearance = (params: UseAppearanceParams = {}) => {
-  const [appearance, setAppearance] = React.useState<Appearance>(
-    params?.appearanceOverride || "light",
+const useAppearance = ({ appearanceOverride }: UseAppearanceParams = {}) => {
+  const [appearance, setAppearance] = useState<Appearance>(
+    appearanceOverride || "light",
   );
 
   // Collection of helper props to apply to elements to set their appearance
@@ -22,7 +27,7 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
   const darkAppearanceProps = { "data-tgph-appearance": "dark" };
 
   const handleAppearanceChange = (newAppearance: Appearance) => {
-    if (document) {
+    if (typeof document !== "undefined") {
       setAppearance(newAppearance);
       document.documentElement.setAttribute(
         "data-tgph-appearance",
@@ -33,21 +38,28 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
 
   // Observer for the `html` element to detect changes in the data-tgph-appearance
   // and update the appearance state accordingly
-  React.useEffect(() => {
-    if (!document) return;
+  useEffect(() => {
+    if (appearanceOverride) {
+      setAppearance(appearanceOverride);
+      return;
+    }
+
+    if (typeof document === "undefined") return;
 
     const mutationsCallback = (mutations: MutationRecord[]) => {
-      for (const mutation of mutations) {
-        if (
+      const appearanceMutation = mutations.find((mutation) => {
+        return (
           mutation.type === "attributes" &&
           mutation.attributeName === "data-tgph-appearance"
-        ) {
-          setAppearance(
-            document.documentElement.getAttribute(
-              "data-tgph-appearance",
-            ) as Appearance,
-          );
-        }
+        );
+      });
+
+      if (appearanceMutation) {
+        setAppearance(
+          document.documentElement.getAttribute(
+            "data-tgph-appearance",
+          ) as Appearance,
+        );
       }
     };
 
@@ -66,7 +78,7 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
         observer.disconnect();
       }
     };
-  }, []);
+  }, [appearanceOverride]);
 
   const toggleAppearance = () => {
     const newAppearance = appearance === "light" ? "dark" : "light";
@@ -85,11 +97,13 @@ const useAppearance = (params: UseAppearanceParams = {}) => {
   };
 };
 
-type AppearanceProps = React.PropsWithChildren<{
-  appearance?: Appearance;
-  inverted?: boolean;
-  asChild?: boolean;
-}>;
+type AppearanceProps = PropsWithChildren<
+  ComponentPropsWithoutRef<"div"> & {
+    appearance?: Appearance;
+    inverted?: boolean;
+    asChild?: boolean;
+  }
+>;
 
 // Applies the data attribute to the element to set the appearance
 // of its children
@@ -107,7 +121,7 @@ const Appearance = ({
     ? invertedAppearanceProps
     : appearanceProps;
 
-  const Component = asChild ? Slot : "div";
+  const Component = asChild ? TgphSlot : "div";
 
   return <Component {...derivedAppearanceProps} {...props} />;
 };
@@ -124,7 +138,7 @@ const OverrideAppearance = ({
   const derivedAppearanceProps =
     appearance === "light" ? lightAppearanceProps : darkAppearanceProps;
 
-  const Component = asChild ? Slot : "div";
+  const Component = asChild ? TgphSlot : "div";
   return <Component {...derivedAppearanceProps} {...props} />;
 };
 

--- a/packages/appearance/vitest.config.mts
+++ b/packages/appearance/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "appearance",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -24,7 +24,10 @@ import {
   PolymorphicProps,
   RefToTgphRef,
   TgphElement,
+  TgphSlot,
+  VisuallyHidden,
   createTgphBaseUIRender,
+  useControllableState,
   useDeterminateState,
 } from "@telegraph/helpers";
 
@@ -42,6 +45,13 @@ const state = useDeterminateState({
 
 // Base UI render bridge for Telegraph components
 const renderTrigger = createTgphBaseUIRender(<Button>Open</Button>);
+
+// Controlled/uncontrolled state bridge for component primitives
+const [open, setOpen] = useControllableState({
+  prop: openProp,
+  defaultProp: false,
+  onChange: onOpenChange,
+});
 ```
 
 ## API Reference
@@ -222,39 +232,38 @@ const CustomButton = ({
 
 ### `RefToTgphRef`
 
-Component for handling ref forwarding between external libraries (like Radix) and Telegraph components.
+Component for handling ref forwarding between external libraries and Telegraph
+components.
 
 ```tsx
-import * as Popover from "@radix-ui/react-popover";
 import { Button } from "@telegraph/button";
 import { RefToTgphRef } from "@telegraph/helpers";
 
-// Radix expects a `ref` prop, but Telegraph uses `tgphRef`
-<Popover.Trigger asChild>
-  <RefToTgphRef>
-    <Button>Open Popover</Button>
-  </RefToTgphRef>
-</Popover.Trigger>;
+// Use when an external primitive passes a React `ref` to a single child,
+// but the Telegraph child expects `tgphRef`.
+<RefToTgphRef>
+  <Button>Open</Button>
+</RefToTgphRef>;
 ```
 
 #### Use Cases
 
-**With Radix UI Primitives:**
+**With Base UI render props:**
 
 ```tsx
-import * as Dialog from "@radix-ui/react-dialog";
+import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
-import { RefToTgphRef } from "@telegraph/helpers";
+import { createTgphBaseUIRender } from "@telegraph/helpers";
 
-const DialogExample = () => (
-  <Dialog.Root>
-    <Dialog.Trigger asChild>
-      <RefToTgphRef>
-        <Button>Open Dialog</Button>
-      </RefToTgphRef>
-    </Dialog.Trigger>
-    <Dialog.Content>{/* Dialog content */}</Dialog.Content>
-  </Dialog.Root>
+const PopoverExample = () => (
+  <Popover.Root>
+    <Popover.Trigger render={createTgphBaseUIRender(<Button>Open</Button>)} />
+    <Popover.Portal>
+      <Popover.Positioner>
+        <Popover.Popup>{/* Popover content */}</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
 );
 ```
 
@@ -280,6 +289,44 @@ const FormExample = () => {
     />
   );
 };
+```
+
+### `TgphSlot`
+
+Component for merging wrapper props into a single child element while preserving
+native refs, custom `forwardRef` children, and Telegraph `tgphRef` children.
+
+```tsx
+import { TgphSlot } from "@telegraph/helpers";
+
+<TgphSlot data-state="open" className="trigger">
+  <button type="button">Open</button>
+</TgphSlot>;
+```
+
+### `VisuallyHidden`
+
+Component for rendering accessible text that should remain available to assistive
+technology without being visible in the UI.
+
+```tsx
+import { VisuallyHidden } from "@telegraph/helpers";
+import { Text } from "@telegraph/typography";
+
+<VisuallyHidden>
+  <Text as="label" htmlFor="search">
+    Search
+  </Text>
+</VisuallyHidden>;
+```
+
+Use `asChild` when the hidden styles need to be applied directly to a specific
+element.
+
+```tsx
+<VisuallyHidden asChild>
+  <label htmlFor="email">Email</label>
+</VisuallyHidden>
 ```
 
 ### `createTgphBaseUIRender`
@@ -326,6 +373,28 @@ import type { ComponentProps } from "react";
 ```
 
 ## React Hooks
+
+### `useControllableState`
+
+Hook for component primitives that support both controlled and uncontrolled
+usage.
+
+```tsx
+import { useControllableState } from "@telegraph/helpers";
+
+const [open, setOpen] = useControllableState({
+  prop: openProp,
+  defaultProp: false,
+  onChange: onOpenChange,
+});
+```
+
+The hook mirrors Telegraph's controlled prop conventions:
+
+- `prop` controls the state when it is not `undefined`.
+- `defaultProp` seeds uncontrolled state.
+- `onChange` is called only when the next value differs from the current value.
+- Updater functions are supported, matching React's `setState` ergonomics.
 
 ### `useDeterminateState`
 
@@ -511,32 +580,6 @@ const Card = ({ variant, children, ...props }: CardProps) => {
 ### Integration with External Libraries
 
 ```tsx
-import * as RadixPopover from "@radix-ui/react-popover";
-import { Button } from "@telegraph/button";
-import { PolymorphicProps, RefToTgphRef } from "@telegraph/helpers";
-
-type PopoverProps = PolymorphicProps<"div"> & {
-  trigger: React.ReactNode;
-  content: React.ReactNode;
-};
-
-const Popover = ({ trigger, content, ...props }: PopoverProps) => (
-  <RadixPopover.Root>
-    <RadixPopover.Trigger asChild>
-      <RefToTgphRef>{trigger}</RefToTgphRef>
-    </RadixPopover.Trigger>
-    <RadixPopover.Content {...props}>{content}</RadixPopover.Content>
-  </RadixPopover.Root>
-);
-
-// Usage:
-<Popover
-  trigger={<Button>Open Menu</Button>}
-  content={<div>Popover content</div>}
-/>;
-```
-
-```tsx
 import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
 import { PolymorphicProps, createTgphBaseUIRender } from "@telegraph/helpers";
@@ -638,10 +681,11 @@ type ConditionalProps<T extends TgphElement> = PolymorphicProps<T> &
 ### Component Development
 
 1. **Use `createTgphBaseUIRender` with Base UI `render` props**: Preserves Base UI props while forwarding refs to Telegraph `tgphRef`
-2. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
-3. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
-4. **Type polymorphic components properly**: Use appropriate helper types
-5. **Test type constraints**: Verify TypeScript catches errors correctly
+2. **Use `TgphSlot` for single-child prop composition**: Preserves native refs and `tgphRef`
+3. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
+4. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
+5. **Type polymorphic components properly**: Use appropriate helper types
+6. **Test type constraints**: Verify TypeScript catches errors correctly
 
 ## References
 

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.tsx
@@ -1,31 +1,10 @@
-import { mergeProps } from "@base-ui/react/merge-props";
 import type { ComponentRenderFn, HTMLProps } from "@base-ui/react/use-render";
-import {
-  type ComponentPropsWithRef,
-  type MutableRefObject,
-  type ReactElement,
-  type Ref,
-  type RefAttributes,
-  cloneElement,
-  isValidElement,
-} from "react";
+import { type ReactElement, type Ref, isValidElement } from "react";
 
-import { RefToTgphRef } from "../components/RefToTgphRef";
+import { TgphSlot } from "../components/TgphSlot";
 
 type PropsWithRef = HTMLProps & {
   ref?: Ref<unknown>;
-};
-
-type CloneableProps = Record<string, unknown> & RefAttributes<unknown>;
-
-type IntrinsicMergeProps = ComponentPropsWithRef<"button">;
-
-type ElementWithRef = ReactElement<CloneableProps> & {
-  ref?: Ref<unknown>;
-};
-
-type WarningGetter = (() => unknown) & {
-  isReactWarning?: boolean;
 };
 
 type TgphBaseUIRenderElement<State = Record<string, unknown>> =
@@ -37,62 +16,9 @@ type GetRenderElementParams<State> = {
   state: State;
 };
 
-type RenderNativeElementParams = {
+type RenderWithTgphSlotParams = {
   props: PropsWithRef;
   renderElement: ReactElement;
-};
-
-const isIntrinsicElement = (element: ReactElement) => {
-  return typeof element.type === "string";
-};
-
-const isReactWarningGetter = (
-  getter: (() => unknown) | undefined,
-): getter is WarningGetter => {
-  return Boolean(getter && "isReactWarning" in getter && getter.isReactWarning);
-};
-
-const getElementRef = (element: ReactElement<CloneableProps>) => {
-  const propsRefGetter = Object.getOwnPropertyDescriptor(
-    element.props,
-    "ref",
-  )?.get;
-
-  if (isReactWarningGetter(propsRefGetter)) {
-    // React 18 can hide the real ref on the element when props.ref is only the
-    // dev warning getter, so read the element field in that case.
-    return (element as ElementWithRef).ref;
-  }
-
-  const elementRefGetter = Object.getOwnPropertyDescriptor(element, "ref")?.get;
-
-  if (isReactWarningGetter(elementRefGetter)) {
-    // React 19 moves refs into props; if element.ref is the warning getter,
-    // prefer the props ref so we do not trip the warning while composing refs.
-    return element.props.ref;
-  }
-
-  return element.props.ref ?? (element as ElementWithRef).ref;
-};
-
-const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
-  if (typeof ref === "function") {
-    ref(value);
-  } else if (ref !== null && ref !== undefined) {
-    (ref as MutableRefObject<T | null>).current = value;
-  }
-};
-
-const composeRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
-  const definedRefs = refs.filter((ref): ref is Ref<T> => Boolean(ref));
-
-  if (definedRefs.length === 0) {
-    return undefined;
-  }
-
-  return (node: T | null) => {
-    definedRefs.forEach((ref) => setRef(ref, node));
-  };
 };
 
 const getRenderElement = <State = Record<string, unknown>,>({
@@ -106,26 +32,19 @@ const getRenderElement = <State = Record<string, unknown>,>({
   return element;
 };
 
-const renderNativeElement = ({
+const renderWithTgphSlot = ({
   props,
   renderElement,
-}: RenderNativeElementParams) => {
-  // React treats refs specially when cloning, so pull Base UI's forwarded ref
-  // out before merging the rest of the props into the rendered element.
-  const { ref, ...baseUIProps } = props;
-  const cloneableElement = renderElement as ReactElement<CloneableProps>;
-  const childRef = getElementRef(cloneableElement);
-  const composedRef = composeRefs(childRef, ref);
+}: RenderWithTgphSlotParams) => {
+  // Base UI gives render targets a standard React ref; TgphSlot decides whether
+  // that ref should stay on `ref` or be bridged onto Telegraph's `tgphRef`.
+  const { ref } = props;
 
-  return cloneElement(cloneableElement, {
-    // Keep Base UI's injected event handlers and data attributes composed with
-    // the caller's element props instead of replacing one side wholesale.
-    ...mergeProps(
-      baseUIProps as IntrinsicMergeProps,
-      renderElement.props as IntrinsicMergeProps,
-    ),
-    ...(composedRef ? { ref: composedRef } : {}),
-  });
+  return (
+    <TgphSlot {...props} ref={ref as Ref<HTMLElement>}>
+      {renderElement}
+    </TgphSlot>
+  );
 };
 
 const createTgphBaseUIRender = <
@@ -136,24 +55,19 @@ const createTgphBaseUIRender = <
 ): ComponentRenderFn<Props, State> => {
   return (props, state) => {
     // Base UI may call `render` with live state, so resolve function children
-    // before choosing the native-element path or Telegraph ref bridge.
+    // before asking TgphSlot to merge props into the concrete element.
     const renderElement = getRenderElement({ element, state });
 
     if (!isValidElement(renderElement)) {
       return renderElement;
     }
 
-    if (isIntrinsicElement(renderElement)) {
-      // Native elements can receive Base UI's merged props and React ref
-      // directly, so keep Base UI's merge behavior intact here.
-      return renderNativeElement({
-        props: props as PropsWithRef,
-        renderElement,
-      });
-    }
-
-    // Telegraph components need Base UI's standard `ref` bridged to `tgphRef`.
-    return <RefToTgphRef {...props}>{renderElement}</RefToTgphRef>;
+    // Keep native elements, forwardRef components, and tgphRef-only components
+    // on the same prop/ref composition path.
+    return renderWithTgphSlot({
+      props: props as PropsWithRef,
+      renderElement,
+    });
   };
 };
 

--- a/packages/helpers/src/components/TgphSlot/TgphSlot.test.tsx
+++ b/packages/helpers/src/components/TgphSlot/TgphSlot.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  forwardRef,
+} from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TgphSlot } from "./TgphSlot";
+
+type TelegraphButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TelegraphButton = ({ tgphRef, ...props }: TelegraphButtonProps) => {
+  return <button ref={tgphRef} type="button" {...props} />;
+};
+
+type TrackingTelegraphButtonProps = TelegraphButtonProps & {
+  onTgphRefChange: (tgphRef: TelegraphButtonProps["tgphRef"]) => void;
+};
+
+const TrackingTelegraphButton = ({
+  tgphRef,
+  onTgphRefChange,
+  ...props
+}: TrackingTelegraphButtonProps) => {
+  onTgphRefChange(tgphRef);
+
+  return <button ref={tgphRef} type="button" {...props} />;
+};
+
+const ForwardRefButton = forwardRef<
+  HTMLButtonElement,
+  ComponentPropsWithoutRef<"button">
+>((props, ref) => {
+  return <button ref={ref} type="button" {...props} />;
+});
+
+describe("TgphSlot", () => {
+  it("merges props and refs into native children", async () => {
+    const childClick = vi.fn();
+    const slotClick = vi.fn();
+    const ref = createRef<HTMLButtonElement>();
+    const user = userEvent.setup();
+
+    render(
+      <TgphSlot
+        aria-expanded
+        className="slot"
+        data-testid="native-button"
+        onClick={slotClick}
+        ref={ref}
+      >
+        <button className="child" onClick={childClick} type="button">
+          Open
+        </button>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByTestId("native-button");
+    await user.click(button);
+
+    expect(button).toHaveClass("child");
+    expect(button).toHaveClass("slot");
+    expect(button).toHaveAttribute("aria-expanded", "true");
+    expect(childClick).toHaveBeenCalledOnce();
+    expect(slotClick).toHaveBeenCalledOnce();
+    expect(ref.current).toBe(button);
+  });
+
+  it("maps refs to tgphRef for Telegraph-style children", () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    render(
+      <TgphSlot data-testid="telegraph-button" ref={ref}>
+        <TelegraphButton>Open</TelegraphButton>
+      </TgphSlot>,
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("telegraph-button"));
+  });
+
+  it("keeps child tgphRef stable when parent refs change", () => {
+    const firstRef = vi.fn();
+    const secondRef = vi.fn();
+    const seenTgphRefs: TelegraphButtonProps["tgphRef"][] = [];
+
+    const { rerender } = render(
+      <TgphSlot ref={firstRef}>
+        <TrackingTelegraphButton
+          onTgphRefChange={(tgphRef) => seenTgphRefs.push(tgphRef)}
+        >
+          Open
+        </TrackingTelegraphButton>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByRole("button", { name: "Open" });
+    const stableTgphRef = seenTgphRefs.at(-1);
+
+    rerender(
+      <TgphSlot ref={secondRef}>
+        <TrackingTelegraphButton
+          onTgphRefChange={(tgphRef) => seenTgphRefs.push(tgphRef)}
+        >
+          Open
+        </TrackingTelegraphButton>
+      </TgphSlot>,
+    );
+
+    expect(seenTgphRefs.at(-1)).toBe(stableTgphRef);
+    expect(firstRef).toHaveBeenCalledWith(button);
+    expect(firstRef).toHaveBeenLastCalledWith(null);
+    expect(secondRef).toHaveBeenCalledWith(button);
+  });
+
+  it("composes refs with existing tgphRef props on Telegraph-style children", () => {
+    const childRef = createRef<HTMLButtonElement>();
+    const slotRef = createRef<HTMLButtonElement>();
+
+    render(
+      <TgphSlot ref={slotRef}>
+        <TelegraphButton tgphRef={childRef}>Open</TelegraphButton>
+      </TgphSlot>,
+    );
+
+    const button = screen.getByRole("button", { name: "Open" });
+
+    expect(childRef.current).toBe(button);
+    expect(slotRef.current).toBe(button);
+  });
+
+  it("preserves ref support for custom forwardRef children without leaking tgphRef", () => {
+    const childRef = createRef<HTMLButtonElement>();
+    const slotRef = createRef<HTMLButtonElement>();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      render(
+        <TgphSlot data-testid="forward-ref-button" ref={slotRef}>
+          <ForwardRefButton ref={childRef}>Open</ForwardRefButton>
+        </TgphSlot>,
+      );
+
+      const button = screen.getByTestId("forward-ref-button");
+
+      expect(slotRef.current).toBe(button);
+      expect(childRef.current).toBe(button);
+      expect(button).not.toHaveAttribute("tgphRef");
+      expect(errorSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("does not recognize the `tgphRef` prop"),
+        expect.anything(),
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/packages/helpers/src/components/TgphSlot/TgphSlot.tsx
+++ b/packages/helpers/src/components/TgphSlot/TgphSlot.tsx
@@ -1,0 +1,225 @@
+import { mergeProps } from "@base-ui/react/merge-props";
+import {
+  Children,
+  type ComponentPropsWithRef,
+  type MutableRefObject,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefAttributes,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+
+// React marks forwardRef components with this symbol in the element metadata.
+// Checking it lets us decide whether a child can safely receive `ref`.
+const FORWARD_REF_SYMBOL = Symbol.for("react.forward_ref");
+
+type TgphSlotProps = ComponentPropsWithRef<"span"> &
+  Record<string, unknown> & {
+    children?: ReactNode;
+  };
+
+type SlottableChildProps = Record<string, unknown> &
+  RefAttributes<HTMLElement> & {
+    tgphRef?: Ref<HTMLElement>;
+  };
+
+type IntrinsicMergeProps = ComponentPropsWithRef<"span">;
+
+type ElementWithRef = ReactElement<SlottableChildProps> & {
+  $$typeof?: symbol;
+  ref?: Ref<HTMLElement>;
+  type:
+    | string
+    | {
+        $$typeof?: symbol;
+      };
+};
+
+type WarningGetter = (() => unknown) & {
+  isReactWarning?: boolean;
+};
+
+const isReactWarningGetter = (
+  getter: (() => unknown) | undefined,
+): getter is WarningGetter => {
+  return Boolean(getter && "isReactWarning" in getter && getter.isReactWarning);
+};
+
+// React 18 and 19 expose child refs differently. Reading the wrong location can
+// trigger React's dev warning getter, so mirror Radix's defensive extraction
+// before composing the wrapper ref with the child's existing ref.
+const getElementRef = (element: ReactElement<SlottableChildProps>) => {
+  const propsRefGetter = Object.getOwnPropertyDescriptor(
+    element.props,
+    "ref",
+  )?.get;
+
+  if (isReactWarningGetter(propsRefGetter)) {
+    // React 18 can hide the real ref on the element when props.ref is only the
+    // dev warning getter, so read the element field in that case.
+    return (element as ElementWithRef).ref;
+  }
+
+  const elementRefGetter = Object.getOwnPropertyDescriptor(element, "ref")?.get;
+
+  if (isReactWarningGetter(elementRefGetter)) {
+    // React 19 moves refs into props; if element.ref is the warning getter,
+    // prefer the props ref so we do not trip the warning while composing refs.
+    return element.props.ref;
+  }
+
+  return element.props.ref ?? (element as ElementWithRef).ref;
+};
+
+const setRef = <T,>(ref: Ref<T> | undefined, value: T | null) => {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref !== null && ref !== undefined) {
+    (ref as MutableRefObject<T | null>).current = value;
+  }
+};
+
+const composeRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
+  return (node: T | null) => {
+    refs.forEach((ref) => setRef(ref, node));
+  };
+};
+
+const getDefinedRefs = <T,>(refs: (Ref<T> | undefined)[]) => {
+  return refs.filter((ref): ref is Ref<T> => Boolean(ref));
+};
+
+const areRefsEqual = <T,>(refs: Ref<T>[], nextRefs: Ref<T>[]) => {
+  return (
+    refs.length === nextRefs.length &&
+    refs.every((ref, index) => ref === nextRefs[index])
+  );
+};
+
+const useStableComposedRefs = <T,>(...refs: (Ref<T> | undefined)[]) => {
+  const definedRefs = getDefinedRefs(refs);
+  const refsStorage = useRef(definedRefs);
+  const previousRefsStorage = useRef(definedRefs);
+  const nodeStorage = useRef<T | null>(null);
+
+  // Keep the returned callback stable while still giving it the latest refs.
+  refsStorage.current = definedRefs;
+
+  useEffect(() => {
+    const previousRefs = previousRefsStorage.current;
+    const currentRefs = refsStorage.current;
+    const currentNode = nodeStorage.current;
+
+    if (currentNode && !areRefsEqual(previousRefs, currentRefs)) {
+      // A child can add or remove refs between renders; clear removed refs and
+      // replay the mounted node to newly introduced refs without remounting it.
+      previousRefs.forEach((ref) => {
+        if (!currentRefs.includes(ref)) {
+          setRef(ref, null);
+        }
+      });
+
+      currentRefs.forEach((ref) => {
+        if (!previousRefs.includes(ref)) {
+          setRef(ref, currentNode);
+        }
+      });
+    }
+
+    previousRefsStorage.current = currentRefs;
+  });
+
+  const stableRef = useCallback((node: T | null) => {
+    // Store the latest node so the effect above can sync refs that appear after
+    // the callback was originally attached.
+    nodeStorage.current = node;
+    composeRefs(...refsStorage.current)(node);
+  }, []);
+
+  return definedRefs.length > 0 ? stableRef : undefined;
+};
+
+const isIntrinsicElement = (element: ElementWithRef) => {
+  return typeof element.type === "string";
+};
+
+const isForwardRefElement = (element: ElementWithRef) => {
+  return (
+    element.$$typeof === FORWARD_REF_SYMBOL ||
+    (typeof element.type !== "string" &&
+      element.type.$$typeof === FORWARD_REF_SYMBOL)
+  );
+};
+
+const getRefProps = (
+  child: ReactElement<SlottableChildProps>,
+  composedRef: Ref<HTMLElement> | undefined,
+  composedTgphRef: Ref<HTMLElement> | undefined,
+) => {
+  const childTgphRef = child.props.tgphRef;
+
+  if (!composedRef && !childTgphRef) {
+    return {};
+  }
+
+  const element = child as ElementWithRef;
+
+  if (isIntrinsicElement(element)) {
+    return { ref: composedRef };
+  }
+
+  // ForwardRef children already have a standard React ref channel. Only keep
+  // the Telegraph ref channel when the child explicitly opted into tgphRef.
+  if (isForwardRefElement(element)) {
+    return {
+      ...(composedRef ? { ref: composedRef } : {}),
+      ...(childTgphRef && composedTgphRef ? { tgphRef: composedTgphRef } : {}),
+    };
+  }
+
+  // Plain function components cannot receive `ref` without React warnings, so
+  // pass only `tgphRef` for Telegraph-style components that do not forward refs.
+  return {
+    ...(composedTgphRef ? { tgphRef: composedTgphRef } : {}),
+  };
+};
+
+const TgphSlot = forwardRef<HTMLElement, TgphSlotProps>(
+  ({ children, ...props }, forwardedRef) => {
+    // Match Radix Slot's one-child contract before cloning wrapper props into
+    // the child element.
+    const child = Children.only(children);
+    const slottableChild = isValidElement<SlottableChildProps>(child)
+      ? child
+      : null;
+    // Compose the wrapper ref with whichever ref API the child already uses so
+    // consumers keep their existing `ref` and `tgphRef` behavior.
+    const childRef = slottableChild ? getElementRef(slottableChild) : undefined;
+    const childTgphRef = slottableChild?.props.tgphRef;
+    const composedRef = useStableComposedRefs(forwardedRef, childRef);
+    const composedTgphRef = useStableComposedRefs(forwardedRef, childTgphRef);
+
+    if (!slottableChild) {
+      return null;
+    }
+
+    return cloneElement(slottableChild, {
+      // Merge events, className, and data attributes before assigning the
+      // compatible ref props chosen for this specific child shape.
+      ...mergeProps(
+        props as IntrinsicMergeProps,
+        slottableChild.props as IntrinsicMergeProps,
+      ),
+      ...getRefProps(slottableChild, composedRef, composedTgphRef),
+    });
+  },
+);
+
+export { TgphSlot };
+export type { TgphSlotProps };

--- a/packages/helpers/src/components/TgphSlot/index.ts
+++ b/packages/helpers/src/components/TgphSlot/index.ts
@@ -1,0 +1,1 @@
+export { TgphSlot, type TgphSlotProps } from "./TgphSlot";

--- a/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { VisuallyHidden } from "./VisuallyHidden";
+
+describe("VisuallyHidden", () => {
+  it("renders content with visually hidden styles", () => {
+    render(<VisuallyHidden>Hidden label</VisuallyHidden>);
+
+    expect(screen.getByText("Hidden label")).toHaveStyle({
+      position: "absolute",
+      width: "1px",
+      height: "1px",
+      overflow: "hidden",
+    });
+  });
+
+  it("merges custom styles", () => {
+    render(
+      <VisuallyHidden style={{ whiteSpace: "normal" }}>
+        Wrapped label
+      </VisuallyHidden>,
+    );
+
+    expect(screen.getByText("Wrapped label")).toHaveStyle({
+      whiteSpace: "normal",
+    });
+  });
+
+  it("renders through TgphSlot when asChild is true", () => {
+    render(
+      <VisuallyHidden asChild>
+        <label htmlFor="email">Email</label>
+      </VisuallyHidden>,
+    );
+
+    expect(screen.getByText("Email").tagName).toBe("LABEL");
+    expect(screen.getByText("Email")).toHaveAttribute("for", "email");
+  });
+});

--- a/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/helpers/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,0 +1,56 @@
+import {
+  type CSSProperties,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+
+import { TgphSlot } from "../TgphSlot";
+
+// Shared a11y-only styles used by migrated primitives that previously relied on
+// Radix VisuallyHidden. Keep this object frozen so callers cannot mutate the
+// base style contract across component instances.
+const VISUALLY_HIDDEN_STYLES = Object.freeze({
+  position: "absolute",
+  border: 0,
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  wordWrap: "normal",
+} satisfies CSSProperties);
+
+export type VisuallyHiddenProps = ComponentPropsWithoutRef<"span"> & {
+  asChild?: boolean;
+  children?: ReactNode;
+};
+
+const getVisuallyHiddenStyle = (
+  style: CSSProperties | undefined,
+): CSSProperties => {
+  return {
+    ...VISUALLY_HIDDEN_STYLES,
+    ...style,
+  };
+};
+
+export const VisuallyHidden = ({
+  asChild = false,
+  style,
+  ...props
+}: VisuallyHiddenProps) => {
+  const visuallyHiddenProps = {
+    style: getVisuallyHiddenStyle(style),
+    ...props,
+  };
+
+  if (asChild) {
+    // `asChild` lets consumers hide an existing semantic node, such as `label`
+    // or Base UI's title/description element, without adding an extra wrapper.
+    return <TgphSlot {...visuallyHiddenProps} />;
+  }
+
+  return <span {...visuallyHiddenProps} />;
+};

--- a/packages/helpers/src/components/VisuallyHidden/index.ts
+++ b/packages/helpers/src/components/VisuallyHidden/index.ts
@@ -1,0 +1,1 @@
+export { VisuallyHidden, type VisuallyHiddenProps } from "./VisuallyHidden";

--- a/packages/helpers/src/hooks/useControllableState.test.tsx
+++ b/packages/helpers/src/hooks/useControllableState.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useControllableState } from "./useControllableState";
+
+const UncontrolledStateExample = ({
+  onChange,
+}: {
+  onChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useControllableState({
+    defaultProp: "one",
+    onChange,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("two")}>
+        Set two
+      </button>
+    </>
+  );
+};
+
+const DuplicateUpdateExample = ({
+  onChange,
+}: {
+  onChange?: (value: boolean) => void;
+}) => {
+  const [, setValue] = useControllableState({
+    defaultProp: true,
+    onChange,
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        setValue(false);
+        setValue(false);
+      }}
+    >
+      Close twice
+    </button>
+  );
+};
+
+const ControlledStateExample = ({
+  onChange,
+}: {
+  onChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useControllableState({
+    prop: "controlled",
+    defaultProp: "uncontrolled",
+    onChange,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("requested")}>
+        Request update
+      </button>
+    </>
+  );
+};
+
+const UpdaterExample = () => {
+  const [value, setValue] = useControllableState({
+    defaultProp: 1,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue((current) => current + 1)}>
+        Increment
+      </button>
+    </>
+  );
+};
+
+const ControlledRerenderExample = () => {
+  const [controlledValue, setControlledValue] = useState("one");
+  const [value, setValue] = useControllableState({
+    prop: controlledValue,
+    defaultProp: "fallback",
+    onChange: setControlledValue,
+  });
+
+  return (
+    <>
+      <output>{value}</output>
+      <button type="button" onClick={() => setValue("two")}>
+        Set controlled value
+      </button>
+    </>
+  );
+};
+
+describe("useControllableState", () => {
+  it("updates uncontrolled state and calls onChange", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<UncontrolledStateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Set two" }));
+
+    expect(screen.getByText("two")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("two");
+  });
+
+  it("dedupes same-value uncontrolled updates before rerender", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<DuplicateUpdateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Close twice" }));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it("requests controlled updates without changing the current value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<ControlledStateExample onChange={onChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Request update" }));
+
+    expect(screen.getByText("controlled")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("requested");
+  });
+
+  it("supports updater functions", async () => {
+    const user = userEvent.setup();
+
+    render(<UpdaterExample />);
+
+    await user.click(screen.getByRole("button", { name: "Increment" }));
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("uses the next controlled prop after onChange updates it", async () => {
+    const user = userEvent.setup();
+
+    render(<ControlledRerenderExample />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Set controlled value" }),
+    );
+
+    expect(screen.getByText("two")).toBeInTheDocument();
+  });
+});

--- a/packages/helpers/src/hooks/useControllableState.ts
+++ b/packages/helpers/src/hooks/useControllableState.ts
@@ -1,0 +1,61 @@
+import {
+  type SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+export type UseControllableStateParams<T> = {
+  defaultProp: T;
+  onChange?: (value: T) => void;
+  prop?: T;
+};
+
+export const useControllableState = <T>({
+  defaultProp,
+  onChange,
+  prop,
+}: UseControllableStateParams<T>) => {
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultProp);
+  // Keep the current uncontrolled value available to the setter without making
+  // the setter depend on every value change. That keeps callback identity stable
+  // for component primitives that pass setters through context.
+  const uncontrolledValueRef = useRef(uncontrolledValue);
+  // `undefined` keeps the previous Radix-style contract: anything else means
+  // the caller owns the value and we only emit changes.
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolledValue;
+
+  useEffect(() => {
+    uncontrolledValueRef.current = uncontrolledValue;
+  }, [uncontrolledValue]);
+
+  const setValue = useCallback(
+    (nextValueOrUpdater: SetStateAction<T>) => {
+      // React-style updater functions need the freshest value from the active
+      // source, not a stale value captured when this setter was created.
+      const currentValue = isControlled ? prop : uncontrolledValueRef.current;
+      const nextValue =
+        typeof nextValueOrUpdater === "function"
+          ? (nextValueOrUpdater as (previousValue: T) => T)(currentValue)
+          : nextValueOrUpdater;
+
+      if (Object.is(currentValue, nextValue)) {
+        return;
+      }
+
+      if (!isControlled) {
+        // Update the ref before React commits state so multiple same-tick setter
+        // calls compare against the latest queued uncontrolled value.
+        uncontrolledValueRef.current = nextValue;
+        setUncontrolledValue(nextValue);
+      }
+
+      onChange?.(nextValue);
+    },
+    [isControlled, onChange, prop],
+  );
+
+  return [value, setValue] as const;
+};

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -12,7 +12,13 @@ export type {
 } from "./types/utility";
 
 export { RefToTgphRef } from "./components/RefToTgphRef";
+export { TgphSlot, type TgphSlotProps } from "./components/TgphSlot";
+export {
+  VisuallyHidden,
+  type VisuallyHiddenProps,
+} from "./components/VisuallyHidden";
 
+export { useControllableState } from "./hooks/useControllableState";
 export { useDeterminateState } from "./hooks/useDeterminateState";
 
 export {

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -73,23 +73,25 @@ For advanced use cases, use the composition API:
 
 Container component that wraps the input and slots.
 
-| Prop         | Type                   | Default     | Description                         |
-| ------------ | ---------------------- | ----------- | ----------------------------------- |
-| `size`       | `"1" \| "2" \| "3"`    | `"2"`       | Input size                          |
-| `variant`    | `"outline" \| "ghost"` | `"outline"` | Visual style variant                |
-| `errored`    | `boolean`              | `false`     | Shows error state styling           |
-| `disabled`   | `boolean`              | `false`     | Disables the input                  |
-| `textProps`  | `object`               | `undefined` | Props to pass to the inner Text component  |
-| `stackProps` | `object`               | `undefined` | Props to pass to the Stack container       |
-| `as`         | `TgphElement`          | `"input"`   | HTML element or component to render |
+| Prop         | Type                   | Default     | Description                               |
+| ------------ | ---------------------- | ----------- | ----------------------------------------- |
+| `size`       | `"1" \| "2" \| "3"`    | `"2"`       | Input size                                |
+| `variant`    | `"outline" \| "ghost"` | `"outline"` | Visual style variant                      |
+| `errored`    | `boolean`              | `false`     | Shows error state styling                 |
+| `disabled`   | `boolean`              | `false`     | Disables the input                        |
+| `textProps`  | `object`               | `undefined` | Props to pass to the inner Text component |
+| `stackProps` | `object`               | `undefined` | Props to pass to the Stack container      |
+| `as`         | `TgphElement`          | `"input"`   | HTML element or component to render       |
 
 #### `<Input.Slot>`
 
-Wrapper for leading and trailing components.
+Wrapper for leading and trailing components. Props passed to `Input.Slot` are
+merged into its single child, and refs are forwarded to that child.
 
 | Prop       | Type                      | Default     | Description          |
 | ---------- | ------------------------- | ----------- | -------------------- |
 | `position` | `"leading" \| "trailing"` | `"leading"` | Position of the slot |
+| `size`     | `"1" \| "2" \| "3"`       | Root size   | Slot size override   |
 
 ## Usage Patterns
 

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -32,7 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.2.4",
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/input/src/Input/Input.test.tsx
+++ b/packages/input/src/Input/Input.test.tsx
@@ -1,9 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Input } from "./Input";
 import type { InputProps, InputRootProps } from "./index";
 
 describe("Input", () => {
+  it("renders slot data attributes and forwards props to the child", () => {
+    render(
+      <Input.Root>
+        <Input.Slot
+          className="slot-child"
+          data-testid="slot-button"
+          position="trailing"
+        >
+          <button className="child" type="button">
+            Action
+          </button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    const slot = document.querySelector("[data-tgph-input-slot]");
+    const button = screen.getByTestId("slot-button");
+
+    expect(slot).toHaveAttribute("data-tgph-input-slot-position", "trailing");
+    expect(slot).toHaveAttribute("data-tgph-input-slot-size", "2");
+    expect(button).toHaveClass("child");
+    expect(button).toHaveClass("slot-child");
+  });
+
+  it("uses explicit slot size for data attributes and child props", () => {
+    render(
+      <Input.Root size="1">
+        <Input.Slot data-testid="slot-button" position="leading" size="3">
+          <button type="button">Action</button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    const slot = document.querySelector("[data-tgph-input-slot]");
+    const button = screen.getByTestId("slot-button");
+
+    expect(slot).toHaveAttribute("data-tgph-input-slot-position", "leading");
+    expect(slot).toHaveAttribute("data-tgph-input-slot-size", "3");
+    expect(button).toHaveAttribute("size", "3");
+  });
+
+  it("forwards Input.Slot refs to the slotted child", () => {
+    const ref = createRef<HTMLButtonElement>();
+
+    render(
+      <Input.Root>
+        <Input.Slot data-testid="slot-button" ref={ref}>
+          <button type="button">Action</button>
+        </Input.Slot>
+      </Input.Root>,
+    );
+
+    expect(ref.current).toBe(screen.getByTestId("slot-button"));
+  });
+
   describe("type inheritance", () => {
     it("accepts valid input-specific props", () => {
       const validProps: InputRootProps = {

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -1,14 +1,23 @@
-import { Slot as RadixSlot } from "@radix-ui/react-slot";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import type {
   PolymorphicProps,
   Required,
   TgphComponentProps,
   TgphElement,
+  TgphSlotProps,
 } from "@telegraph/helpers";
+import { TgphSlot } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
-import React from "react";
+import {
+  type ComponentProps,
+  type MouseEvent,
+  type ReactNode,
+  createContext,
+  forwardRef,
+  useContext,
+  useRef,
+} from "react";
 
 import { COLOR, SIZE } from "./Input.constants";
 
@@ -19,15 +28,15 @@ export type BaseRootProps = {
 };
 
 export type RootProps<T extends TgphElement = "input"> = BaseRootProps & {
-  textProps?: Omit<React.ComponentProps<typeof Text<T>>, "as">;
-  stackProps?: Omit<React.ComponentProps<typeof Stack>, "as">;
-} & Omit<React.ComponentProps<typeof Text<T>>, "as" | keyof BaseRootProps>;
+  textProps?: Omit<ComponentProps<typeof Text<T>>, "as">;
+  stackProps?: Omit<ComponentProps<typeof Stack>, "as">;
+} & Omit<ComponentProps<typeof Text<T>>, "as" | keyof BaseRootProps>;
 
 type InternalProps = Omit<BaseRootProps, "errored"> & {
   state: "default" | "disabled" | "error";
 };
 
-const InputContext = React.createContext<Required<InternalProps>>({
+const InputContext = createContext<Required<InternalProps>>({
   state: "default",
   size: "2",
   variant: "outline",
@@ -46,7 +55,7 @@ const Root = <T extends TgphElement = "input">({
   ...props
 }: RootProps<T>) => {
   const Component = as;
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const composedRefs = useComposedRefs(tgphRef, inputRef);
 
   const state = disabled ? "disabled" : errored ? "error" : "default";
@@ -55,7 +64,7 @@ const Root = <T extends TgphElement = "input">({
     <InputContext.Provider value={{ size, variant, state }}>
       <Stack
         // Focus the input when clicking on the container
-        onPointerDown={(event: React.MouseEvent<HTMLDivElement>) => {
+        onPointerDown={(event: MouseEvent<HTMLDivElement>) => {
           const target = event.target as HTMLElement;
 
           // Make sure we're not clicking on an interactive element
@@ -104,15 +113,17 @@ const Root = <T extends TgphElement = "input">({
   );
 };
 
-export type SlotProps = React.ComponentPropsWithoutRef<typeof RadixSlot> & {
+export type SlotProps = Omit<TgphSlotProps, "size"> & {
   size?: "1" | "2" | "3";
   position?: "leading" | "trailing";
 };
-type SlotRef = React.ElementRef<typeof RadixSlot>;
+type SlotRef = HTMLElement;
 
-const Slot = React.forwardRef<SlotRef, SlotProps>(
+const Slot = forwardRef<SlotRef, SlotProps>(
   ({ position = "leading", ...props }, forwardedRef) => {
-    const context = React.useContext(InputContext);
+    const context = useContext(InputContext);
+    const slotSize = props.size ?? context.size;
+
     return (
       <Stack
         align="center"
@@ -120,11 +131,11 @@ const Slot = React.forwardRef<SlotRef, SlotProps>(
         h="full"
         data-tgph-input-slot
         data-tgph-input-slot-position={position}
-        data-tgph-input-slot-size={props.size ?? context.size}
+        data-tgph-input-slot-size={slotSize}
         {...(position === "leading" && SIZE.SlotLeading[context.size])}
         {...(position === "trailing" && SIZE.SlotTrailing[context.size])}
       >
-        <RadixSlot size={context.size} {...props} ref={forwardedRef} />
+        <TgphSlot size={slotSize} {...props} ref={forwardedRef} />
       </Stack>
     );
   },
@@ -135,8 +146,8 @@ export type DefaultProps<T extends TgphElement = "input"> = Omit<
   keyof BaseRootProps
 > &
   TgphComponentProps<typeof Root> & {
-    LeadingComponent?: React.ReactNode;
-    TrailingComponent?: React.ReactNode;
+    LeadingComponent?: ReactNode;
+    TrailingComponent?: ReactNode;
   };
 
 const Default = <T extends TgphElement = "input">({

--- a/packages/input/vitest.config.mts
+++ b/packages/input/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "input",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,7 +3551,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-slot@npm:1.2.4, @radix-ui/react-slot@npm:^1.2.4":
+"@radix-ui/react-slot@npm:1.2.4":
   version: 1.2.4
   resolution: "@radix-ui/react-slot@npm:1.2.4"
   dependencies:
@@ -4316,7 +4316,7 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-slot": "npm:^1.2.4"
+    "@telegraph/helpers": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
@@ -4524,7 +4524,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-slot": "npm:^1.2.4"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #837.
- Linear: [KNO-13665](https://linear.app/knock/issue/KNO-13665).

## What changed

- Adds shared `TgphSlot`, `VisuallyHidden`, and `useControllableState` helpers.
- Replaces Radix Slot usage in Appearance and Input with `TgphSlot`.
- Updates `RefToTgphRef` and helper docs to describe generic external-library interop instead of Radix-specific guidance.
- Removes affected Radix utility dependencies and adds package changesets.

## Why

- Removes the first Radix utility layer while preserving slot prop merging, event composition, refs, and `tgphRef`.
- Centralizes compatibility helpers that later component PRs reuse.

## Verification

- `yarn test packages/helpers/src/components/TgphSlot/TgphSlot.test.tsx packages/helpers/src/hooks/useControllableState.test.tsx packages/helpers/src/components/VisuallyHidden/VisuallyHidden.test.tsx packages/appearance/src/useAppearance.test.tsx packages/input/src/Input/Input.test.tsx`
- `yarn workspace @telegraph/helpers build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
