### PR TITLE
refactor(popover): migrate Popover to Base UI

### DIFF
--- a/.changeset/base-popovers-move.md
+++ b/.changeset/base-popovers-move.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/popover": minor
+---
+
+Migrate Popover internals from Radix UI to Base UI while preserving Telegraph styling, `tgphRef`, dismissal callbacks, focus callbacks, `avoidCollisions`, and `hideWhenDetached` compatibility. Also add shared Base UI compatibility helpers for migrated floating components.

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -21,6 +21,8 @@ npm install @telegraph/helpers
 ```tsx
 import { Button } from "@telegraph/button";
 import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
   PolymorphicProps,
   RefToTgphRef,
   TgphElement,
@@ -52,6 +54,12 @@ const [open, setOpen] = useControllableState({
   defaultProp: false,
   onChange: onOpenChange,
 });
+
+// Legacy Radix-style dismissal and animation compatibility for Base UI wrappers
+const shouldCancelDismiss = callLegacyDismissHandlers(eventDetails, {
+  onEscapeKeyDown,
+});
+const initial = { opacity: 0, ...getBaseUIMotionOffset(side) };
 ```
 
 ## API Reference
@@ -372,6 +380,35 @@ import type { ComponentProps } from "react";
     ),
   )}
 />;
+```
+
+### Base UI Compatibility Utilities
+
+Small helpers for preserving legacy Radix-style Telegraph behavior while
+wrapping Base UI primitives.
+
+```tsx
+import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+} from "@telegraph/helpers";
+
+const shouldCancelDismiss = callLegacyDismissHandlers(eventDetails, {
+  onEscapeKeyDown,
+  onPointerDownOutside,
+});
+
+const initial = {
+  opacity: 0,
+  ...getBaseUIMotionOffset(side),
+};
+
+const positionerStyle = getBaseUIPositionerVisibilityStyle({
+  anchorHidden,
+  hideWhenDetached,
+  zIndex: "var(--tgph-zIndex-tooltip)",
+});
 ```
 
 ## React Hooks

--- a/packages/helpers/src/base-ui/compatibility.test.ts
+++ b/packages/helpers/src/base-ui/compatibility.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+} from "./compatibility";
+
+describe("callLegacyDismissHandlers", () => {
+  it("calls escape handlers and returns whether they prevented dismissal", () => {
+    const event = new KeyboardEvent("keydown", { cancelable: true });
+    const onEscapeKeyDown = vi.fn((dismissEvent: KeyboardEvent) => {
+      dismissEvent.preventDefault();
+    });
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "escape-key" },
+      { onEscapeKeyDown },
+    );
+
+    expect(onEscapeKeyDown).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(true);
+  });
+
+  it("calls pointer and interact handlers for outside press dismissal", () => {
+    const event = new MouseEvent("mousedown", { cancelable: true });
+    const onPointerDownOutside = vi.fn();
+    const onInteractOutside = vi.fn((dismissEvent: Event) => {
+      dismissEvent.preventDefault();
+    });
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "outside-press" },
+      { onInteractOutside, onPointerDownOutside },
+    );
+
+    expect(onPointerDownOutside).toHaveBeenCalledWith(event);
+    expect(onInteractOutside).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(true);
+  });
+
+  it("calls focus and interact handlers for focus-out dismissal", () => {
+    const event = new FocusEvent("focusout", { cancelable: true });
+    const onFocusOutside = vi.fn();
+    const onInteractOutside = vi.fn();
+
+    const prevented = callLegacyDismissHandlers(
+      { event, reason: "focus-out" },
+      { onFocusOutside, onInteractOutside },
+    );
+
+    expect(onFocusOutside).toHaveBeenCalledWith(event);
+    expect(onInteractOutside).toHaveBeenCalledWith(event);
+    expect(prevented).toBe(false);
+  });
+});
+
+describe("getBaseUIMotionOffset", () => {
+  it("returns directional motion offsets", () => {
+    expect(getBaseUIMotionOffset("top")).toEqual({ y: -5 });
+    expect(getBaseUIMotionOffset("bottom", 8)).toEqual({ y: 8 });
+    expect(getBaseUIMotionOffset("left")).toEqual({ x: -5 });
+    expect(getBaseUIMotionOffset("right", 8)).toEqual({ x: 8 });
+    expect(getBaseUIMotionOffset("inline-start")).toEqual({});
+  });
+});
+
+describe("getBaseUIPositionerVisibilityStyle", () => {
+  it("only hides detached positioners when requested", () => {
+    expect(
+      getBaseUIPositionerVisibilityStyle({
+        anchorHidden: true,
+        hideWhenDetached: true,
+        zIndex: "var(--tgph-zIndex-tooltip)",
+      }),
+    ).toEqual({
+      visibility: "hidden",
+      zIndex: "var(--tgph-zIndex-tooltip)",
+    });
+
+    expect(
+      getBaseUIPositionerVisibilityStyle({
+        anchorHidden: true,
+        hideWhenDetached: false,
+      }),
+    ).toEqual({
+      visibility: undefined,
+      zIndex: undefined,
+    });
+  });
+});

--- a/packages/helpers/src/base-ui/compatibility.ts
+++ b/packages/helpers/src/base-ui/compatibility.ts
@@ -1,0 +1,155 @@
+import type { CSSProperties } from "react";
+
+const ANIMATION_OFFSET = 5;
+const BASE_UI_DISMISS_REASONS = {
+  escapeKey: "escape-key",
+  focusOut: "focus-out",
+  outsidePress: "outside-press",
+} as const;
+
+type BaseUIChangeDetails = {
+  event: Event;
+  reason?: string;
+};
+
+type BaseUIFloatingSide =
+  | "top"
+  | "bottom"
+  | "left"
+  | "right"
+  | "inline-start"
+  | "inline-end";
+
+type LegacyDismissEventHandler<TEvent extends Event = Event> = (
+  event: TEvent,
+) => void;
+
+type LegacyDismissHandlers = {
+  onEscapeKeyDown?: LegacyDismissEventHandler<KeyboardEvent>;
+  onFocusOutside?: LegacyDismissEventHandler<FocusEvent | KeyboardEvent>;
+  onInteractOutside?: LegacyDismissEventHandler;
+  onPointerDownOutside?: LegacyDismissEventHandler<
+    MouseEvent | PointerEvent | TouchEvent
+  >;
+};
+
+type BaseUIPositionerVisibilityStyleParams = {
+  anchorHidden: boolean;
+  hideWhenDetached?: boolean;
+  zIndex?: CSSProperties["zIndex"];
+};
+
+const callLegacyEventHandler = <TEvent extends Event>(
+  handler: LegacyDismissEventHandler<TEvent> | undefined,
+  event: TEvent,
+) => {
+  handler?.(event);
+  return event.defaultPrevented;
+};
+
+const callLegacyDismissHandlers = (
+  eventDetails: BaseUIChangeDetails,
+  callbacks: LegacyDismissHandlers,
+) => {
+  const { event, reason } = eventDetails;
+
+  if (reason === BASE_UI_DISMISS_REASONS.escapeKey) {
+    // Radix exposed escape as a typed keyboard callback, so preserve that event
+    // shape even though Base UI sends all dismiss reasons through one details object.
+    return callLegacyEventHandler(
+      callbacks.onEscapeKeyDown,
+      event as KeyboardEvent,
+    );
+  }
+
+  if (reason === BASE_UI_DISMISS_REASONS.outsidePress) {
+    // Radix fired both pointer-specific and generic outside-interaction hooks;
+    // cancellation from either one should block Base UI's dismiss.
+    const pointerDismissPrevented = callLegacyEventHandler(
+      callbacks.onPointerDownOutside,
+      event as MouseEvent | PointerEvent | TouchEvent,
+    );
+    const interactDismissPrevented = callLegacyEventHandler(
+      callbacks.onInteractOutside,
+      event,
+    );
+
+    return pointerDismissPrevented || interactDismissPrevented;
+  }
+
+  if (reason === BASE_UI_DISMISS_REASONS.focusOut) {
+    // Focus-out maps to Radix's focus-specific hook and the broader
+    // interaction hook, matching the previous callback cascade.
+    const focusDismissPrevented = callLegacyEventHandler(
+      callbacks.onFocusOutside,
+      event as FocusEvent | KeyboardEvent,
+    );
+    const interactDismissPrevented = callLegacyEventHandler(
+      callbacks.onInteractOutside,
+      event,
+    );
+
+    return focusDismissPrevented || interactDismissPrevented;
+  }
+
+  return false;
+};
+
+const getBaseUIMotionOffset = (
+  side: BaseUIFloatingSide | undefined,
+  offset = ANIMATION_OFFSET,
+) => {
+  // Base UI includes logical sides, but Telegraph's existing animation only
+  // offsets physical sides; logical sides intentionally fall through to no offset.
+  if (side === "top") {
+    return {
+      y: -offset,
+    };
+  }
+
+  if (side === "bottom") {
+    return {
+      y: offset,
+    };
+  }
+
+  if (side === "left") {
+    return {
+      x: -offset,
+    };
+  }
+
+  if (side === "right") {
+    return {
+      x: offset,
+    };
+  }
+
+  return {};
+};
+
+const getBaseUIPositionerVisibilityStyle = ({
+  anchorHidden,
+  hideWhenDetached,
+  zIndex,
+}: BaseUIPositionerVisibilityStyleParams): CSSProperties => {
+  return {
+    // Radix's `hideWhenDetached` hid content without unmounting it; Base UI
+    // reports anchor visibility through render state instead.
+    visibility: hideWhenDetached && anchorHidden ? "hidden" : undefined,
+    zIndex,
+  };
+};
+
+export {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+};
+export type {
+  BaseUIChangeDetails,
+  BaseUIFloatingSide,
+  BaseUIPositionerVisibilityStyleParams,
+  LegacyDismissEventHandler,
+  LegacyDismissHandlers,
+};

--- a/packages/helpers/src/base-ui/index.ts
+++ b/packages/helpers/src/base-ui/index.ts
@@ -2,3 +2,14 @@ export {
   createTgphBaseUIRender,
   type TgphBaseUIRenderElement,
 } from "./createTgphBaseUIRender";
+
+export {
+  callLegacyDismissHandlers,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+  type BaseUIChangeDetails,
+  type BaseUIFloatingSide,
+  type BaseUIPositionerVisibilityStyleParams,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
+} from "./compatibility";

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -22,6 +22,14 @@ export { useControllableState } from "./hooks/useControllableState";
 export { useDeterminateState } from "./hooks/useDeterminateState";
 
 export {
+  callLegacyDismissHandlers,
   createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
+  type BaseUIChangeDetails,
+  type BaseUIFloatingSide,
+  type BaseUIPositionerVisibilityStyleParams,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type TgphBaseUIRenderElement,
 } from "./base-ui";

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -1,6 +1,6 @@
 # 💬 Popover
 
-> Accessible popover component with positioning, animations, and portal rendering built on Radix UI.
+> Accessible popover component with positioning, animations, and portal rendering built on Base UI.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -76,22 +76,26 @@ The trigger element that opens/closes the popover. Must wrap a single focusable 
 
 The popover content container that appears in a portal.
 
-| Prop            | Type                                     | Default       | Description                           |
-| --------------- | ---------------------------------------- | ------------- | ------------------------------------- |
-| `side`          | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`    | Side to display popover               |
-| `align`         | `"start" \| "center" \| "end"`           | `"center"`    | Alignment relative to trigger         |
-| `sideOffset`    | `number`                                 | `4`           | Distance from trigger                 |
-| `alignOffset`   | `number`                                 | `0`           | Additional alignment offset           |
-| `gap`           | `SpacingToken`                           | `"1"`         | Gap between content items             |
-| `py`            | `SpacingToken`                           | `"1"`         | Vertical padding                      |
-| `rounded`       | `RoundedToken`                           | `"4"`         | Border radius                         |
-| `shadow`        | `ShadowToken`                            | `"2"`         | Drop shadow                           |
-| `border`        | `SpacingToken`                           | `"px"`        | Border width                          |
-| `borderColor`   | `ColorToken`                             | `"gray-8"`    | Border color                          |
-| `bg`            | `ColorToken`                             | `"surface-1"` | Background color                      |
-| `skipAnimation` | `boolean`                                | `false`       | Whether to skip enter/exit animations |
+| Prop               | Type                                     | Default       | Description                                     |
+| ------------------ | ---------------------------------------- | ------------- | ----------------------------------------------- |
+| `side`             | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`    | Side to display popover                         |
+| `align`            | `"start" \| "center" \| "end"`           | `"center"`    | Alignment relative to trigger                   |
+| `sideOffset`       | `number`                                 | `4`           | Distance from trigger                           |
+| `alignOffset`      | `number`                                 | `0`           | Additional alignment offset                     |
+| `avoidCollisions`  | `boolean`                                | `true`        | Flip/shift content to avoid viewport collisions |
+| `hideWhenDetached` | `boolean`                                | `false`       | Hide content while the anchor is detached       |
+| `gap`              | `SpacingToken`                           | `"1"`         | Gap between content items                       |
+| `py`               | `SpacingToken`                           | `"1"`         | Vertical padding                                |
+| `rounded`          | `RoundedToken`                           | `"4"`         | Border radius                                   |
+| `shadow`           | `ShadowToken`                            | `"2"`         | Drop shadow                                     |
+| `border`           | `SpacingToken`                           | `"px"`        | Border width                                    |
+| `borderColor`      | `ColorToken`                             | `"gray-8"`    | Border color                                    |
+| `bg`               | `ColorToken`                             | `"surface-1"` | Background color                                |
+| `skipAnimation`    | `boolean`                                | `false`       | Whether to skip enter/exit animations           |
 
 Inherits all Stack props for additional styling.
+
+Popover is implemented with Base UI Popover primitives and rendered through Telegraph layout components, so the public API, styling tokens, and `tgphRef` support remain stable while the underlying headless behavior comes from Base UI.
 
 ## Usage Patterns
 
@@ -645,9 +649,9 @@ The popover component uses Telegraph design tokens for consistent styling:
 
 ```tsx
 import { Button } from "@telegraph/button";
