### PR TITLE
refactor(tooltip): migrate Tooltip to Base UI

### DIFF
--- a/.changeset/base-tooltips-shift.md
+++ b/.changeset/base-tooltips-shift.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/tooltip": minor
+"@telegraph/truncate": patch
+"@telegraph/vite-config": patch
+---
+
+Migrate Tooltip internals from Radix UI to Base UI while preserving Telegraph trigger state attributes, dismissal callbacks, collision props, hidden-when-detached behavior, and `tgphRef` support. The portaled tooltip surface keeps a dark Telegraph appearance attribute without reintroducing the removed public `appearance` prop. Keep dependency subpath imports external in shared Vite library builds so Base UI-backed packages publish browser-safe ESM output.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -70,7 +70,9 @@ The main tooltip component that wraps content and provides contextual informatio
 
 | Prop                      | Type                                     | Default     | Description                                                  |
 | ------------------------- | ---------------------------------------- | ----------- | ------------------------------------------------------------ |
-| `label`                   | `string \| ReactNode`                    | -           | **Required.** Content to display in the tooltip              |
+| `label`                   | `string \| ReactNode`                    | `undefined` | Content to display in the tooltip                            |
+| `labelProps`              | `TgphComponentProps<typeof Stack>`       | `undefined` | Props to pass to the rendered tooltip content                |
+| `enabled`                 | `boolean`                                | `true`      | Whether the tooltip can open                                 |
 | `side`                    | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`  | Preferred placement side                                     |
 | `align`                   | `"start" \| "center" \| "end"`           | `"center"`  | Alignment relative to the trigger                            |
 | `sideOffset`              | `number`                                 | `4`         | Distance from the trigger element                            |
@@ -79,6 +81,8 @@ The main tooltip component that wraps content and provides contextual informatio
 | `skipDelayDuration`       | `number`                                 | -           | Skip delay if another tooltip was recently shown             |
 | `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
 | `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
+| `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                          |
+| `triggerRef`              | `RefObject<HTMLButtonElement>`           | `undefined` | Ref forwarded to the rendered trigger element                |
 | `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
 | `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
 | `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |
@@ -185,11 +189,7 @@ When wrapping elements inside a `Select` or `Combobox` (where DOM focus moves to
 import { Tooltip } from "@telegraph/tooltip";
 
 export const ListItemTooltip = ({ item }) => (
-  <Tooltip
-    label={item.description}
-    disableFocusOpen
-    delayDuration={500}
-  >
+  <Tooltip label={item.description} disableFocusOpen delayDuration={500}>
     <li>{item.name}</li>
   </Tooltip>
 );
@@ -469,6 +469,12 @@ export const NestedTooltips = () => (
 );
 ```
 
