### PR TITLE
refactor(radio): migrate RadioCards to Base UI

### DIFF
--- a/.changeset/fresh-radios-shift.md
+++ b/.changeset/fresh-radios-shift.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/radio": minor
+---
+
+Migrate RadioCards from Radix Radio Group to Base UI Radio primitives while preserving Telegraph visual states, `tgphRef` support, orientation, looping, and RTL keyboard behavior. The documented option title and description types now reflect ReactNode support.

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -75,6 +75,8 @@ export const ActionSelector = () => {
 ### `<RadioCards>`
 
 The main component that renders a radio group with card-style options.
+RadioCards is backed by Base UI Radio primitives and keeps the Telegraph public
+API, styling hooks, and `tgphRef` behavior stable.
 
 | Prop            | Type                                                     | Default     | Description                          |
 | --------------- | -------------------------------------------------------- | ----------- | ------------------------------------ |
@@ -88,8 +90,8 @@ The main component that renders a radio group with card-style options.
 ```tsx
 type RadioOption = {
   value: string;
-  title?: string;
-  description?: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
   icon?: { icon: LucideIcon; alt: string };
   // Additional RadioCards.Item props
 };
@@ -100,7 +102,7 @@ type RadioOption = {
 For custom layouts, use the individual components:
 
 - **`<RadioCards.Root>`** - Radio group container
-- **`<RadioCards.Item>`** - Individual radio button item
+- **`<RadioCards.Item>`** - Individual radio button item rendered as a Telegraph button
 - **`<RadioCards.ItemTitle>`** - Title text component
 - **`<RadioCards.ItemDescription>`** - Description text component
 - **`<RadioCards.ItemIcon>`** - Icon component
@@ -322,8 +324,8 @@ export const ConditionalRadio = ({ userPlan, options }) => {
 ### Loading States
 
 ```tsx
-import { RadioCards } from "@telegraph/radio";
 import { Box, Stack } from "@telegraph/layout";
+import { RadioCards } from "@telegraph/radio";
 
 export const RadioCardsWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -446,32 +448,32 @@ Individual radio button item.
 
 Title text component for radio items.
 
-| Prop       | Type                                  | Default     | Description        |
-| ---------- | ------------------------------------- | ----------- | ------------------ |
-| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"` | Text size |
-| `weight`   | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight        |
-| `children` | `ReactNode`                           | -           | Title text content |
+| Prop       | Type                                                                 | Default    | Description        |
+| ---------- | -------------------------------------------------------------------- | ---------- | ------------------ |
+| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"`      | Text size          |
+| `weight`   | `"regular" \| "medium" \| "semi-bold" \| "bold"`                     | `"medium"` | Font weight        |
+| `children` | `ReactNode`                                                          | -          | Title text content |
 
 ### `<RadioCards.ItemDescription>`
 
 Description text component for radio items.
 
-| Prop       | Type                              | Default  | Description              |
-| ---------- | --------------------------------- | -------- | ------------------------ |
-| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"0"` | Text size |
-| `color`    | `"default" \| "gray" \| "red" \| "beige" \| "blue" \| "green" \| "yellow" \| "purple" \| "accent" \| "white" \| "black" \| "disabled"` | `"gray"` | Text color |
-| `children` | `ReactNode`                       | -        | Description text content |
+| Prop       | Type                                                                                                                                   | Default  | Description              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------ |
+| `size`     | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"`                                                                   | `"0"`    | Text size                |
+| `color`    | `"default" \| "gray" \| "red" \| "beige" \| "blue" \| "green" \| "yellow" \| "purple" \| "accent" \| "white" \| "black" \| "disabled"` | `"gray"` | Text color               |
+| `children` | `ReactNode`                                                                                                                            | -        | Description text content |
 
 ### `<RadioCards.ItemIcon>`
 
 Icon component for radio items.
 
-| Prop    | Type                                     | Default  | Description                   |
-| ------- | ---------------------------------------- | -------- | ----------------------------- |
-| `icon`  | `LucideIcon`                             | -        | Lucide icon component         |
-| `alt`   | `string`                                 | -        | Alternative text for the icon |
-| `size`  | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"` | `"2"` | Icon size |
-| `color` | `"default" \| "gray" \| "accent" \| "red" \| "blue" \| "green" \| "yellow" \| "purple" \| "beige" \| "white" \| "black" \| "disabled"` | `"gray"` | Icon color |
+| Prop    | Type                                                                                                                                   | Default  | Description                   |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| `icon`  | `LucideIcon`                                                                                                                           | -        | Lucide icon component         |
+| `alt`   | `string`                                                                                                                               | -        | Alternative text for the icon |
+| `size`  | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| "6" \| "7" \| "8" \| "9"`                                                                   | `"2"`    | Icon size                     |
+| `color` | `"default" \| "gray" \| "accent" \| "red" \| "blue" \| "green" \| "yellow" \| "purple" \| "beige" \| "white" \| "black" \| "disabled"` | `"gray"` | Icon color                    |
 
 ## Examples
 
@@ -541,7 +543,11 @@ export const PricingPlanSelector = () => {
                 <RadioCards.ItemTitle size="3" weight="semi-bold">
                   {plan.title}
                 </RadioCards.ItemTitle>
-                {plan.popular && <Tag size="0" color="accent">Popular</Tag>}
+                {plan.popular && (
+                  <Tag size="0" color="accent">
+                    Popular
+                  </Tag>
+                )}
               </Stack>
 
               <Text as="span" size="5" weight="bold">
@@ -630,7 +636,7 @@ export const DeliveryOptionsForm = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/radio)
-- [Radix UI Radio Group](https://www.radix-ui.com/primitives/docs/components/radio-group)
+- [Base UI Radio](https://base-ui.com/react/components/radio)
 
 ## Contributing
 

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -31,7 +31,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-radio-group": "^1.3.8",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/radio/src/RadioCards/RadioCards.helpers.ts
+++ b/packages/radio/src/RadioCards/RadioCards.helpers.ts
@@ -1,0 +1,217 @@
+import type { TextDirection } from "@base-ui/react/direction-provider";
+import type { KeyboardEvent, ReactNode } from "react";
+
+type NavigationOrientation = "horizontal" | "vertical";
+
+type RadioCardKeyboardEvent = KeyboardEvent<HTMLDivElement> & {
+  baseUIHandlerPrevented?: boolean;
+  preventBaseUIHandler: () => void;
+};
+
+const getHorizontalForwardKey = (dir: TextDirection | undefined) => {
+  return dir === "rtl" ? "ArrowLeft" : "ArrowRight";
+};
+
+const getHorizontalBackwardKey = (dir: TextDirection | undefined) => {
+  return dir === "rtl" ? "ArrowRight" : "ArrowLeft";
+};
+
+const isOrientationBlockedKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+) => {
+  // Radix ignored cross-axis arrows for fixed-orientation groups, while Base UI
+  // would otherwise continue moving focus through the radio group.
+  if (orientation === "horizontal") {
+    return key === "ArrowUp" || key === "ArrowDown";
+  }
+
+  if (orientation === "vertical") {
+    return key === "ArrowLeft" || key === "ArrowRight";
+  }
+
+  return false;
+};
+
+const isForwardNavigationKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  if (orientation === "vertical") {
+    return key === "ArrowDown";
+  }
+
+  return key === getHorizontalForwardKey(dir) || key === "ArrowDown";
+};
+
+const isBackwardNavigationKey = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  if (orientation === "vertical") {
+    return key === "ArrowUp";
+  }
+
+  return key === getHorizontalBackwardKey(dir) || key === "ArrowUp";
+};
+
+const getNavigationDirection = (
+  key: string,
+  orientation: NavigationOrientation | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const resolvedOrientation = orientation ?? "horizontal";
+
+  // Collapse vertical groups and RTL horizontal groups into one signed movement
+  // value so the wrapping logic below does not need separate branches.
+  if (isForwardNavigationKey(key, resolvedOrientation, dir)) {
+    return 1;
+  }
+
+  if (isBackwardNavigationKey(key, resolvedOrientation, dir)) {
+    return -1;
+  }
+
+  return 0;
+};
+
+const getEnabledRadios = (root: HTMLElement) => {
+  return Array.from(
+    root.querySelectorAll<HTMLElement>('[role="radio"]'),
+  ).filter(
+    (radio) =>
+      !radio.matches(":disabled, [data-disabled], [aria-disabled='true']"),
+  );
+};
+
+const getCurrentRadio = (root: HTMLElement, enabledRadios: HTMLElement[]) => {
+  const activeElement = root.ownerDocument.activeElement;
+
+  if (
+    activeElement instanceof HTMLElement &&
+    root.contains(activeElement) &&
+    activeElement.getAttribute("role") === "radio"
+  ) {
+    // Prefer the focused radio because keyboard navigation should continue from
+    // the user's current roving focus position, not only from the checked value.
+    return activeElement;
+  }
+
+  return (
+    enabledRadios.find(
+      (radio) => radio.getAttribute("aria-checked") === "true",
+    ) ?? null
+  );
+};
+
+const getNextRadio = (
+  event: RadioCardKeyboardEvent,
+  orientation: NavigationOrientation | undefined,
+  loop: boolean | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const navigationDirection = getNavigationDirection(
+    event.key,
+    orientation,
+    dir,
+  );
+
+  if (navigationDirection === 0) {
+    return null;
+  }
+
+  const enabledRadios = getEnabledRadios(event.currentTarget);
+  const currentRadio = getCurrentRadio(event.currentTarget, enabledRadios);
+  const currentIndex = currentRadio ? enabledRadios.indexOf(currentRadio) : -1;
+
+  if (currentIndex === -1) {
+    // If the selected/focused item is disabled, keep keyboard handling inside the
+    // compatibility shim and restart navigation from the appropriate enabled edge.
+    return navigationDirection === 1
+      ? (enabledRadios[0] ?? null)
+      : (enabledRadios[enabledRadios.length - 1] ?? null);
+  }
+
+  const nextIndex = currentIndex + navigationDirection;
+
+  if (nextIndex >= 0 && nextIndex < enabledRadios.length) {
+    return enabledRadios[nextIndex] ?? null;
+  }
+
+  if (loop === false) {
+    // Preserve Radix's `loop={false}` behavior by keeping focus on the edge
+    // option while still blocking Base UI from wrapping internally.
+    return currentRadio;
+  }
+
+  return navigationDirection === 1
+    ? enabledRadios[0]
+    : enabledRadios[enabledRadios.length - 1];
+};
+
+const preventBaseUIKeyboardNavigation = (event: RadioCardKeyboardEvent) => {
+  event.preventBaseUIHandler();
+};
+
+const syncRadioTabStops = (root: HTMLElement, activeRadio: HTMLElement) => {
+  // The selected radio is moved with click semantics for parity, then the
+  // roving tab stops are corrected so tabbing resumes from the focused item.
+  getEnabledRadios(root).forEach((radio) => {
+    radio.tabIndex = radio === activeRadio ? 0 : -1;
+  });
+
+  activeRadio.focus();
+};
+
+const handleCompatibilityKeyboardNavigation = (
+  event: RadioCardKeyboardEvent,
+  orientation: NavigationOrientation | undefined,
+  loop: boolean | undefined,
+  dir: TextDirection | undefined,
+) => {
+  const resolvedOrientation = orientation ?? "horizontal";
+
+  if (isOrientationBlockedKey(event.key, resolvedOrientation)) {
+    // Stop Base UI before it treats a blocked cross-axis arrow as navigation.
+    preventBaseUIKeyboardNavigation(event);
+    event.preventDefault();
+    return;
+  }
+
+  const nextRadio = getNextRadio(event, resolvedOrientation, loop, dir);
+
+  if (!nextRadio) {
+    return;
+  }
+
+  preventBaseUIKeyboardNavigation(event);
+  event.preventDefault();
+
+  if (nextRadio === event.target) {
+    syncRadioTabStops(event.currentTarget, nextRadio);
+    return;
+  }
+
+  const root = event.currentTarget;
+
+  nextRadio.click();
+  queueMicrotask(() => {
+    // Let Base UI process the click selection first, then repair focus and
+    // tabIndex after its internal radio state has settled.
+    syncRadioTabStops(root, nextRadio);
+  });
+};
+
+const shouldRenderRadioCardContent = (content: ReactNode) => {
+  return (
+    content !== null &&
+    content !== undefined &&
+    typeof content !== "boolean" &&
+    content !== ""
+  );
+};
+
+export { handleCompatibilityKeyboardNavigation, shouldRenderRadioCardContent };
+export type { RadioCardKeyboardEvent };

--- a/packages/radio/src/RadioCards/RadioCards.stories.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Bell, DoorClosed } from "lucide-react";
-import React from "react";
+import { useState } from "react";
 
 import { RadioCards as TelegraphRadioCards } from "./RadioCards";
 
@@ -25,27 +25,66 @@ export default meta;
 
 type StorybookRadioCardsType = StoryObj<typeof TelegraphRadioCards>;
 
+const DEFAULT_OPTIONS = [
+  {
+    icon: { icon: Bell, alt: "Bell" },
+    title: "Option 1",
+    description: "Description 1",
+    value: "1",
+  },
+  {
+    icon: { icon: DoorClosed, alt: "Door" },
+    title: "Option 2",
+    description: "Description 2",
+    value: "2",
+  },
+];
+
 export const RadioCards: StorybookRadioCardsType = {
   render: ({ direction }) => {
     //eslint-disable-next-line
-    const [value, setValue] = React.useState("1");
+    const [value, setValue] = useState("1");
     return (
       <TelegraphRadioCards
         value={value}
         onValueChange={(value) => setValue(value)}
         direction={direction}
+        options={DEFAULT_OPTIONS}
+      />
+    );
+  },
+};
+
+export const Vertical: StorybookRadioCardsType = {
+  render: () => {
+    //eslint-disable-next-line
+    const [value, setValue] = useState("1");
+    return (
+      <TelegraphRadioCards
+        value={value}
+        onValueChange={(value) => setValue(value)}
+        direction="column"
+        orientation="vertical"
+        options={DEFAULT_OPTIONS}
+      />
+    );
+  },
+};
+
+export const DisabledOption: StorybookRadioCardsType = {
+  render: () => {
+    //eslint-disable-next-line
+    const [value, setValue] = useState("1");
+    return (
+      <TelegraphRadioCards
+        value={value}
+        onValueChange={(value) => setValue(value)}
+        direction="row"
         options={[
+          DEFAULT_OPTIONS[0],
           {
-            icon: { icon: Bell, alt: "Bell" },
-            title: "Option 1",
-            description: "Description 1",
-            value: "1",
-          },
-          {
-            icon: { icon: DoorClosed, alt: "Door" },
-            title: "Option 2",
-            description: "Description 2",
-            value: "2",
+            ...DEFAULT_OPTIONS[1],
+            disabled: true,
           },
         ]}
       />

--- a/packages/radio/src/RadioCards/RadioCards.test.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.test.tsx
@@ -1,0 +1,387 @@
+// @vitest-environment jsdom
+import { DirectionProvider } from "@base-ui/react/direction-provider";
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { RadioCards } from "./RadioCards";
+
+afterEach(() => {
+  cleanup();
+});
+
+const radioOptions = [
+  {
+    title: "Option one",
+    description: "The first option",
+    value: "one",
+  },
+  {
+    title: "Option two",
+    description: "The second option",
+    value: "two",
+  },
+];
+
+describe("RadioCards", () => {
+  it("is accessible", async () => {
+    const { container } = render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    expectToHaveNoViolations(await axe(container));
+  });
+
+  it("renders the default value with Telegraph and Radix-compatible state attributes", () => {
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    expect(firstRadio).toHaveAttribute("data-tgph-radio-group-button");
+    expect(firstRadio).toHaveAttribute("aria-checked", "true");
+    expect(firstRadio).toHaveAttribute("data-checked", "");
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("aria-checked", "false");
+    expect(secondRadio).toHaveAttribute("data-unchecked", "");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+  });
+
+  it("supports controlled values and change callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledRadioCards = () => {
+      const [value, setValue] = useState("one");
+
+      return (
+        <RadioCards
+          aria-label="Delivery method"
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue);
+          }}
+          options={radioOptions}
+        />
+      );
+    };
+
+    render(<ControlledRadioCards />);
+
+    await user.click(screen.getByRole("radio", { name: /Option two/ }));
+
+    expect(onValueChange).toHaveBeenCalledWith("two");
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("does not select disabled items", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        onValueChange={onValueChange}
+        options={[
+          radioOptions[0],
+          {
+            ...radioOptions[1],
+            disabled: true,
+          },
+        ]}
+      />,
+    );
+
+    const disabledRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    expect(disabledRadio).toBeDisabled();
+    expect(disabledRadio).toHaveAttribute("data-disabled", "");
+
+    await user.click(disabledRadio);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("radio", { name: /Option one/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("moves from a disabled selected value to an enabled radio with keyboard navigation", async () => {
+    const onValueChange = vi.fn();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        onValueChange={onValueChange}
+        options={[
+          {
+            ...radioOptions[0],
+            disabled: true,
+          },
+          radioOptions[1],
+        ]}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(onValueChange).toHaveBeenCalledWith("two");
+    });
+
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+  });
+
+  it("selects the next radio with arrow-key navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    screen.getByRole("radio", { name: /Option one/ }).focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(screen.getByRole("radio", { name: /Option one/ })).toHaveAttribute(
+      "tabindex",
+      "-1",
+    );
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "data-state",
+      "checked",
+    );
+    expect(screen.getByRole("radio", { name: /Option two/ })).toHaveAttribute(
+      "tabindex",
+      "0",
+    );
+  });
+
+  it("uses horizontal arrow-key navigation by default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowDown}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowRight}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors inherited RTL direction for horizontal keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DirectionProvider direction="rtl">
+        <RadioCards
+          aria-label="Delivery method"
+          defaultValue="one"
+          loop={false}
+          options={radioOptions}
+        />
+      </DirectionProvider>,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowLeft}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors vertical orientation keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        orientation="vertical"
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("honors loop=false keyboard navigation", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        defaultValue="one"
+        loop={false}
+        options={radioOptions}
+      />,
+    );
+
+    const firstRadio = screen.getByRole("radio", { name: /Option one/ });
+    const secondRadio = screen.getByRole("radio", { name: /Option two/ });
+
+    firstRadio.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(firstRadio).toHaveAttribute("data-state", "checked");
+    expect(firstRadio).toHaveAttribute("tabindex", "0");
+    expect(secondRadio).toHaveAttribute("data-state", "unchecked");
+    expect(secondRadio).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowRight}");
+    await user.keyboard("{ArrowRight}");
+
+    expect(secondRadio).toHaveAttribute("data-state", "checked");
+    expect(secondRadio).toHaveAttribute("tabindex", "0");
+  });
+
+  it("participates in forms with hidden radio inputs", () => {
+    const { container } = render(
+      <form data-testid="form">
+        <RadioCards
+          aria-label="Delivery method"
+          defaultValue="two"
+          name="delivery"
+          options={radioOptions}
+        />
+      </form>,
+    );
+
+    const form = screen.getByTestId("form") as HTMLFormElement;
+    const selectedInput = container.querySelector(
+      'input[type="radio"][name="delivery"][value="two"]',
+    );
+
+    expect(selectedInput).toBeChecked();
+    expect(new FormData(form).get("delivery")).toBe("two");
+  });
+
+  it("renders numeric zero option title and description nodes", () => {
+    render(
+      <RadioCards
+        aria-label="Delivery method"
+        options={[
+          {
+            title: 0,
+            description: 0,
+            value: "zero",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getAllByText("0")).toHaveLength(2);
+  });
+
+  it("does not render empty string option title and description nodes", () => {
+    const { container } = render(
+      <RadioCards
+        aria-label="Delivery method"
+        options={[
+          {
+            title: "",
+            description: "",
+            value: "empty",
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-button-text]"),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector("[data-tgph-radio-card-description]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("forwards ref and tgphRef to the rendered radio button", () => {
+    const forwardedRef = createRef<HTMLButtonElement>();
+    const tgphRef = createRef<HTMLButtonElement>();
+
+    render(
+      <RadioCards.Root aria-label="Delivery method" defaultValue="one">
+        <RadioCards.Item value="one" ref={forwardedRef} tgphRef={tgphRef}>
+          Option one
+        </RadioCards.Item>
+      </RadioCards.Root>,
+    );
+
+    const radio = screen.getByRole("radio", { name: "Option one" });
+
+    expect(forwardedRef.current).toBe(radio);
+    expect(tgphRef.current).toBe(radio);
+  });
+});

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -1,71 +1,200 @@
-import * as RadioGroup from "@radix-ui/react-radio-group";
+import {
+  DirectionProvider,
+  type TextDirection,
+  useDirection,
+} from "@base-ui/react/direction-provider";
+import { Radio as BaseRadio } from "@base-ui/react/radio";
+import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
 import { Button } from "@telegraph/button";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
 } from "@telegraph/helpers";
 import type { Icon } from "@telegraph/icon";
 import { Box, Stack } from "@telegraph/layout";
-import React from "react";
+import {
+  type CSSProperties,
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+  forwardRef,
+} from "react";
 
-export type RootProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Root> &
-  TgphComponentProps<typeof Stack>;
+import {
+  type RadioCardKeyboardEvent,
+  handleCompatibilityKeyboardNavigation,
+  shouldRenderRadioCardContent,
+} from "./RadioCards.helpers";
 
-type RadioButtonInternalContext = {
-  value?: string;
+type BaseRadioGroupProps = ComponentPropsWithoutRef<typeof BaseRadioGroup>;
+
+type LegacyRadioGroupProps = {
+  // Kept for Radix API compatibility and enforced by the Telegraph wrapper
+  // because Base UI RadioGroup does not expose an orientation prop.
+  orientation?: "horizontal" | "vertical";
+  // Kept for Radix API compatibility and enforced by the Telegraph wrapper
+  // because Base UI RadioGroup does not expose a loop prop.
+  loop?: boolean;
+  // Kept for Radix API compatibility and forwarded through Base UI's
+  // DirectionProvider.
+  dir?: TextDirection;
 };
 
-const RadioButtonContext = React.createContext<RadioButtonInternalContext>({
-  value: "",
-});
+export type RootProps = Omit<
+  BaseRadioGroupProps,
+  | "children"
+  | "className"
+  | "defaultValue"
+  | "onValueChange"
+  | "render"
+  | "style"
+  | "value"
+> &
+  TgphComponentProps<typeof Stack> &
+  LegacyRadioGroupProps & {
+    defaultValue?: string;
+    value?: string | null;
+    onValueChange?: (value: string) => void;
+  };
 
-const Root = ({ value, children, onValueChange, ...props }: RootProps) => {
+type RootContentProps = RootProps;
+
+const RootContent = ({
+  value,
+  defaultValue,
+  children,
+  onValueChange,
+  disabled,
+  dir,
+  form,
+  inputRef,
+  loop,
+  name,
+  onKeyDown,
+  orientation,
+  readOnly,
+  required,
+  ...props
+}: RootContentProps) => {
+  const inheritedDir = useDirection();
+  const resolvedDir = dir ?? inheritedDir;
+  const handleValueChange: BaseRadioGroupProps["onValueChange"] | undefined =
+    onValueChange
+      ? (nextValue) => {
+          // Telegraph's public callback only emits concrete option values;
+          // ignore any Base UI callback value that does not match that contract.
+          if (typeof nextValue === "string") {
+            onValueChange(nextValue);
+          }
+        }
+      : undefined;
+
+  const handleKeyDown = (event: RadioCardKeyboardEvent) => {
+    onKeyDown?.(event);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    // Base UI handles radio roving focus differently than Radix, so run the
+    // compatibility shim after user handlers have had first chance to prevent.
+    handleCompatibilityKeyboardNavigation(
+      event,
+      orientation,
+      loop,
+      resolvedDir,
+    );
+  };
+
   return (
-    <RadioButtonContext.Provider value={{ value: value ?? "" }}>
-      <RadioGroup.Root
-        value={value}
-        onValueChange={onValueChange}
-        asChild
-        {...props}
-      >
-        <RefToTgphRef>
-          <Stack gap="1">{children}</Stack>
-        </RefToTgphRef>
-      </RadioGroup.Root>
-    </RadioButtonContext.Provider>
+    <BaseRadioGroup
+      value={value}
+      defaultValue={defaultValue}
+      onValueChange={handleValueChange}
+      disabled={disabled}
+      form={form}
+      inputRef={inputRef}
+      name={name}
+      readOnly={readOnly}
+      required={required}
+      render={createTgphBaseUIRender(
+        <Stack gap="1" dir={dir} onKeyDown={handleKeyDown} {...props}>
+          {children}
+        </Stack>,
+      )}
+    />
   );
 };
 
-export type ItemProps = React.ComponentPropsWithoutRef<typeof RadioGroup.Item>;
-type ItemRef = React.ElementRef<typeof RadioGroup.Item>;
-
-const Item = React.forwardRef<ItemRef, ItemProps>(
-  ({ children, style, ...props }, forwardedRef) => {
-    const { value: contextValue } = React.useContext(RadioButtonContext);
+const Root = ({ dir, ...props }: RootProps) => {
+  if (dir) {
     return (
-      <>
-        <RadioGroup.Item {...props} ref={forwardedRef} asChild>
-          <RefToTgphRef>
+      <DirectionProvider direction={dir}>
+        <RootContent dir={dir} {...props} />
+      </DirectionProvider>
+    );
+  }
+
+  return <RootContent {...props} />;
+};
+
+type BaseRadioRootProps = ComponentPropsWithoutRef<typeof BaseRadio.Root>;
+type BaseRadioRenderProps = ComponentPropsWithoutRef<"button"> & {
+  ref?: Ref<HTMLElement>;
+};
+type BaseRadioState = {
+  checked: boolean;
+  disabled: boolean;
+};
+
+const getRadioCardButtonStyle = (
+  style: CSSProperties | undefined,
+): CSSProperties =>
+  ({
+    "--tgph-button-active-shadow": "inset 0 0 0 1px var(--tgph-blue-8)",
+    ...style,
+  }) as CSSProperties;
+
+export type ItemProps = Omit<
+  BaseRadioRootProps,
+  "children" | "className" | "render" | "style" | "value"
+> & {
+  children?: ReactNode;
+  style?: CSSProperties;
+  tgphRef?: Ref<HTMLButtonElement>;
+  value: string;
+};
+type ItemRef = HTMLButtonElement;
+
+const Item = forwardRef<ItemRef, ItemProps>(
+  ({ children, style, tgphRef, ...props }, forwardedRef) => {
+    return (
+      <BaseRadio.Root
+        {...props}
+        ref={forwardedRef as Ref<HTMLElement>}
+        nativeButton
+        render={createTgphBaseUIRender<BaseRadioRenderProps, BaseRadioState>(
+          (state) => (
             <Button.Root
               variant="outline"
-              active={props.value === contextValue}
+              active={state.checked}
+              disabled={state.disabled}
               h="full"
               w="full"
               px="0"
               py="0"
               data-tgph-radio-group-button
-              style={{
-                "--tgph-button-active-shadow":
-                  "inset 0 0 0 1px var(--tgph-blue-8)",
-                ...style,
-              }}
+              data-state={state.checked ? "checked" : "unchecked"}
+              tgphRef={tgphRef}
+              style={getRadioCardButtonStyle(style)}
             >
               {children}
             </Button.Root>
-          </RefToTgphRef>
-        </RadioGroup.Item>
-      </>
+          ),
+        )}
+      />
     );
   },
 );
@@ -106,15 +235,15 @@ const ItemIcon = <T extends TgphElement = "span">(props: ItemIconProps<T>) => {
   return <Button.Icon color="gray" data-tgph-radio-card-icon {...props} />;
 };
 
-type DefaultIconProps = React.ComponentProps<typeof Icon>;
+type DefaultIconProps = ComponentProps<typeof Icon>;
 
-export type DefaultProps = React.ComponentPropsWithoutRef<typeof Root> & {
+export type DefaultProps = ComponentPropsWithoutRef<typeof Root> & {
   options: Array<
     {
-      title?: string;
-      description?: string;
+      title?: ReactNode;
+      description?: ReactNode;
       icon?: DefaultIconProps;
-    } & React.ComponentPropsWithoutRef<typeof Item>
+    } & ComponentPropsWithoutRef<typeof Item>
   >;
 };
 
@@ -122,27 +251,29 @@ const Default = ({ options, direction = "row", ...props }: DefaultProps) => {
   const isGroupHorizontal = direction === "row" || direction === "row-reverse";
   return (
     <Root direction={direction} {...props}>
-      {options.map((option) => (
-        <Item key={option.value} value={option.value}>
+      {options.map(({ title, description, icon, ...itemProps }) => (
+        <Item key={itemProps.value} {...itemProps}>
           <Stack
             direction={isGroupHorizontal ? "column" : "row"}
             align={isGroupHorizontal ? "flex-start" : "center"}
             p="3"
             w="full"
           >
-            {option.icon && (
+            {icon && (
               <Box
                 mb={isGroupHorizontal ? "2" : "0"}
                 mr={isGroupHorizontal ? "0" : "4"}
                 ml={isGroupHorizontal ? "0" : "1"}
               >
-                <ItemIcon {...option.icon} />
+                <ItemIcon {...icon} />
               </Box>
             )}
             <Stack direction="column" align="flex-start">
-              {option.title && <ItemTitle>{option.title}</ItemTitle>}
-              {option.description && (
-                <ItemDescription>{option.description}</ItemDescription>
+              {shouldRenderRadioCardContent(title) && (
+                <ItemTitle>{title}</ItemTitle>
+              )}
+              {shouldRenderRadioCardContent(description) && (
+                <ItemDescription>{description}</ItemDescription>
               )}
             </Stack>
           </Stack>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3481,34 +3481,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-radio-group@npm:^1.3.8":
-  version: 1.3.8
-  resolution: "@radix-ui/react-radio-group@npm:1.3.8"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    "@radix-ui/react-use-previous": "npm:1.1.1"
-    "@radix-ui/react-use-size": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/23af8e8b833da1fc4aa4e67c3607dedee4fc5b39278d2e2b820bec7f7b3c0891b006a8a35c57ba436ddf18735bbd8dad9a598d14632a328753a875fde447975c
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-roving-focus@npm:1.1.11":
   version: 1.1.11
   resolution: "@radix-ui/react-roving-focus@npm:1.1.11"
@@ -3711,19 +3683,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-previous@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-previous@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/52f1089d941491cd59b7f52a5679a14e9381711419a0557ce0f3bc9a4c117078224efec54dcced41a3653a13a386a7b6ec75435d61a273e8b9f5d00235f2b182
   languageName: node
   linkType: hard
 
@@ -4733,10 +4692,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/radio@workspace:packages/radio"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-radio-group": "npm:^1.3.8"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #839.
- Linear: [KNO-13667](https://linear.app/knock/issue/KNO-13667).

## What changed

- Migrates `RadioCards` from Radix Radio Group to Base UI Radio primitives.
- Moves keyboard compatibility logic into `RadioCards.helpers.ts`.
- Preserves Telegraph rendering, `tgphRef`, React `ref`, controlled value, disabled behavior, form behavior, and Radix-compatible state attributes.
- Keeps keyboard navigation inside the compatibility shim when the selected value points at a disabled item, falling back to the appropriate enabled edge.
- Renders valid falsy `ReactNode` title/description values such as numeric `0` while still omitting nullish, boolean, and empty-string content.
- Updates stories, README, dependencies, tests, and changeset.

## Why

- Removes the RadioCards Radix dependency while keeping published API, keyboard behavior, form semantics, and visuals stable.
- Keeps compatibility logic out of the main component file.
- Closes Cursor review findings around disabled selected values and falsy option content without changing the public API.

## Verification

- `yarn test packages/radio/src/RadioCards/RadioCards.test.tsx`
- `yarn workspace @telegraph/radio lint`
- `yarn workspace @telegraph/radio build`
- `yarn prettier --check packages/radio/src/RadioCards/RadioCards.helpers.ts packages/radio/src/RadioCards/RadioCards.tsx packages/radio/src/RadioCards/RadioCards.test.tsx`
- Stack-wide: `yarn build:packages`
- Stack-wide: `yarn lint`