-import { Tag } from "@telegraph/tag";
 import { Box, Stack } from "@telegraph/layout";
 import { Popover } from "@telegraph/popover";
+import { Tag } from "@telegraph/tag";
 
 export const UserProfilePopover = ({ user }) => (
   <Popover.Root>
@@ -670,7 +674,11 @@ export const UserProfilePopover = ({ user }) => (
           <Stack direction="column" gap="1">
             <Stack direction="row" align="center" gap="2">
               <strong>{user.name}</strong>
-              {user.isOnline && <Tag size="0" color="green">Online</Tag>}
+              {user.isOnline && (
+                <Tag size="0" color="green">
+                  Online
+                </Tag>
+              )}
             </Stack>
             <span>{user.role}</span>
           </Stack>
@@ -984,7 +992,7 @@ export const SearchFilterPopover = ({ onApplyFilters }) => {
 
 ## References
 
-- [Radix UI Popover](https://www.radix-ui.com/docs/primitives/components/popover)
+- [Base UI Popover](https://base-ui.com/react/components/popover)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/popover)
 
 ## Contributing

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -32,8 +32,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-popover": "^1.1.15",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",
     "motion": "^12.38.0"

--- a/packages/popover/src/Popover/Popover.helpers.ts
+++ b/packages/popover/src/Popover/Popover.helpers.ts
@@ -1,0 +1,7 @@
+const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;
+
+export { NO_COLLISION_AVOIDANCE };

--- a/packages/popover/src/Popover/Popover.stories.tsx
+++ b/packages/popover/src/Popover/Popover.stories.tsx
@@ -6,6 +6,25 @@ import { Ellipsis } from "lucide-react";
 
 import { Popover } from "./Popover";
 
+const placementOptions = [
+  {
+    label: "Top",
+    side: "top",
+  },
+  {
+    label: "Right",
+    side: "right",
+  },
+  {
+    label: "Bottom",
+    side: "bottom",
+  },
+  {
+    label: "Left",
+    side: "left",
+  },
+] as const;
+
 const meta: Meta = {
   tags: ["autodocs"],
   title: "Components/Popover",
@@ -63,6 +82,63 @@ export const Default: Story = {
             <p>Test popover content</p>
           </Popover.Content>
         </Popover.Root>
+      </Stack>
+    );
+  },
+};
+
+export const Closed: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center">
+        <Popover.Root {...args}>
+          <Popover.Trigger asChild={true}>
+            <Button
+              variant="outline"
+              leadingIcon={{ icon: Ellipsis, "aria-hidden": true }}
+            />
+          </Popover.Trigger>
+          <Popover.Content
+            px="4"
+            align={args.align}
+            side={args.side}
+            skipAnimation={args.skipAnimation}
+          >
+            <p>Test popover content</p>
+          </Popover.Content>
+        </Popover.Root>
+      </Stack>
+    );
+  },
+};
+
+export const Placements: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack
+        w="full"
+        minH="96"
+        my="10"
+        direction="row"
+        gap="10"
+        align="center"
+        justify="center"
+      >
+        {placementOptions.map((placement) => (
+          <Popover.Root key={placement.side} {...args} defaultOpen={true}>
+            <Popover.Trigger asChild={true}>
+              <Button variant="outline">{placement.label}</Button>
+            </Popover.Trigger>
+            <Popover.Content
+              px="4"
+              align={args.align}
+              side={placement.side}
+              skipAnimation={args.skipAnimation}
+            >
+              <p>{placement.label} popover content</p>
+            </Popover.Content>
+          </Popover.Root>
+        ))}
       </Stack>
     );
   },