+## Implementation Notes
+
+`Tooltip` is implemented with [Base UI Tooltip](https://base-ui.com/react/components/tooltip) primitives and a Telegraph-rendered content surface. The public API keeps the long-standing Telegraph/Radix-style prop names, including `delayDuration`, `skipDelayDuration`, `disableHoverableContent`, `forceMount`, `onEscapeKeyDown`, and `onPointerDownOutside`.
+
+The portaled tooltip content renders with `className="tgph"`, `role="tooltip"`, `data-state`, and `data-tgph-appearance="dark"`, and the trigger is linked with `aria-describedby` while the tooltip is open. Telegraph trigger refs continue to work through `triggerRef` and `tgphRef`-compatible children.
+
 ## Accessibility
 
 - ✅ **Keyboard Navigation**: Full keyboard support with proper focus management
@@ -518,8 +524,8 @@ export const BasicExample = () => (
 ### Advanced Example
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Button } from "@telegraph/button";
+import { Tag } from "@telegraph/tag";
 import { Tooltip } from "@telegraph/tooltip";
 import { Calendar, Mail, MapPin, User } from "lucide-react";
 
@@ -576,8 +582,8 @@ export const UserProfileTooltip = ({ user }) => (
 ### Real-world Example
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Button } from "@telegraph/button";
+import { Tag } from "@telegraph/tag";
 import { Tooltip } from "@telegraph/tooltip";
 import {
   Bell,
@@ -729,7 +735,7 @@ export const ApplicationHeader = ({ user, notifications }) => (
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/tooltip)
-- [Radix UI Tooltip](https://www.radix-ui.com/primitives/docs/components/tooltip) - Base primitive
+- [Base UI Tooltip](https://base-ui.com/react/components/tooltip) - Base primitive
 - [Popover Component](../popover/README.md) - Related overlay component
 
 ## Contributing

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -32,8 +32,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-tooltip": "^1.2.8",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/appearance": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/tooltip/src/Tooltip/Tooltip.constants.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.constants.ts
@@ -2,13 +2,10 @@ import type { OverrideAppearance } from "@telegraph/appearance";
 import type { Required, TgphComponentProps } from "@telegraph/helpers";
 import type { Stack } from "@telegraph/layout";
 
-type Appearance = Required<
+export type Appearance = Required<
   TgphComponentProps<typeof OverrideAppearance>
 >["appearance"];
 
-// Set any appearance specifics props for the content.
-// For example, a light appearance tooltip should stand out
-// from the background of the page.
 export const TooltipContentProps: Record<
   Appearance,
   TgphComponentProps<typeof Stack>

--- a/packages/tooltip/src/Tooltip/Tooltip.helpers.ts
+++ b/packages/tooltip/src/Tooltip/Tooltip.helpers.ts
@@ -1,0 +1,5 @@
+export const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;

--- a/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.hooks.tsx
@@ -1,11 +1,17 @@
-import React from "react";
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 type TooltipGroupContextState = {
   groupOpen: boolean;
   setGroupOpen?: (open: boolean) => void;
 };
 
-const TooltipContext = React.createContext<TooltipGroupContextState>({
+const TooltipContext = createContext<TooltipGroupContextState>({
   groupOpen: false,
   setGroupOpen: () => {},
 });
@@ -16,31 +22,24 @@ type UseTooltipGroupParams = {
 };
 
 const useTooltipGroup = ({ open, delay = 600 }: UseTooltipGroupParams) => {
-  const context = React.useContext(TooltipContext);
+  const context = useContext(TooltipContext);
 
-  // If the open prop is set to true, we set the groupOpen state to true
-  // If the open prop is set to false, we set the groupOpen state to false after a delay
-  // to ensure that another tooltip is not opened while this one is closed.
-  React.useEffect(() => {
-    let timer: NodeJS.Timeout | null = null;
-    if (context.setGroupOpen) {
-      if (open === true) {
-        context.setGroupOpen(true);
-      }
-
-      if (open === false) {
-        timer = setTimeout(() => {
-          if (context.setGroupOpen) {
-            context.setGroupOpen(false);
-          }
-        }, delay);
-      }
+  useEffect(() => {
+    if (!context.setGroupOpen) {
+      return;
     }
 
+    if (open === true) {
+      context.setGroupOpen(true);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      context.setGroupOpen?.(false);
+    }, delay);
+
     return () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
+      clearTimeout(timer);
     };
   }, [open, context, delay]);
 
@@ -50,11 +49,11 @@ const useTooltipGroup = ({ open, delay = 600 }: UseTooltipGroupParams) => {
 };
 
 type TooltipGroupProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const TooltipGroupProvider = ({ children }: TooltipGroupProviderProps) => {
-  const [groupOpen, setGroupOpen] = React.useState<boolean>(false);
+  const [groupOpen, setGroupOpen] = useState<boolean>(false);
 
   return (
     <TooltipContext.Provider value={{ groupOpen, setGroupOpen }}>

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -28,13 +28,17 @@ const meta: Meta = {
         type: "select",
       },
     },
-    appearance: {
-      options: ["light", "dark"],
+    enabled: {
       control: {
-        type: "select",
+        type: "boolean",
       },
     },
-    enabled: {
+    open: {
+      control: {
+        type: "boolean",
+      },
+    },
+    defaultOpen: {
       control: {
         type: "boolean",
       },
@@ -50,7 +54,6 @@ const meta: Meta = {
     side: "bottom",
     align: "center",
     enabled: true,
-    appearance: "dark",
   },
 };
 
@@ -59,6 +62,23 @@ export default meta;
 type Story = StoryObj<TgphComponentProps<typeof TelegraphTooltip>>;
 
 export const Default: Story = {
+  render: ({ ...args }) => {
+    return (
+      <Stack w="full" my="10" align="center" justify="center">
+        <TelegraphTooltip {...args}>
+          <Button color="blue">Hover me</Button>
+        </TelegraphTooltip>
+      </Stack>
+    );
+  },
+};
+
+export const Open: Story = {
+  args: {
+    defaultOpen: true,
+    delayDuration: 0,
+    skipAnimation: true,
+  },
   render: ({ ...args }) => {
     return (
       <Stack w="full" my="10" align="center" justify="center">

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -1,6 +1,33 @@
-import { describe, it } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { Tooltip } from "./Tooltip";
 import type { TooltipProps } from "./Tooltip";
+import { TooltipGroupProvider } from "./Tooltip.hooks";
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Tooltip", () => {
   describe("type inheritance", () => {
@@ -9,7 +36,6 @@ describe("Tooltip", () => {
         label: "Tooltip text",
         side: "top",
         enabled: true,
-        appearance: "dark",
         children: null,
       };
       void validProps;
@@ -24,6 +50,16 @@ describe("Tooltip", () => {
       void propsWithDisableFocusOpen;
     });
 
+    it("accepts legacy wrapper passthrough props", () => {
+      const validProps: TooltipProps = {
+        label: "Tooltip text",
+        asChild: true,
+        style: { zIndex: 9999 },
+        children: null,
+      };
+      void validProps;
+    });
+
     it("rejects unknown props on type level", () => {
       // @ts-expect-error unknown prop rejected on TooltipProps
       const invalidProp: TooltipProps = {
@@ -33,5 +69,306 @@ describe("Tooltip", () => {
       };
       void invalidProp;
     });
+  });
+
+  it("opens and closes on hover in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Tooltip
+        label="Helpful context"
+        delayDuration={0}
+        onOpenChange={onOpenChange}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    expect(trigger).toHaveAttribute("data-state", "closed");
+
+    await user.hover(trigger);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Helpful context",
+    );
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.unhover(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+      expect(trigger).toHaveAttribute("data-state", "closed");
+    });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledTooltip = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Tooltip
+          label="Controlled context"
+          delayDuration={0}
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      );
+    };
+
+    render(<ControlledTooltip />);
+
+    await user.hover(screen.getByRole("button", { name: "Hover target" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Controlled context",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("keeps disabled tooltips closed", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip
+        defaultOpen
+        enabled={false}
+        label="Hidden context"
+        delayDuration={0}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hover target" }));
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("dismisses with Escape", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Tooltip
+          defaultOpen
+          label="Dismissible context"
+          onEscapeKeyDown={onEscapeKeyDown}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      </>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses with outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Tooltip
+          defaultOpen
+          label="Dismissible context"
+          onPointerDownOutside={onPointerDownOutside}
+          skipAnimation
+        >
+          <TestButton>Hover target</TestButton>
+        </Tooltip>
+      </>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the tooltip open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Tooltip
+        defaultOpen
+        label="Persistent context"
+        onEscapeKeyDown={(event) => event.preventDefault()}
+        onOpenChange={onOpenChange}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    await screen.findByRole("tooltip");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("prevents focus-triggered opens when disableFocusOpen is true", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tooltip
+        label="Focus context"
+        delayDuration={0}
+        disableFocusOpen
+        skipAnimation
+      >
+        <TestButton>Focus target</TestButton>
+      </Tooltip>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "Focus target" })).toHaveFocus();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = render(
+      <Tooltip
+        defaultOpen
+        label="Styled context"
+        labelProps={{ "data-testid": "tooltip-content" }}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("data-tgph-appearance", "dark");
+    expect(content).toHaveAttribute("role", "tooltip");
+    expect(trigger).toHaveAttribute("aria-describedby", content.id);
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("preserves existing trigger descriptions when linking the tooltip", async () => {
+    render(
+      <Tooltip
+        defaultOpen
+        label="Described context"
+        labelProps={{ "data-testid": "tooltip-content" }}
+        skipAnimation
+      >
+        <TestButton aria-describedby="existing-description">
+          Hover target
+        </TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+
+    expect(
+      screen.getByRole("button", { name: "Hover target" }),
+    ).toHaveAttribute("aria-describedby", `existing-description ${content.id}`);
+  });
+
+  it("keeps the trigger description linked when labelProps includes an id", async () => {
+    render(
+      <Tooltip
+        defaultOpen
+        label="Described context"
+        labelProps={{
+          "data-testid": "tooltip-content",
+          id: "custom-tooltip-id",
+        }}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const content = await screen.findByTestId("tooltip-content");
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(content).not.toHaveAttribute("id", "custom-tooltip-id");
+    expect(trigger).toHaveAttribute("aria-describedby", content.id);
+  });
+
+  it("forwards trigger refs through tgphRef-compatible children", async () => {
+    const triggerRef = createRef<HTMLButtonElement>();
+
+    render(
+      <Tooltip
+        defaultOpen
+        label="Ref context"
+        triggerRef={triggerRef}
+        skipAnimation
+      >
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover target" });
+
+    expect(triggerRef.current).toBe(trigger);
+  });
+
+  it("opens grouped tooltips without delay after another tooltip is open", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipGroupProvider>
+        <Tooltip
+          defaultOpen
+          label="First context"
+          delayDuration={1000}
+          skipAnimation
+        >
+          <TestButton>First target</TestButton>
+        </Tooltip>
+        <Tooltip label="Second context" delayDuration={1000} skipAnimation>
+          <TestButton>Second target</TestButton>
+        </Tooltip>
+      </TooltipGroupProvider>,
+    );
+
+    await screen.findByText("First context");
+    await user.hover(screen.getByRole("button", { name: "Second target" }));
+
+    expect(await screen.findByText("Second context")).toBeInTheDocument();
   });
 });

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -1,51 +1,132 @@
-import * as RadixTooltip from "@radix-ui/react-tooltip";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import {
-  RefToTgphRef,
   type TgphComponentProps,
   type TgphElement,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  getBaseUIMotionOffset,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Text } from "@telegraph/typography";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  Children,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type RefObject,
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useId,
+  useState,
+} from "react";
 
+import { NO_COLLISION_AVOIDANCE } from "./Tooltip.helpers";
 import { useTooltipGroup } from "./Tooltip.hooks";
 
+type BaseTooltipRootProps = ComponentPropsWithoutRef<typeof BaseTooltip.Root>;
+type BaseTooltipProviderProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Provider
+>;
+type BaseTooltipTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Trigger
+>;
+type BaseTooltipPortalProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Portal
+>;
+type BaseTooltipPositionerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Positioner
+>;
+type BaseTooltipPopupProps = ComponentPropsWithoutRef<typeof BaseTooltip.Popup>;
+
+type BaseTooltipTriggerFocusEvent = Parameters<
+  NonNullable<BaseTooltipTriggerProps["onFocus"]>
+>[0];
+
+type TooltipPopupRenderState = {
+  open: boolean;
+};
+
+type LegacyTooltipProviderProps = Omit<
+  BaseTooltipProviderProps,
+  "children" | "delay" | "timeout"
+> & {
+  delayDuration?: BaseTooltipProviderProps["delay"];
+  skipDelayDuration?: BaseTooltipProviderProps["timeout"];
+};
+
+type LegacyTooltipRootProps = Omit<
+  BaseTooltipRootProps,
+  | "children"
+  | "defaultOpen"
+  | "disableHoverablePopup"
+  | "disabled"
+  | "onOpenChange"
+  | "open"
+> & {
+  defaultOpen?: BaseTooltipRootProps["defaultOpen"];
+  disableHoverableContent?: BaseTooltipRootProps["disableHoverablePopup"];
+  onOpenChange?: (open: boolean) => void;
+  open?: BaseTooltipRootProps["open"];
+};
+
+type LegacyTooltipPositionerProps = Omit<
+  BaseTooltipPositionerProps,
+  "children" | "className" | "render" | "style"
+> & {
+  avoidCollisions?: boolean;
+  hideWhenDetached?: boolean;
+};
+
+type LegacyTooltipPopupProps = Omit<
+  BaseTooltipPopupProps,
+  "children" | "className" | "render" | "style"
+> & {
+  "aria-label"?: BaseTooltipPopupProps["aria-label"];
+  forceMount?: BaseTooltipPortalProps["keepMounted"];
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onPointerDownOutside?: (
+    event: MouseEvent | PointerEvent | TouchEvent,
+  ) => void;
+};
+
 export type TooltipBaseProps<T extends TgphElement = "div"> = {
-  label: string | React.ReactNode;
+  children?: ReactNode;
+  label: ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
-  /**
-   * When `true`, prevents focus events from instantly opening the tooltip.
-   * Useful when a parent component (e.g. Select/Combobox) moves DOM focus on
-   * hover, which would otherwise bypass `delayDuration` via Radix's composed
-   * `onFocus` handler.
-   * @default false
-   */
+  asChild?: boolean;
+  // When true, prevents focus events from instantly opening the tooltip. This
+  // preserves delayed hover behavior when Select/Combobox move DOM focus on hover.
   disableFocusOpen?: boolean;
-
   skipAnimation?: boolean;
-  triggerRef?: React.RefObject<HTMLButtonElement>;
+  style?: TgphComponentProps<typeof Stack<T>>["style"];
+  triggerRef?: RefObject<HTMLButtonElement>;
 };
 
 export type TooltipProps<T extends TgphElement = "div"> =
-  React.ComponentPropsWithoutRef<typeof RadixTooltip.Root> &
-    React.ComponentPropsWithoutRef<typeof RadixTooltip.Provider> &
-    React.ComponentPropsWithoutRef<typeof RadixTooltip.Content> &
+  LegacyTooltipProviderProps &
+    LegacyTooltipRootProps &
+    LegacyTooltipPositionerProps &
+    LegacyTooltipPopupProps &
     TooltipBaseProps<T>;
 
 const Tooltip = <T extends TgphElement = "div">({
-  // Radix Tooltip Provider Props
   delayDuration = 400,
   skipDelayDuration,
+  closeDelay,
   disableHoverableContent,
-  // Radix Tooltip Root Props
   defaultOpen: defaultOpenProp,
   open: openProp,
   onOpenChange: onOpenChangeProp,
-  // Radix Tooltip Content Props
+  onOpenChangeComplete,
+  actionsRef,
+  handle,
+  trackCursorAxis,
+  triggerId,
+  defaultTriggerId,
   "aria-label": ariaLabel,
   onEscapeKeyDown,
   onPointerDownOutside,
@@ -54,161 +135,247 @@ const Tooltip = <T extends TgphElement = "div">({
   sideOffset = 4,
   align = "center",
   alignOffset,
+  anchor,
+  positionMethod,
   avoidCollisions,
+  collisionAvoidance,
   collisionBoundary,
   collisionPadding,
   arrowPadding,
   sticky,
+  disableAnchorTracking,
   hideWhenDetached,
-  skipAnimation,
-  // Label Props
   label,
   labelProps,
-  // Telegraph Props
   enabled = true,
   disableFocusOpen = false,
-
+  skipAnimation,
+  style,
   triggerRef,
+  id,
   children,
 }: TooltipProps<T>) => {
-  const [open, setOpen] = useControllableState({
-    prop: openProp,
-    onChange: onOpenChangeProp,
-    defaultProp: defaultOpenProp ?? false,
+  const generatedTooltipId = useId();
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(
+    defaultOpenProp ?? false,
+  );
+  // Base UI does not ship the Radix controllable-state helper, so keep the old
+  // controlled/uncontrolled behavior local to Tooltip.
+  const controlled = openProp !== undefined;
+  const open = controlled ? openProp : uncontrolledOpen;
+  // `enabled={false}` has historically forced the tooltip closed even when a
+  // controlled caller still passes `open`.
+  const resolvedOpen = enabled === false ? false : open;
+  const { groupOpen } = useTooltipGroup({
+    open: Boolean(resolvedOpen),
+    delay: delayDuration,
   });
-  const { groupOpen } = useTooltipGroup({ open: !!open, delay: delayDuration });
 
-  const areAnyChildrenElementsDisabled = React.Children.toArray(children).some(
+  const areAnyChildrenElementsDisabled = Children.toArray(children).some(
     (child) => {
-      if (React.isValidElement(child)) {
+      if (isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
         return childProps.disabled;
       }
+
       return false;
     },
   );
 
+  // Disabled trigger children do not reliably emit hover/focus timing events,
+  // so match the previous Radix behavior by removing the delay in that case.
   const derivedDelayDuration =
     groupOpen || areAnyChildrenElementsDisabled ? 0 : delayDuration;
-
-  const shouldAnimate = !groupOpen;
-
-  const deriveAnimationBasedOnSide = (side: TooltipProps<T>["side"]) => {
-    const ANIMATION_OFFSET = 5;
-    if (side === "top") {
-      return {
-        y: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "bottom") {
-      return {
-        y: ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "left") {
-      return {
-        x: -ANIMATION_OFFSET,
-      };
-    }
-
-    if (side === "right") {
-      return {
-        x: ANIMATION_OFFSET,
-      };
-    }
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  const popupLabelProps = labelProps as
+    | TgphComponentProps<typeof Stack>
+    | undefined;
+  const { style: labelStyle, ...popupLabelRestProps } = popupLabelProps ?? {};
+  const popupStyle = {
+    transformOrigin: "var(--transform-origin)",
+    ...style,
+    ...labelStyle,
   };
+  const shouldAnimate = !groupOpen;
+  const tooltipId = id ?? generatedTooltipId;
+  const triggerDataState = resolvedOpen ? "open" : "closed";
+  const existingAriaDescribedBy = isValidElement(children)
+    ? ((children.props as Record<string, unknown>)["aria-describedby"] as
+        | string
+        | undefined)
+    : undefined;
+  // Preserve any caller-provided description id while appending the tooltip id
+  // only while the tooltip is actually exposed.
+  const triggerAriaDescribedBy =
+    [existingAriaDescribedBy, resolvedOpen ? tooltipId : undefined]
+      .filter(Boolean)
+      .join(" ") || undefined;
+
+  const handleOpenChange = useCallback<
+    NonNullable<BaseTooltipRootProps["onOpenChange"]>
+  >(
+    (nextOpen, eventDetails) => {
+      if (
+        !nextOpen &&
+        callLegacyDismissHandlers(eventDetails, {
+          onEscapeKeyDown,
+          onPointerDownOutside,
+        })
+      ) {
+        // Legacy Radix dismissal handlers could cancel close; translate that
+        // prevention back to Base UI's eventDetails cancel API.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (!controlled) {
+        // Controlled callers receive the callback below but keep ownership of
+        // the actual open value.
+        setUncontrolledOpen(nextOpen);
+      }
+
+      onOpenChangeProp?.(nextOpen);
+    },
+    [controlled, onEscapeKeyDown, onOpenChangeProp, onPointerDownOutside],
+  );
+
+  const handleFocus = useCallback(
+    (event: BaseTooltipTriggerFocusEvent) => {
+      if (disableFocusOpen) {
+        // Base UI composes focus open internally, so prevent both the DOM event
+        // and Base UI's handler to preserve the old opt-out prop.
+        event.preventDefault();
+        event.preventBaseUIHandler();
+      }
+    },
+    [disableFocusOpen],
+  );
 
   return (
     <LazyMotion features={domAnimation}>
-      <RadixTooltip.Provider
-        delayDuration={derivedDelayDuration}
-        skipDelayDuration={skipDelayDuration}
-        disableHoverableContent={disableHoverableContent}
+      <BaseTooltip.Provider
+        delay={derivedDelayDuration}
+        closeDelay={closeDelay}
+        timeout={skipDelayDuration}
       >
-        <RadixTooltip.Root
-          open={enabled === false ? false : open}
-          onOpenChange={setOpen}
+        <BaseTooltip.Root
+          actionsRef={actionsRef}
+          defaultTriggerId={defaultTriggerId}
+          disabled={enabled === false}
+          disableHoverablePopup={disableHoverableContent}
+          handle={handle}
+          onOpenChange={handleOpenChange}
+          onOpenChangeComplete={onOpenChangeComplete}
+          open={resolvedOpen}
+          trackCursorAxis={trackCursorAxis}
+          triggerId={triggerId}
         >
-          <RadixTooltip.Trigger asChild={true} ref={triggerRef}>
-            <RefToTgphRef
-              {...(disableFocusOpen
-                ? { onFocus: (e: React.FocusEvent) => e.preventDefault() }
-                : {})}
+          {isValidElement(children) ? (
+            <BaseTooltip.Trigger
+              aria-describedby={triggerAriaDescribedBy}
+              data-state={triggerDataState}
+              delay={derivedDelayDuration}
+              onFocus={handleFocus}
+              ref={triggerRef}
+              render={createTgphBaseUIRender(
+                cloneElement(children, {
+                  "aria-describedby": triggerAriaDescribedBy,
+                  "data-state": triggerDataState,
+                } as Record<string, unknown>),
+              )}
+            />
+          ) : (
+            <BaseTooltip.Trigger
+              aria-describedby={triggerAriaDescribedBy}
+              data-state={triggerDataState}
+              delay={derivedDelayDuration}
+              onFocus={handleFocus}
+              ref={triggerRef}
             >
               {children}
-            </RefToTgphRef>
-          </RadixTooltip.Trigger>
-          <RadixTooltip.Portal>
-            <RadixTooltip.Content
-              aria-label={ariaLabel}
-              onEscapeKeyDown={onEscapeKeyDown}
-              onPointerDownOutside={onPointerDownOutside}
-              forceMount={forceMount}
-              side={side}
-              sideOffset={sideOffset}
+            </BaseTooltip.Trigger>
+          )}
+          <BaseTooltip.Portal keepMounted={forceMount}>
+            <BaseTooltip.Positioner
               align={align}
               alignOffset={alignOffset}
-              avoidCollisions={avoidCollisions}
+              anchor={anchor}
+              arrowPadding={arrowPadding}
+              collisionAvoidance={resolvedCollisionAvoidance}
               collisionBoundary={collisionBoundary}
               collisionPadding={collisionPadding}
-              arrowPadding={arrowPadding}
+              disableAnchorTracking={disableAnchorTracking}
+              positionMethod={positionMethod}
+              side={side}
+              sideOffset={sideOffset}
               sticky={sticky}
-              hideWhenDetached={hideWhenDetached}
-              style={{
-                zIndex: `var(--tgph-zIndex-tooltip)`,
-              }}
+              style={(state) =>
+                getBaseUIPositionerVisibilityStyle({
+                  anchorHidden: state.anchorHidden,
+                  hideWhenDetached,
+                  zIndex: "var(--tgph-zIndex-tooltip)",
+                })
+              }
             >
-              <Stack
-                as={motion.div}
-                // Add tgph class so that this always works in portals
-                className="tgph"
-                initial={
-                  shouldAnimate && !skipAnimation
-                    ? {
-                        opacity: 0,
-                        scale: 0.8,
-                        ...deriveAnimationBasedOnSide(side),
+              <BaseTooltip.Popup
+                aria-label={ariaLabel}
+                id={tooltipId}
+                render={createTgphBaseUIRender(
+                  (state: TooltipPopupRenderState) => (
+                    <Stack
+                      as={motion.div}
+                      className="tgph"
+                      initial={
+                        shouldAnimate && !skipAnimation
+                          ? {
+                              opacity: 0,
+                              scale: 0.8,
+                              ...getBaseUIMotionOffset(side),
+                            }
+                          : {}
                       }
-                    : {}
-                }
-                animate={{
-                  opacity: 1,
-                  scale: 1,
-                  x: 0,
-                  y: 0,
-                }}
-                transition={{
-                  duration: 0.1,
-                  type: "spring",
-                  bounce: 0,
-                }}
-                bg="surface-1"
-                shadow="2"
-                rounded="3"
-                py="1_5"
-                px="2"
-                align="center"
-                justify="center"
-                style={{
-                  transformOrigin:
-                    "var(--radix-tooltip-content-transform-origin)",
-                }}
-                {...(labelProps ?? {})}
-              >
-                {typeof label === "string" ? (
-                  <Text as="span" size="1">
-                    {label}
-                  </Text>
-                ) : (
-                  label
+                      animate={{
+                        opacity: 1,
+                        scale: 1,
+                        x: 0,
+                        y: 0,
+                      }}
+                      transition={{
+                        duration: 0.1,
+                        type: "spring",
+                        bounce: 0,
+                      }}
+                      bg="surface-1"
+                      data-state={state.open ? "open" : "closed"}
+                      data-tgph-appearance="dark"
+                      shadow="2"
+                      rounded="3"
+                      py="1_5"
+                      px="2"
+                      align="center"
+                      justify="center"
+                      style={popupStyle}
+                      {...popupLabelRestProps}
+                      id={tooltipId}
+                      role="tooltip"
+                    >
+                      {typeof label === "string" ? (
+                        <Text as="span" size="1">
+                          {label}
+                        </Text>
+                      ) : (
+                        label
+                      )}
+                    </Stack>
+                  ),
                 )}
-              </Stack>
-            </RadixTooltip.Content>
-          </RadixTooltip.Portal>
-        </RadixTooltip.Root>
-      </RadixTooltip.Provider>
+              />
+            </BaseTooltip.Positioner>
+          </BaseTooltip.Portal>
+        </BaseTooltip.Root>
+      </BaseTooltip.Provider>
     </LazyMotion>
   );
 };

--- a/packages/tooltip/vitest.config.mts
+++ b/packages/tooltip/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "tooltip",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/packages/truncate/README.md
+++ b/packages/truncate/README.md
@@ -62,11 +62,11 @@ const CustomTruncatedComponent = () => {
 
 A text component that automatically truncates content with an ellipsis and shows a tooltip when truncated.
 
-| Prop           | Type                               | Default     | Description                                                     |
-| -------------- | ---------------------------------- | ----------- | --------------------------------------------------------------- |
-| `maxWidth`     | `string`                           | `undefined` | Maximum width of the text container                             |
-| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>` | `undefined` | Props to pass to the underlying TooltipIfTruncated component |
-| `...TextProps` | `TgphComponentProps<typeof Text>`  | -           | All props from [@telegraph/typography](../typography/README.md) |
+| Prop           | Type                                                     | Default     | Description                                                     |
+| -------------- | -------------------------------------------------------- | ----------- | --------------------------------------------------------------- |
+| `maxWidth`     | `string`                                                 | `undefined` | Maximum width of the text container                             |
+| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>` | `undefined` | Props to pass to the underlying TooltipIfTruncated component    |
+| `...TextProps` | `TgphComponentProps<typeof Text>`                        | -           | All props from [@telegraph/typography](../typography/README.md) |
 
 ### `<TooltipIfTruncated>`
 
@@ -78,16 +78,18 @@ A component that conditionally shows a tooltip only when its content is truncate
 | `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                               |
 | `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                     |
 
+`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It continues to pass tooltip props through unchanged and only enables the tooltip when `useTruncate` detects overflow.
+
 ### `useTruncate`
 
 A hook that detects whether an element's content is truncated.
 
 #### Parameters
 
-| Name     | Type                                        | Description                                                           |
-| -------- | ------------------------------------------- | --------------------------------------------------------------------- |
+| Name     | Type                                                | Description                                                           |
+| -------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `params` | `{ tgphRef: React.RefObject<HTMLElement \| null> }` | A ref to the element to check for truncation                          |
-| `deps`   | `React.DependencyList`                      | Optional dependencies to re-run the truncation check when they change |
+| `deps`   | `React.DependencyList`                              | Optional dependencies to re-run the truncation check when they change |
 
 #### Returns
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -1,0 +1,84 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ComponentPropsWithoutRef, type Ref } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TooltipIfTruncated } from "./TooltipIfTruncated";
+
+type TestTriggerProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const TestTrigger = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestTriggerProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+  Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+    configurable: true,
+    get() {
+      return Number(this.getAttribute("data-scroll-width") ?? 0);
+    },
+  });
+
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return Number(this.getAttribute("data-client-width") ?? 0);
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("TooltipIfTruncated", () => {
+  it("shows the tooltip when the child is truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Long value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Long value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Long value");
+  });
+
+  it("keeps the tooltip disabled when the child is not truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="80" data-client-width="100">
+          Short value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Short value" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -5,7 +5,7 @@ import {
 } from "@telegraph/helpers";
 import { Tooltip } from "@telegraph/tooltip";
 import { Text } from "@telegraph/typography";
-import React from "react";
+import { type ReactNode, type RefObject, isValidElement, useRef } from "react";
 
 import { useTruncate } from "../useTruncate";
 
@@ -19,31 +19,30 @@ const TooltipIfTruncated = ({
   children,
   ...props
 }: TooltipIfTruncatedProps) => {
-  const truncateRef = React.useRef<HTMLButtonElement>(null);
+  const truncateRef = useRef<HTMLButtonElement>(null);
   const { truncated } = useTruncate(
-    { tgphRef: truncateRef as React.RefObject<HTMLElement> },
+    { tgphRef: truncateRef as RefObject<HTMLElement> },
     [children],
   );
 
-  // We extract the text so that we can properly wrap it in the Text component
-  const textToDisplayInTooltip = React.useMemo(() => {
+  const textToDisplayInTooltip = (() => {
     if (typeof children === "string") return children;
-    if (React.isValidElement(children)) {
+    if (isValidElement(children)) {
       const childProps = children.props as Record<string, unknown>;
       return childProps.children;
     }
     return label;
-  }, [children, label]);
+  })();
 
   return (
     <Tooltip
       label={
         <Text as="span" size="1">
-          {textToDisplayInTooltip as React.ReactNode}
+          {textToDisplayInTooltip as ReactNode}
         </Text>
       }
       enabled={truncated}
-      triggerRef={truncateRef as React.RefObject<HTMLButtonElement>}
+      triggerRef={truncateRef as RefObject<HTMLButtonElement>}
       {...props}
     >
       <RefToTgphRef>{children}</RefToTgphRef>

--- a/packages/vite-config/README.md
+++ b/packages/vite-config/README.md
@@ -46,6 +46,7 @@ This configuration provides optimized Vite settings specifically tailored for Te
 - **TypeScript Support**: Proper TypeScript configuration and path resolution
 - **Asset Handling**: Optimized asset processing and public path configuration
 - **Plugin Integration**: Pre-configured plugins for Telegraph development
+- **Dependency Externalization**: Package dependencies, peer dependencies, dev dependencies, and their subpath imports stay external in library builds
 
 ## API Reference
 

--- a/packages/vite-config/src/vite-config.ts
+++ b/packages/vite-config/src/vite-config.ts
@@ -32,6 +32,18 @@ const nodeBuiltins = [
   ...builtinModules.map((name) => `node:${name}`),
 ];
 
+const isPackageImport = (id: string, packageName: string) => {
+  return id === packageName || id.startsWith(`${packageName}/`);
+};
+
+const isExternalDependency = (id: string) => {
+  return allDependencies.some((dependency) => isPackageImport(id, dependency));
+};
+
+const isNodeBuiltin = (id: string) => {
+  return nodeBuiltins.some((builtin) => isPackageImport(id, builtin));
+};
+
 const buildTimeInfo = {
   format: "es",
 };
@@ -59,7 +71,9 @@ export default {
       },
     },
     rolldownOptions: {
-      external: [...allDependencies, ...nodeBuiltins],
+      external: (id: string) => {
+        return isExternalDependency(id) || isNodeBuiltin(id);
+      },
       output: {
         assetFileNames: (assetInfo: Rollup.PreRenderedAsset) => {
           if (assetInfo?.name?.endsWith(".css")) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3551,36 +3551,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tooltip@npm:^1.2.8":
-  version: 1.2.8
-  resolution: "@radix-ui/react-tooltip@npm:1.2.8"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/de0cbae9c571a00671f160928d819e59502f59be8749f536ab4b180181d9d70aee3925a5b2555f8f32d0bea622bc35f65b70ca7ff0449e4844f891302310cc48
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-use-callback-ref@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
@@ -3680,25 +3650,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/851d09a816f44282e0e9e2147b1b571410174cc048703a50c4fa54d672de994fd1dfff1da9d480ecfd12c77ae8f48d74f01adaf668f074156b8cd0043c6c21d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-visually-hidden@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.3"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/cf86a37f1cbee50a964056f3dc4f6bb1ee79c76daa321f913aa20ff3e1ccdfafbf2b114d7bb616aeefc7c4b895e6ca898523fdb67710d89bd5d8edb739a0d9b6
   languageName: node
   linkType: hard
 
@@ -4913,10 +4864,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/tooltip@workspace:packages/tooltip"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-tooltip": "npm:^1.2.8"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
     "@telegraph/appearance": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #841.
- Linear: [KNO-13669](https://linear.app/knock/issue/KNO-13669).

## What changed

- Migrates `@telegraph/tooltip` from Radix Tooltip to Base UI Tooltip.
- Reuses shared helper dismissal, visibility, and motion compatibility utilities from `@telegraph/helpers`.
- Keeps local Tooltip helpers limited to tooltip-specific collision settings.
- Preserves public prop names, trigger descriptions, `tgphRef` rendering, grouped delay behavior, portal styling, and legacy dismiss callbacks.

## Why

- Removes Tooltip's Radix dependency while preserving long-standing Telegraph/Radix-style API names and visuals.
- Keeps shared migration behavior consistent with Popover and future overlay components.

## Verification

- `yarn test packages/helpers/src/base-ui/compatibility.test.ts packages/tooltip/src/Tooltip/Tooltip.test.tsx`
- `yarn workspace @telegraph/tooltip build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
