### PR TITLE
refactor(tabs): migrate Tabs to Base UI

### DIFF
--- a/.changeset/bright-tabs-shift.md
+++ b/.changeset/bright-tabs-shift.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/tabs": minor
+---
+
+Migrate Tabs from Radix primitives to Base UI while preserving Telegraph styling hooks and `tgphRef` support. `onValueChange` now honestly types the Base UI cleared-selection case as `string | null`, and list activation behavior is configured through `Tabs.List` props.

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -355,7 +355,9 @@ const PopoverExample = () => (
 
 The helper accepts a React element or a state callback. It preserves Base UI
 props, event handlers, class names, styles, native refs, custom `forwardRef`
-children, and Telegraph `tgphRef` children.
+children, and Telegraph `tgphRef` children. When the child already has its own
+`tgphRef`, the helper composes it with the Base UI ref so both refs receive the
+same rendered element.
 
 ```tsx
 import { Popover } from "@base-ui/react/popover";

--- a/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
+++ b/packages/helpers/src/base-ui/createTgphBaseUIRender.test.tsx
@@ -5,7 +5,7 @@ import {
   createRef,
   forwardRef,
 } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { createTgphBaseUIRender } from "./createTgphBaseUIRender";
 
@@ -96,6 +96,29 @@ describe("createTgphBaseUIRender", () => {
     );
 
     const button = screen.getByTestId("native-button");
+
+    expect(baseUIRef.current).toBe(button);
+    expect(childRef.current).toBe(button);
+  });
+
+  it("composes Base UI refs with existing tgphRef props", () => {
+    const baseUIRef = createRef<HTMLButtonElement>();
+    const childRef = createRef<HTMLButtonElement>();
+    const renderButton = createTgphBaseUIRender<BaseUIRenderProps>(
+      <TelegraphButton tgphRef={childRef}>Open</TelegraphButton>,
+    );
+
+    render(
+      renderButton(
+        {
+          "data-testid": "telegraph-button",
+          ref: baseUIRef,
+        },
+        {},
+      ),
+    );
+
+    const button = screen.getByTestId("telegraph-button");
 
     expect(baseUIRef.current).toBe(button);
     expect(childRef.current).toBe(button);

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -69,28 +69,38 @@ export const BasicTabs = () => (
 );
 ```
 
+## Implementation Notes
+
+Tabs are backed by Base UI Tabs primitives and keep the Telegraph public API,
+data attributes, styling hooks, and `tgphRef` behavior stable for existing
+consumers.
+
+Controlled tab values can be `null` when no tab is selected, such as when the
+current/default value no longer matches a rendered tab.
+
 ## API Reference
 
 ### `<Tabs>`
 
 The root container component that provides tab state management and context.
 
-| Prop            | Type                         | Default        | Description                                   |
-| --------------- | ---------------------------- | -------------- | --------------------------------------------- |
-| `defaultValue`  | `string`                     | `undefined`    | ID of the initially active tab (uncontrolled) |
-| `value`         | `string`                     | `undefined`    | Currently active tab ID (controlled)          |
-| `onValueChange` | `(value: string) => void`    | `undefined`    | Called when the active tab changes            |
-| `disabled`      | `boolean`                    | `false`        | Disables all tabs when true                   |
-| `orientation`   | `"horizontal" \| "vertical"` | `"horizontal"` | Layout orientation                            |
-| `dir`           | `"ltr" \| "rtl"`             | `"ltr"`        | Text direction                                |
+| Prop            | Type                              | Default        | Description                                   |
+| --------------- | --------------------------------- | -------------- | --------------------------------------------- |
+| `defaultValue`  | `string`                          | `undefined`    | ID of the initially active tab (uncontrolled) |
+| `value`         | `string`                          | `undefined`    | Currently active tab ID (controlled)          |
+| `onValueChange` | `(value: string) => void`         | `undefined`    | Called when the active tab changes            |
+| `disabled`      | `boolean`                         | `false`        | Disables all tabs when true                   |
+| `orientation`   | `"horizontal" \| "vertical"`      | `"horizontal"` | Layout orientation                            |
+| `dir`           | `"ltr" \| "rtl"`                  | `"ltr"`        | Text direction                                |
 
 ### `<Tabs.List>`
 
 Container for tab buttons that manages keyboard navigation.
 
-| Prop   | Type      | Default | Description                                              |
-| ------ | --------- | ------- | -------------------------------------------------------- |
-| `loop` | `boolean` | `true`  | Whether keyboard navigation loops from last to first tab |
+| Prop              | Type      | Default | Description                                                  |
+| ----------------- | --------- | ------- | ------------------------------------------------------------ |
+| `loop`            | `boolean` | `true`  | Whether keyboard navigation loops from last to first tab     |
+| `activateOnFocus` | `boolean` | `true`  | Whether arrow-key focus also activates the newly focused tab |
 
 ### `<Tabs.Tab>`
 
@@ -124,8 +134,11 @@ Content panel associated with a specific tab.
 | Prop                   | Type               | Default  | Description                                       |
 | ---------------------- | ------------------ | -------- | ------------------------------------------------- |
 | `value`                | `string`           | -        | **Required.** ID of the tab this panel belongs to |
-| `forceMount`           | `boolean`          | `false`  | Whether to force mounting when tab is inactive    |
+| `forceMount`           | `boolean`          | `false`  | Whether to keep the panel mounted when inactive   |
 | `forceBackgroundMount` | `"once" \| "none"` | `"none"` | Background mounting strategy for performance      |
+
+Inactive kept panels remain mounted for compatibility, but are hidden from
+layout and assistive technology until their tab is active.
 
 ## Usage Patterns
 
@@ -199,7 +212,7 @@ import { Tabs } from "@telegraph/tabs";
 import { useState } from "react";
 
 export const ControlledTabs = () => {
-  const [activeTab, setActiveTab] = useState("tab1");
+  const [activeTab, setActiveTab] = useState<string | null>("tab1");
 
   return (
     <div>
@@ -306,7 +319,7 @@ export const OptimizedTabs = () => (
       <LargeDataTable />
     </Tabs.Panel>
 
-    {/* Render once on component mount */}
+    {/* Keep mounted in the background when inactive */}
     <Tabs.Panel value="charts" forceBackgroundMount="once">
       <ExpensiveCharts />
     </Tabs.Panel>
@@ -325,7 +338,7 @@ export const DynamicTabs = () => {
     { id: "tab1", title: "Tab 1", content: "Content 1" },
     { id: "tab2", title: "Tab 2", content: "Content 2" },
   ]);
-  const [activeTab, setActiveTab] = useState("tab1");
+  const [activeTab, setActiveTab] = useState<string | null>("tab1");
 
   const addTab = () => {
     const newId = `tab${tabs.length + 1}`;
@@ -344,8 +357,8 @@ export const DynamicTabs = () => {
     const newTabs = tabs.filter((tab) => tab.id !== tabId);
     setTabs(newTabs);
 
-    if (activeTab === tabId && newTabs.length > 0) {
-      setActiveTab(newTabs[0].id);
+    if (activeTab === tabId) {
+      setActiveTab(newTabs[0]?.id ?? null);
     }
   };
 
@@ -396,7 +409,7 @@ export const FormTabs = () => {
     preferences: { theme: "light", notifications: true },
     billing: { plan: "free", cardNumber: "" },
   });
-  const [currentTab, setCurrentTab] = useState("personal");
+  const [currentTab, setCurrentTab] = useState<string | null>("personal");
 
   const updateFormData = (section: string, data: any) => {
     setFormData((prev) => ({
@@ -602,7 +615,7 @@ import { BarChart, Bell, Settings, Users } from "lucide-react";
 import { useEffect, useState } from "react";
 
 export const DashboardTabs = () => {
-  const [activeTab, setActiveTab] = useState("overview");
+  const [activeTab, setActiveTab] = useState<string | null>("overview");
   const [notifications, setNotifications] = useState(3);
 
   // Simulate notification updates
@@ -693,7 +706,7 @@ import { useState } from "react";
 
 export const MediaLibrary = () => {
   const [selectedFiles, setSelectedFiles] = useState([]);
-  const [currentTab, setCurrentTab] = useState("documents");
+  const [currentTab, setCurrentTab] = useState<string | null>("documents");
 
   const fileTypes = {
     documents: {
@@ -769,7 +782,7 @@ export const MediaLibrary = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/tabs)
-- [Radix UI Tabs](https://www.radix-ui.com/primitives/docs/components/tabs) - Base primitive
+- [Base UI Tabs](https://base-ui.com/react/components/tabs) - Base primitive
 
 ## Contributing
 

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -32,7 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-tabs": "^1.1.13",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -1,28 +1,24 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
 } from "@telegraph/helpers";
 import { MenuItem } from "@telegraph/menu";
-import React from "react";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
 
-/**
- * Props for the Tab component
- * @property {string} value - Unique identifier for the tab
- * @property {React.ReactNode} children - Content to display in the tab
- * @property {boolean} disabled - Whether this tab is disabled
- * @property {() => void} onClick - Additional onClick handler
- * @property {TabIconProps} leadingIcon - Icon to display on the left side of the tab
- * @property {TabIconProps} trailingIcon - Icon to display on the right side of the tab
- */
+type BaseTabRenderProps = ComponentPropsWithoutRef<"button"> & {
+  ref?: Ref<HTMLElement>;
+};
+
+type BaseTabState = {
+  active: boolean;
+};
+
 export type TabProps<T extends TgphElement = "button"> = {
   value: string;
 } & TgphComponentProps<typeof MenuItem<T>>;
 
-/**
- * Tab component that uses RadixTabs.Trigger with MenuItem styling
- */
 const Tab = <T extends TgphElement = "button">({
   disabled = false,
   value,
@@ -47,39 +43,46 @@ const Tab = <T extends TgphElement = "button">({
     : icon
       ? ({ ...defaultIconProps, ...icon } as const)
       : undefined;
+  const combinedTrailingIcon = trailingIcon
+    ? ({ ...defaultIconProps, ...trailingIcon } as const)
+    : undefined;
+  const menuItemProps = props as TgphComponentProps<typeof MenuItem<T>>;
+  // Base UI renders a native button by default; only opt out when Telegraph's
+  // polymorphic `as` prop means MenuItem owns the element type.
+  const nativeButton = !props.as || props.as === "button";
 
   return (
-    <RadixTabs.Trigger
+    <BaseTabs.Tab
       value={value}
       disabled={disabled}
       onClick={onClick}
-      asChild
-    >
-      <RefToTgphRef>
-        <MenuItem
-          leadingIcon={combinedLeadingIcon}
-          trailingIcon={
-            trailingIcon && { ...defaultIconProps, ...trailingIcon }
-          }
-          disabled={disabled}
-          py="4"
-          px="2"
-          fontWeight="medium"
-          position="relative"
-          data-tgph-tab=""
-          gap="2"
-          color="gray"
-          size="1"
-          // Important for styling the active color
-          textProps={{
-            "data-tgph-tab-text": "",
-          }}
-          {...props}
-        >
-          {children}
-        </MenuItem>
-      </RefToTgphRef>
-    </RadixTabs.Trigger>
+      nativeButton={nativeButton}
+      render={createTgphBaseUIRender<BaseTabRenderProps, BaseTabState>(
+        (state) => (
+          <MenuItem<T>
+            leadingIcon={combinedLeadingIcon}
+            trailingIcon={combinedTrailingIcon}
+            disabled={disabled}
+            py="4"
+            px="2"
+            fontWeight="medium"
+            position="relative"
+            data-tgph-tab=""
+            data-state={state.active ? "active" : "inactive"}
+            gap="2"
+            color="gray"
+            size="1"
+            // Important for styling the active color
+            textProps={{
+              "data-tgph-tab-text": "",
+            }}
+            {...menuItemProps}
+          >
+            {children}
+          </MenuItem>
+        ),
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/TabList/TabList.tsx
+++ b/packages/tabs/src/TabList/TabList.tsx
@@ -1,19 +1,28 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
-import React from "react";
+import { type ComponentProps } from "react";
 
-export type TabListProps = TgphComponentProps<typeof Stack> &
-  React.ComponentProps<typeof RadixTabs.List>;
+type BaseTabsListProps = ComponentProps<typeof BaseTabs.List>;
+export type TabListProps = TgphComponentProps<typeof Stack> & {
+  activateOnFocus?: BaseTabsListProps["activateOnFocus"];
+  loop?: BaseTabsListProps["loopFocus"];
+};
 
-/**
- * Container component for Tab components
- * Renders a Radix TabsList
- */
-const TabList = ({ children, loop = true, ...props }: TabListProps) => {
+const TabList = ({
+  children,
+  loop = true,
+  activateOnFocus = true,
+  ...props
+}: TabListProps) => {
   return (
-    <RadixTabs.List asChild loop={loop}>
-      <RefToTgphRef>
+    <BaseTabs.List
+      activateOnFocus={activateOnFocus}
+      loopFocus={loop}
+      render={createTgphBaseUIRender(
         <Stack
           flexDirection={"row"}
           spacing="2"
@@ -26,9 +35,9 @@ const TabList = ({ children, loop = true, ...props }: TabListProps) => {
           {...props}
         >
           {children}
-        </Stack>
-      </RefToTgphRef>
-    </RadixTabs.List>
+        </Stack>,
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/Tabs/TabPanel.tsx
+++ b/packages/tabs/src/Tabs/TabPanel.tsx
@@ -1,17 +1,24 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
-import React from "react";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
 
-export type TabPanelProps = TgphComponentProps<typeof Box> &
-  React.ComponentProps<typeof RadixTabs.Content> & {
-    forceBackgroundMount?: "once" | "none";
-  };
+type BasePanelRenderProps = ComponentPropsWithoutRef<"div"> & {
+  ref?: Ref<HTMLDivElement>;
+};
+type BasePanelState = {
+  hidden: boolean;
+};
 
-/**
- * Content panel associated with a Tab
- * Only renders when its associated tab is active
- */
+export type TabPanelProps = TgphComponentProps<typeof Box> & {
+  value: string;
+  forceMount?: boolean;
+  forceBackgroundMount?: "once" | "none";
+};
+
 const TabPanel = ({
   value,
   children,
@@ -19,32 +26,35 @@ const TabPanel = ({
   forceBackgroundMount = "none",
   ...props
 }: TabPanelProps) => {
-  const shouldForceMount = forceBackgroundMount === "once" || forceMount;
+  // Radix `forceMount` and Telegraph `forceBackgroundMount="once"` both kept
+  // inactive panels mounted; Base UI exposes that behavior as `keepMounted`.
+  const shouldKeepMounted = forceBackgroundMount === "once" || forceMount;
 
   return (
-    <RadixTabs.Content value={value} forceMount={shouldForceMount} asChild>
-      <RefToTgphRef>
-        <Box
-          data-tgph-tab-panel=""
-          {...props}
-          style={{
-            ...(shouldForceMount && {
-              visibility: "var(--radix-tabs-content-visibility, visible)",
-              overflow: "var(--radix-tabs-content-overflow, visible)",
-              height: "var(--radix-tabs-content-height, auto)",
-            }),
-            ...props.style,
-          }}
-          aria-hidden={
-            shouldForceMount
-              ? "var(--radix-tabs-content-aria-hidden, false)"
-              : undefined
-          }
-        >
-          {children}
-        </Box>
-      </RefToTgphRef>
-    </RadixTabs.Content>
+    <BaseTabs.Panel
+      value={value}
+      keepMounted={shouldKeepMounted}
+      render={createTgphBaseUIRender<BasePanelRenderProps, BasePanelState>(
+        (state) => (
+          <Box
+            data-tgph-tab-panel=""
+            data-state={state.hidden ? "inactive" : "active"}
+            {...props}
+            style={{
+              ...(shouldKeepMounted && {
+                visibility: state.hidden ? "hidden" : "visible",
+                overflow: state.hidden ? "hidden" : "visible",
+                height: state.hidden ? 0 : "auto",
+              }),
+              ...props.style,
+            }}
+            aria-hidden={shouldKeepMounted && state.hidden ? true : undefined}
+          >
+            {children}
+          </Box>
+        ),
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/Tabs/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs/Tabs.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Tabs } from "../index";
+
+const TabsFixture = () => {
+  return (
+    <Tabs defaultValue="tab1">
+      <Tabs.List>
+        <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+        <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        <Tabs.Tab value="tab3" disabled>
+          Disabled Tab
+        </Tabs.Tab>
+      </Tabs.List>
+
+      <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      <Tabs.Panel value="tab3">Disabled panel</Tabs.Panel>
+    </Tabs>
+  );
+};
+
+describe("Tabs", () => {
+  it("renders the default tab with Telegraph and Radix-compatible state attributes", () => {
+    render(<TabsFixture />);
+
+    const activeTab = screen.getByRole("tab", { name: "First Tab" });
+
+    expect(activeTab).toHaveAttribute("data-tgph-tab", "");
+    expect(activeTab).toHaveAttribute("data-active", "");
+    expect(activeTab).toHaveAttribute("data-state", "active");
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
+  });
+
+  it("supports controlled values and change callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledTabs = () => {
+      const [value, setValue] = useState("tab1");
+
+      return (
+        <Tabs
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue);
+          }}
+        >
+          <Tabs.List>
+            <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+            <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+          <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+        </Tabs>
+      );
+    };
+
+    render(<ControlledTabs />);
+
+    await user.click(screen.getByRole("tab", { name: "Second Tab" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("tab2");
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("does not forward Base UI-only cleared selection changes", async () => {
+    const onValueChange = vi.fn();
+
+    render(
+      <Tabs defaultValue="missing-tab" onValueChange={onValueChange}>
+        <Tabs.List>
+          <Tabs.Tab value="tab1" disabled>
+            First Tab
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    await waitFor(() => {
+      expect(onValueChange).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not auto-select a tab when no default or controlled value is provided", () => {
+    render(
+      <Tabs>
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole("tab", { name: "First Tab" })).toHaveAttribute(
+      "data-state",
+      "inactive",
+    );
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "inactive",
+    );
+    expect(screen.queryByRole("tabpanel")).not.toBeInTheDocument();
+  });
+
+  it("does not activate disabled tabs", async () => {
+    const user = userEvent.setup();
+
+    render(<TabsFixture />);
+
+    const disabledTab = screen.getByRole("tab", { name: "Disabled Tab" });
+    await user.click(disabledTab);
+
+    expect(disabledTab).toHaveAttribute("data-disabled", "");
+    expect(screen.getByRole("tab", { name: "First Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
+  });
+
+  it("activates tabs with arrow-key focus by default", async () => {
+    const user = userEvent.setup();
+
+    render(<TabsFixture />);
+
+    screen.getByRole("tab", { name: "First Tab" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("respects disabled keyboard looping", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="tab2">
+        <Tabs.List loop={false}>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2">Second panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    screen.getByRole("tab", { name: "Second Tab" }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("tab", { name: "Second Tab" })).toHaveAttribute(
+      "data-state",
+      "active",
+    );
+    expect(screen.getByRole("tabpanel")).toHaveTextContent("Second panel");
+  });
+
+  it("keeps forceBackgroundMount panels mounted and hidden while inactive", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tabs defaultValue="tab1">
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+          <Tabs.Tab value="tab2">Second Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+        <Tabs.Panel value="tab2" forceBackgroundMount="once">
+          Second panel
+        </Tabs.Panel>
+      </Tabs>,
+    );
+
+    const inactivePanel = screen
+      .getByText("Second panel")
+      .closest("[data-tgph-tab-panel]");
+
+    expect(inactivePanel).toHaveAttribute("data-state", "inactive");
+    expect(inactivePanel).toHaveAttribute("hidden");
+    expect(inactivePanel).toHaveAttribute("aria-hidden", "true");
+    expect(inactivePanel).toHaveStyle({
+      height: "0px",
+      overflow: "hidden",
+      visibility: "hidden",
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Second Tab" }));
+
+    expect(inactivePanel).toHaveAttribute("data-state", "active");
+    expect(inactivePanel).not.toHaveAttribute("hidden");
+    expect(inactivePanel).not.toHaveAttribute("aria-hidden");
+    expect(inactivePanel).toHaveStyle({
+      height: "auto",
+      overflow: "visible",
+      visibility: "visible",
+    });
+  });
+
+  it("forwards tgphRef through Base UI render props", () => {
+    const rootRef = createRef<HTMLDivElement>();
+    const tabRef = createRef<HTMLButtonElement>();
+
+    render(
+      <Tabs defaultValue="tab1" data-testid="tabs-root" tgphRef={rootRef}>
+        <Tabs.List>
+          <Tabs.Tab value="tab1" tgphRef={tabRef}>
+            First Tab
+          </Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    expect(rootRef.current).toBe(screen.getByTestId("tabs-root"));
+    expect(tabRef.current).toBe(screen.getByRole("tab", { name: "First Tab" }));
+  });
+});

--- a/packages/tabs/src/Tabs/Tabs.tsx
+++ b/packages/tabs/src/Tabs/Tabs.tsx
@@ -1,35 +1,62 @@
-import * as RadixTabs from "@radix-ui/react-tabs";
-import { RefToTgphRef, TgphComponentProps } from "@telegraph/helpers";
+import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
 import { Box } from "@telegraph/layout";
-import React from "react";
+import { type ComponentProps } from "react";
 
-export type TabsProps = TgphComponentProps<typeof Box> &
-  React.ComponentProps<typeof RadixTabs.Root>;
+type BaseTabsRootProps = ComponentProps<typeof BaseTabs.Root>;
+type TabsValue = string;
+type TabsValueChangeHandler<Value extends TabsValue> = {
+  bivarianceHack(value: Value): void;
+}["bivarianceHack"];
 
-/**
- * Root component for Tabs
- * Provides context for tab state management and renders child components
- */
-const Tabs = ({
+export type TabsProps<Value extends TabsValue = string> = TgphComponentProps<
+  typeof Box
+> & {
+  defaultValue?: Value;
+  orientation?: BaseTabsRootProps["orientation"];
+  value?: Value;
+  onValueChange?: TabsValueChangeHandler<Value>;
+};
+
+const Tabs = <Value extends TabsValue = string>({
   children,
   defaultValue,
   value,
   onValueChange,
+  orientation,
   ...props
-}: TabsProps) => {
+}: TabsProps<Value>) => {
+  // Base UI uses `null` for "no tab selected"; keep defaultValue undefined
+  // when controlled so React does not see both controlled and default values.
+  const baseDefaultValue =
+    defaultValue ?? (value === undefined ? null : undefined);
+  const handleValueChange: BaseTabsRootProps["onValueChange"] | undefined =
+    onValueChange
+      ? (nextValue) => {
+          // Base UI can report `null` when it cannot resolve an active tab.
+          // Radix-backed Telegraph tabs only notified consumers with string
+          // tab values, so keep that Base UI state internal for compatibility.
+          if (typeof nextValue === "string") {
+            onValueChange(nextValue as Value);
+          }
+        }
+      : undefined;
+
   return (
-    <RadixTabs.Root
-      defaultValue={defaultValue}
+    <BaseTabs.Root
+      defaultValue={baseDefaultValue}
       value={value}
-      onValueChange={onValueChange}
-      asChild
-    >
-      <RefToTgphRef>
+      onValueChange={handleValueChange}
+      orientation={orientation}
+      render={createTgphBaseUIRender(
         <Box data-tgph-tabs="" {...props}>
           {children}
-        </Box>
-      </RefToTgphRef>
-    </RadixTabs.Root>
+        </Box>,
+      )}
+    />
   );
 };
 

--- a/packages/tabs/src/default.css
+++ b/packages/tabs/src/default.css
@@ -1,10 +1,11 @@
 /* Active tab style - orange underline */
-[data-tgph-tab][data-state="active"]::after {
+[data-tgph-tab][data-state="active"]::after,
+[data-tgph-tab][data-active]::after {
   animation: tabActivate 0.15s cubic-bezier(0.4, 0, 0.2, 1);
   background-color: var(--tgph-accent-9, #ff4f00);
   bottom: calc(var(--tgph-spacing-1) * -1);
   border-radius: 1px;
-  content: '';
+  content: "";
   height: 1px;
   left: 0;
   position: absolute;
@@ -25,34 +26,30 @@
 }
 
 /* Active tab text and icon color */
-[data-tgph-tab][data-state="active"] [data-tgph-tab-text] {
-  color: var(--tgph-accent-11, #D13415);
+[data-tgph-tab][data-state="active"] [data-tgph-tab-text],
+[data-tgph-tab][data-active] [data-tgph-tab-text] {
+  color: var(--tgph-accent-11, #d13415);
 }
 
 /* Active tab icon color */
-[data-tgph-tab][data-state="active"] [data-tgph-tab-icon] {
-  color: var(--tgph-accent-10, #DD4425);
+[data-tgph-tab][data-state="active"] [data-tgph-tab-icon],
+[data-tgph-tab][data-active] [data-tgph-tab-icon] {
+  color: var(--tgph-accent-10, #dd4425);
 }
 
 /* Disabled tab icon color */
 [data-tgph-tab][data-disabled] [data-tgph-tab-icon] {
-  color: var(--tgph-gray-7, #CDCED6);
+  color: var(--tgph-gray-7, #cdced6);
 }
 
 /* Disabled tab text color */
 [data-tgph-tab][data-disabled] [data-tgph-tab-text] {
-  color: var(--tgph-gray-9, #8B8D98);
+  color: var(--tgph-gray-9, #8b8d98);
 }
 
-/* Background rendering styles for TabPanel */
+/* Background rendering styles for force-mounted TabPanel */
 [data-tgph-tab-panel][data-state="inactive"] {
-  --radix-tabs-content-visibility: hidden;
-  --radix-tabs-content-overflow: hidden;
-  --radix-tabs-content-height: 0;
-}
-
-[data-tgph-tab-panel][data-state="active"] {
-  --radix-tabs-content-visibility: visible;
-  --radix-tabs-content-overflow: visible;
-  --radix-tabs-content-height: auto;
+  visibility: hidden;
+  overflow: hidden;
+  height: 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3566,32 +3566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tabs@npm:^1.1.13":
-  version: 1.1.13
-  resolution: "@radix-ui/react-tabs@npm:1.1.13"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/a3c78cd8c30dcb95faf1605a8424a1a71dab121dfa6e9c0019bb30d0f36d882762c925b17596d4977990005a255d8ddc0b7454e4f83337fe557b45570a2d8058
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-toggle-group@npm:^1.1.11":
   version: 1.1.11
   resolution: "@radix-ui/react-toggle-group@npm:1.1.11"
@@ -4883,9 +4857,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/tabs@workspace:packages/tabs"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-tabs": "npm:^1.1.13"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #838.
- Linear: [KNO-13666](https://linear.app/knock/issue/KNO-13666).

## What changed

- Migrates `@telegraph/tabs` from Radix Tabs to Base UI Tabs primitives.
- Preserves the public string-value API, `tgphRef`, `loop`, `forceMount`, Telegraph data attributes, and Radix-compatible `data-state`.
- Keeps the keep-mounted panel style inline and updates the Tabs README reference to Base UI.
- Adds package tests and a changeset.

## Why

- Removes the Tabs Radix runtime dependency without changing consumer-facing behavior or visuals.
- Exercises the shared Base UI render bridge before deeper component migrations use it.

## Verification

- `yarn test packages/tabs/src/Tabs/Tabs.test.tsx`
- `yarn workspace @telegraph/tabs build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