--- a/packages/popover/src/Popover/Popover.test.tsx
+++ b/packages/popover/src/Popover/Popover.test.tsx
@@ -1,11 +1,47 @@
-import { describe, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Popover } from "./Popover";
 import type { PopoverContentProps } from "./index";
+
+type PopoverRootActions = NonNullable<
+  NonNullable<
+    ComponentPropsWithoutRef<typeof Popover.Root>["actionsRef"]
+  >["current"]
+>;
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Popover", () => {
   describe("type inheritance", () => {
     it("accepts valid content-specific props", () => {
       const validProps: PopoverContentProps = {
+        avoidCollisions: false,
+        hideWhenDetached: true,
         side: "bottom",
         sideOffset: 4,
         skipAnimation: true,
@@ -28,5 +64,462 @@ describe("Popover", () => {
       const invalidProp: PopoverContentProps = { invalidProp: "invalid" };
       void invalidProp;
     });
+  });
+
+  it("is accessible when open", async () => {
+    render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content aria-label="Settings" skipAnimation>
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+
+    expectToHaveNoViolations(await axe(dialog));
+  });
+
+  it("opens and closes with the trigger in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover.Root onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Popover.Root
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+        >
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content skipAnimation>Settings content</Popover.Content>
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("opens on hover when Base UI trigger hover props are passed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger openOnHover delay={0} closeDelay={0}>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(await screen.findByRole("dialog")).toHaveTextContent(
+      "Settings content",
+    );
+  });
+
+  it("preserves Base UI touch-aware default open focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content>
+          <input aria-label="Setting name" />
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.pointer({
+      keys: "[TouchA]",
+      target: screen.getByRole("button", { name: "Open settings" }),
+    });
+
+    const dialog = await screen.findByRole("dialog");
+
+    expect(dialog).toHaveFocus();
+    expect(
+      screen.getByRole("textbox", { name: "Setting name" }),
+    ).not.toHaveFocus();
+  });
+
+  it("dismisses with Escape and outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Popover.Root defaultOpen>
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+            skipAnimation
+          >
+            Settings content
+          </Popover.Content>
+        </Popover.Root>
+      </>,
+    );
+
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the popover open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Popover.Root defaultOpen onOpenChange={onOpenChange}>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content
+          onEscapeKeyDown={(event) => event.preventDefault()}
+          skipAnimation
+        >
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("lets legacy open autofocus handlers move focus", async () => {
+    const user = userEvent.setup();
+    const inputRef = createRef<HTMLInputElement>();
+    const onOpenAutoFocus = vi.fn((event: Event) => {
+      event.preventDefault();
+      inputRef.current?.focus();
+    });
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content onOpenAutoFocus={onOpenAutoFocus} skipAnimation>
+          <input aria-label="Setting name" ref={inputRef} />
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    const input = await screen.findByRole("textbox", { name: "Setting name" });
+
+    expect(input).toHaveFocus();
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps animated content mounted while close motion starts", async () => {
+    const user = userEvent.setup();
+    const actionsRef: { current: PopoverRootActions | null } = {
+      current: null,
+    };
+    const unmount = vi.fn();
+
+    render(
+      <Popover.Root actionsRef={actionsRef} defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content data-testid="popover-content">
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+
+    actionsRef.current = {
+      ...actionsRef.current,
+      unmount,
+    } as PopoverRootActions;
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    expect(screen.getByTestId("popover-content")).toHaveAttribute(
+      "data-state",
+      "closed",
+    );
+  });
+
+  it("finishes the deferred close unmount if controlled content unmounts before animation completion", async () => {
+    const user = userEvent.setup();
+    const actionsRef: { current: PopoverRootActions | null } = {
+      current: null,
+    };
+    const unmount = vi.fn();
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(true);
+
+      return (
+        <Popover.Root
+          open={open}
+          onOpenChange={setOpen}
+          actionsRef={actionsRef}
+        >
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          {open && (
+            <Popover.Content data-testid="popover-content">
+              Settings content
+            </Popover.Content>
+          )}
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+
+    actionsRef.current = {
+      ...actionsRef.current,
+      unmount,
+    } as PopoverRootActions;
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    await waitFor(() => {
+      expect(unmount).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByTestId("popover-content")).not.toBeInTheDocument();
+  });
+
+  it("keeps animated content mounted if the controlled root rerenders during close", async () => {
+    const user = userEvent.setup();
+    const unmount = vi.fn();
+    const onAnimationComplete = vi.fn();
+    let currentActions: PopoverRootActions | null = null;
+    const actionsRef: { current: PopoverRootActions | null } = {
+      get current() {
+        return currentActions;
+      },
+      set current(nextActions) {
+        currentActions = nextActions
+          ? ({ ...nextActions, unmount } as PopoverRootActions)
+          : null;
+      },
+    };
+
+    const ControlledPopover = () => {
+      const [open, setOpen] = useState(true);
+      const [rerenderCount, setRerenderCount] = useState(0);
+
+      return (
+        <Popover.Root
+          actionsRef={actionsRef}
+          open={open}
+          onOpenChange={(nextOpen) => {
+            setOpen(nextOpen);
+            setRerenderCount((count) => count + 1);
+          }}
+        >
+          <span data-testid="rerender-count">{rerenderCount}</span>
+          <Popover.Trigger>
+            <TestButton>Open settings</TestButton>
+          </Popover.Trigger>
+          <Popover.Content
+            data-testid="popover-content"
+            onAnimationComplete={onAnimationComplete}
+          >
+            Settings content
+          </Popover.Content>
+        </Popover.Root>
+      );
+    };
+
+    render(<ControlledPopover />);
+
+    await screen.findByTestId("popover-content");
+    await waitFor(() => {
+      expect(actionsRef.current).not.toBeNull();
+    });
+    onAnimationComplete.mockClear();
+    unmount.mockClear();
+
+    await user.click(screen.getByRole("button", { name: "Open settings" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rerender-count")).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId("popover-content")).toHaveAttribute(
+      "data-state",
+      "closed",
+    );
+    await waitFor(() => {
+      expect(onAnimationComplete).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(unmount).toHaveBeenCalled();
+    });
+
+    expect(onAnimationComplete.mock.invocationCallOrder[0]).toBeLessThan(
+      unmount.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("returns focus to the trigger after dismissal", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content skipAnimation>Settings content</Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+
+    await user.click(trigger);
+    await screen.findByRole("dialog");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content data-testid="popover-content" skipAnimation>
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const content = await screen.findByTestId("popover-content");
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("role", "dialog");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("forwards trigger and content refs through tgphRef", async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+    const triggerTgphRef = createRef<HTMLButtonElement>();
+    const contentTgphRef = createRef<HTMLDivElement>();
+    const contentStackRef = createRef<HTMLDivElement>();
+
+    render(
+      <Popover.Root defaultOpen>
+        <Popover.Trigger ref={triggerRef} tgphRef={triggerTgphRef}>
+          <TestButton>Open settings</TestButton>
+        </Popover.Trigger>
+        <Popover.Content
+          contentStackRef={contentStackRef}
+          tgphRef={contentTgphRef}
+          skipAnimation
+        >
+          Settings content
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Open settings" });
+    const content = await screen.findByRole("dialog");
+
+    expect(triggerRef.current).toBe(trigger);
+    expect(triggerTgphRef.current).toBe(trigger);
+    expect(contentTgphRef.current).toBe(content);
+    expect(contentStackRef.current).toBe(content);
   });
 });

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -1,195 +1,405 @@
-import * as RadixPopover from "@radix-ui/react-popover";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Popover as BasePopover } from "@base-ui/react/popover";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
-  RefToTgphRef,
-  TgphComponentProps,
-  TgphElement,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
+  type TgphComponentProps,
+  type TgphElement,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from "react";
 
-export type RootProps = React.ComponentProps<typeof RadixPopover.Root> & {
-  defaultOpen?: boolean;
+import { NO_COLLISION_AVOIDANCE } from "./Popover.helpers";
+
+type BasePopoverRootProps = ComponentProps<typeof BasePopover.Root>;
+type BasePopoverTriggerProps = ComponentPropsWithoutRef<
+  typeof BasePopover.Trigger
+>;
+type BasePopoverPositionerProps = ComponentPropsWithoutRef<
+  typeof BasePopover.Positioner
+>;
+type BasePopoverPopupProps = ComponentPropsWithoutRef<typeof BasePopover.Popup>;
+type PopoverRootActions = BasePopover.Root.Actions;
+type MotionAnimationCompleteHandler = NonNullable<
+  ComponentProps<typeof motion.div>["onAnimationComplete"]
+>;
+
+export type RootProps = Omit<BasePopoverRootProps, "onOpenChange"> & {
+  onOpenChange?: (open: boolean) => void;
 };
 
-type PopoverContextProps = {
+type PopoverCompatibilityContextProps = {
+  closeAnimationRef: {
+    current: {
+      pendingCloseUnmount: boolean;
+      preventUnmountOnClose: boolean;
+    };
+  };
+  contentCallbacksRef: {
+    current: LegacyDismissHandlers;
+  };
+  rootActionsRef: RefObject<PopoverRootActions | null>;
+};
+
+type PopoverPopupRenderState = {
   open: boolean;
-  setOpen: (open: boolean) => void;
 };
 
-const PopoverContext = React.createContext<PopoverContextProps>({
-  open: false,
-  setOpen: () => {},
-});
+const PopoverCompatibilityContext =
+  createContext<PopoverCompatibilityContextProps | null>(null);
 
-const Root = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  children,
-  ...props
-}: RootProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
+const Root = ({ actionsRef, children, onOpenChange, ...props }: RootProps) => {
+  const internalRootActionsRef = useRef<PopoverRootActions | null>(null);
+  const rootActionsRef = actionsRef ?? internalRootActionsRef;
+  const closeAnimationRef = useRef({
+    pendingCloseUnmount: false,
+    preventUnmountOnClose: false,
   });
+  const contentCallbacksRef = useRef<LegacyDismissHandlers>({});
+  const compatibilityContext = useMemo<PopoverCompatibilityContextProps>(
+    () => ({
+      closeAnimationRef,
+      contentCallbacksRef,
+      rootActionsRef,
+    }),
+    [rootActionsRef],
+  );
+  const handleOpenChange = useCallback<
+    NonNullable<BasePopoverRootProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        callLegacyDismissHandlers(eventDetails, contentCallbacksRef.current)
+      ) {
+        // Legacy Radix outside/escape handlers could prevent dismissal, so
+        // translate that prevention back into Base UI's cancel API.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (open) {
+        closeAnimationRef.current.pendingCloseUnmount = false;
+      }
+
+      if (!open && closeAnimationRef.current.preventUnmountOnClose) {
+        // Keep the popup mounted through its exit animation; the content calls
+        // Base UI's action ref to unmount once motion reports completion.
+        closeAnimationRef.current.pendingCloseUnmount = true;
+        eventDetails.preventUnmountOnClose();
+      }
+
+      onOpenChange?.(open);
+    },
+    [onOpenChange],
+  );
 
   return (
     <LazyMotion features={domAnimation}>
-      <PopoverContext.Provider value={{ open, setOpen }}>
-        <RadixPopover.Root open={open} onOpenChange={setOpen} {...props}>
+      <PopoverCompatibilityContext.Provider value={compatibilityContext}>
+        <BasePopover.Root
+          actionsRef={rootActionsRef}
+          onOpenChange={handleOpenChange}
+          {...props}
+        >
           {children}
-        </RadixPopover.Root>
-      </PopoverContext.Provider>
+        </BasePopover.Root>
+      </PopoverCompatibilityContext.Provider>
     </LazyMotion>
   );
 };
 
-export type TriggerProps = React.ComponentProps<typeof RadixPopover.Trigger> & {
-  tgphRef?: React.RefObject<HTMLButtonElement>;
+export type TriggerProps = Omit<BasePopoverTriggerProps, "render"> & {
+  asChild?: boolean;
+  children?: ReactNode;
+  tgphRef?: Ref<HTMLButtonElement>;
 };
 
-const Trigger = ({
-  asChild = true,
-  tgphRef,
-  children,
-  ...props
-}: TriggerProps) => {
-  const context = React.useContext(PopoverContext);
+const Trigger = forwardRef<HTMLButtonElement, TriggerProps>(
+  ({ asChild = true, tgphRef, children, ...props }, forwardedRef) => {
+    const triggerRef = useComposedRefs<HTMLButtonElement>(
+      forwardedRef,
+      tgphRef,
+    );
 
-  return (
-    <RadixPopover.Trigger
-      onClick={() => {
-        context.setOpen(!context.open);
-      }}
-      asChild={asChild}
-      {...props}
-      ref={tgphRef}
-    >
-      <RefToTgphRef>{children}</RefToTgphRef>
-    </RadixPopover.Trigger>
-  );
-};
+    if (!asChild || !isValidElement(children)) {
+      return (
+        <BasePopover.Trigger {...props} ref={triggerRef}>
+          {children}
+        </BasePopover.Trigger>
+      );
+    }
 
-export type ContentProps<T extends TgphElement = "div"> = React.ComponentProps<
-  typeof RadixPopover.Content
+    return (
+      <BasePopover.Trigger
+        {...props}
+        ref={triggerRef}
+        render={createTgphBaseUIRender(children as ReactElement)}
+      />
+    );
+  },
+);
+
+export type ContentProps<T extends TgphElement = "div"> = Omit<
+  BasePopoverPositionerProps,
+  "children" | "className" | "render"
 > &
+  Omit<BasePopoverPopupProps, "children" | "className" | "render" | "style"> &
   Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
-    contentStackRef?: React.RefObject<HTMLDivElement>;
+    avoidCollisions?: boolean;
+    contentStackRef?: Ref<HTMLDivElement>;
+    forceMount?: boolean;
+    hideWhenDetached?: boolean;
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onEscapeKeyDown?: LegacyDismissHandlers["onEscapeKeyDown"];
+    onFocusOutside?: LegacyDismissHandlers["onFocusOutside"];
+    onInteractOutside?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+    onPointerDownOutside?: LegacyDismissHandlers["onPointerDownOutside"];
     skipAnimation?: boolean;
   };
 
 const Content = <T extends TgphElement = "div">({
+  align = "center",
+  alignOffset,
+  anchor,
+  arrowPadding,
+  children,
+  avoidCollisions,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  contentStackRef,
   direction = "column",
+  disableAnchorTracking,
+  finalFocus,
+  forceMount,
   gap = "1",
+  hideWhenDetached,
+  initialFocus,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocusOutside,
+  onInteractOutside,
+  onOpenAutoFocus,
+  onPointerDownOutside,
+  positionMethod,
   rounded = "4",
   py = "1",
   shadow = "2",
   side = "bottom",
   sideOffset = 4,
-  align = "center",
+  skipAnimation,
+  sticky,
   bg = "surface-1",
-  alignOffset,
   tgphRef,
   style,
-  skipAnimation,
-  children,
   ...props
 }: ContentProps<T>) => {
-  const deriveAnimationBasedOnSide = (side: ContentProps<T>["side"]) => {
-    const ANIMATION_OFFSET = 5;
-    if (side === "top") {
-      return {
-        y: -ANIMATION_OFFSET,
-      };
-    }
+  const compatibilityContext = useContext(PopoverCompatibilityContext);
+  const contentRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    contentStackRef as Ref<HTMLElement>,
+  );
+  const shouldAnimate = !skipAnimation;
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  // Base UI unmounts immediately on close unless we explicitly hold the popup
+  // mounted, which is only needed for animated, non-force-mounted content.
+  const shouldManageCloseAnimation = shouldAnimate && !forceMount;
+  const resolvedInitialFocus =
+    initialFocus ??
+    (onOpenAutoFocus
+      ? () => {
+          const event = new Event("openAutoFocus", { cancelable: true });
+          onOpenAutoFocus(event);
 
-    if (side === "bottom") {
-      return {
-        y: ANIMATION_OFFSET,
-      };
-    }
+          // Base UI uses `false` to cancel autofocus; Radix used
+          // preventDefault on the synthetic lifecycle event.
+          return event.defaultPrevented ? false : true;
+        }
+      : undefined);
+  const resolvedFinalFocus =
+    finalFocus ??
+    (onCloseAutoFocus
+      ? () => {
+          const event = new Event("closeAutoFocus", { cancelable: true });
+          onCloseAutoFocus(event);
 
-    if (side === "left") {
-      return {
-        x: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "right") {
-      return {
-        x: ANIMATION_OFFSET,
-      };
-    }
+          // Preserve Radix's close autofocus contract while using Base UI's
+          // boolean finalFocus callback shape.
+          return event.defaultPrevented ? false : true;
+        }
+      : undefined);
+  const { onAnimationComplete, ...stackProps } = props as typeof props & {
+    onAnimationComplete?: MotionAnimationCompleteHandler;
   };
 
+  useEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Tell the root whether this content needs Base UI's unmount prevented
+    // until the exit animation has had a chance to complete.
+    compatibilityContext.closeAnimationRef.current = {
+      ...compatibilityContext.closeAnimationRef.current,
+      preventUnmountOnClose: shouldManageCloseAnimation,
+    };
+
+    return () => {
+      if (compatibilityContext.closeAnimationRef.current.pendingCloseUnmount) {
+        // A controlled parent can stop rendering Content as soon as it sees
+        // onOpenChange(false); in that case the motion callback below will not
+        // fire, so finish Base UI's deferred unmount from cleanup.
+        compatibilityContext.rootActionsRef.current?.unmount();
+      }
+
+      compatibilityContext.closeAnimationRef.current = {
+        ...compatibilityContext.closeAnimationRef.current,
+        pendingCloseUnmount: false,
+        preventUnmountOnClose: false,
+      };
+    };
+  }, [compatibilityContext, shouldManageCloseAnimation]);
+
+  useEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Store the latest legacy dismiss callbacks where Root can reach them from
+    // Base UI's single `onOpenChange` dismissal details callback.
+    compatibilityContext.contentCallbacksRef.current = {
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onPointerDownOutside,
+    };
+
+    return () => {
+      compatibilityContext.contentCallbacksRef.current = {};
+    };
+  }, [
+    compatibilityContext,
+    onEscapeKeyDown,
+    onFocusOutside,
+    onInteractOutside,
+    onPointerDownOutside,
+  ]);
+  const closedAnimation = shouldAnimate
+    ? {
+        opacity: 0.5,
+        scale: 0.6,
+        ...getBaseUIMotionOffset(side),
+      }
+    : undefined;
+
   return (
-    <RadixPopover.Portal>
-      <RadixPopover.Content
-        asChild
-        side={side}
-        sideOffset={sideOffset}
+    <BasePopover.Portal keepMounted={forceMount}>
+      <BasePopover.Positioner
         align={align}
         alignOffset={alignOffset}
-        {...props}
-        ref={tgphRef}
+        anchor={anchor}
+        arrowPadding={arrowPadding}
+        collisionAvoidance={resolvedCollisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        disableAnchorTracking={disableAnchorTracking}
+        positionMethod={positionMethod}
+        side={side}
+        sideOffset={sideOffset}
+        sticky={sticky}
+        style={(state) =>
+          getBaseUIPositionerVisibilityStyle({
+            anchorHidden: state.anchorHidden,
+            hideWhenDetached,
+          })
+        }
       >
-        <RefToTgphRef>
-          <Stack
-            as={motion.div}
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            initial={
-              skipAnimation
-                ? undefined
-                : {
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
+        <BasePopover.Popup
+          initialFocus={resolvedInitialFocus}
+          finalFocus={resolvedFinalFocus}
+          render={createTgphBaseUIRender((state: PopoverPopupRenderState) => (
+            <Stack
+              as={motion.div}
+              className="tgph"
+              initial={closedAnimation}
+              animate={
+                shouldAnimate
+                  ? state.open
+                    ? {
+                        opacity: 1,
+                        scale: 1,
+                        x: 0,
+                        y: 0,
+                      }
+                    : closedAnimation
+                  : undefined
+              }
+              exit={closedAnimation}
+              transition={{
+                duration: 0.1,
+                type: "spring",
+                bounce: 0,
+              }}
+              bg={bg}
+              data-state={state.open ? "open" : "closed"}
+              direction={direction}
+              gap={gap}
+              rounded={rounded}
+              py={py}
+              shadow={shadow}
+              style={{
+                overflowY: "auto",
+                transformOrigin: "var(--transform-origin)",
+                ...style,
+              }}
+              tgphRef={contentRef}
+              zIndex="popover"
+              key="tgph-popover-content"
+              {...stackProps}
+              onAnimationComplete={(definition) => {
+                onAnimationComplete?.(definition);
+
+                if (!state.open && shouldManageCloseAnimation) {
+                  // The root held the popup mounted for the exit animation; now
+                  // that motion is done, ask Base UI to finish the unmount.
+                  if (compatibilityContext) {
+                    compatibilityContext.closeAnimationRef.current.pendingCloseUnmount = false;
                   }
-            }
-            animate={{
-              opacity: 1,
-              scale: 1,
-              x: 0,
-              y: 0,
-            }}
-            exit={
-              skipAnimation
-                ? undefined
-                : {
-                    opacity: 0.5,
-                    scale: 0.6,
-                    ...deriveAnimationBasedOnSide(side),
-                  }
-            }
-            transition={{
-              duration: 0.1,
-              type: "spring",
-              bounce: 0,
-            }}
-            bg={bg}
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-              transformOrigin: "var(--radix-tooltip-content-transform-origin)",
-              ...style,
-            }}
-            zIndex="popover"
-            key="tgph-popover-content"
-          >
-            {children}
-          </Stack>
-        </RefToTgphRef>
-      </RadixPopover.Content>
-    </RadixPopover.Portal>
+                  compatibilityContext?.rootActionsRef.current?.unmount();
+                }
+              }}
+            >
+              {children}
+            </Stack>
+          ))}
+        />
+      </BasePopover.Positioner>
+    </BasePopover.Portal>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,39 +3322,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-popover@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "@radix-ui/react-popover@npm:1.1.15"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c1c76b5e5985b128d03b621424fb453f769931d497759a1977734d303007da9f970570cf3ea1f6968ab609ab4a97f384168bff056197bd2d3d422abea0e3614b
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-popper@npm:1.2.8":
   version: 1.2.8
   resolution: "@radix-ui/react-popper@npm:1.2.8"
@@ -4636,10 +4603,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/popover@workspace:packages/popover"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-popover": "npm:^1.1.15"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #840.
- Linear: [KNO-13668](https://linear.app/knock/issue/KNO-13668).

## What changed

- Migrates `@telegraph/popover` from Radix Popover to Base UI Popover primitives.
- Adds shared Base UI compatibility helpers in `@telegraph/helpers` for dismissal callbacks, visibility styles, and motion offsets.
- Preserves `Popover.Root`, `Popover.Trigger`, `Popover.Content`, `tgphRef`, `asChild`, positioning props, animation props, portal scoping, and preventable dismiss behavior.
- Tracks pending animated close unmounts so controlled parents that remove `Popover.Content` on `onOpenChange(false)` still let Base UI finish its deferred unmount.
- Stabilizes the Popover compatibility context value so controlled root re-renders during close do not abort the exit-animation handoff.
- Updates Popover and Helpers READMEs, tests, dependencies, lockfile, and changeset.

## Why

- Removes Popover's Radix runtime dependency while keeping controlled state, dismissal, focus return, portal styling, and refs backwards compatible.
- Shares helper code with Tooltip, Menu, and Modal instead of duplicating it package by package.
- Closes Cursor review findings around controlled close animation cleanup, including content unmounts and root re-renders during the deferred close path.

## Verification

- `yarn test packages/popover/src/Popover/Popover.test.tsx`
- `yarn workspace @telegraph/popover lint`
- `yarn workspace @telegraph/popover build`
- `yarn prettier --check packages/popover/src/Popover/Popover.tsx packages/popover/src/Popover/Popover.test.tsx`
- Stack-wide: `yarn build:packages`
- Stack-wide: `yarn lint`
- Stack-wide: `yarn test`
