### PR TITLE
refactor(menu): migrate Menu to Base UI

### DIFF
--- a/.changeset/soft-menus-rhyme.md
+++ b/.changeset/soft-menus-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/combobox": patch
+"@telegraph/menu": minor
+---
+
+Migrate Menu internals to Base UI while preserving Telegraph dismissal callbacks, focus callbacks, `avoidCollisions`, `hideWhenDetached`, trigger refs, submenu state attributes, and portal styling. Combobox trigger aria labels now fall back to option values when labels are rendered as React nodes so assistive text remains string-safe.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "turbo lint --filter=\"./packages/**\" --filter=\"!@telegraph/prettier-config\"",
     "format": "turbo format",
     "format:check": "turbo format:check",
-    "dev:storybook": "storybook dev --port 3005",
+    "dev:storybook": "storybook dev --port 3005 --no-open --exact-port",
     "build:storybook": "storybook build",
     "release": "yarn release:publish && yarn changeset tag",
     "release:publish": "yarn workspaces foreach -Rpt --no-private --from '@telegraph/*' npm publish --access public --tolerate-republish",

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
-import { Combobox } from "./Combobox";
+import { Combobox, getOptionAccessibleLabel } from "./Combobox";
 import { findStringNodes } from "./Combobox.helpers";
 import type { ComboboxContentProps, ComboboxOptionsProps } from "./index";
 
@@ -713,6 +713,14 @@ describe("findStringNodes", () => {
       </p>
     );
     expect(findStringNodes(node)).toStrictEqual(["Lorem", "ipsum", "dolor"]);
+  });
+});
+
+describe("getOptionAccessibleLabel", () => {
+  it("falls back to the option value when the label is an empty string", () => {
+    expect(getOptionAccessibleLabel({ value: "email", label: "" })).toBe(
+      "email",
+    );
   });
 });
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -14,7 +14,23 @@ import { Box, Stack } from "@telegraph/layout";
 import { Menu as TelegraphMenu } from "@telegraph/menu";
 import { Text } from "@telegraph/typography";
 import { Plus, Search as SearchIcon, X } from "lucide-react";
-import React from "react";
+import {
+  type CSSProperties,
+  type ChangeEvent,
+  type MouseEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type KeyboardEventHandler as ReactKeyboardEventHandler,
+  type ReactNode,
+  type RefObject,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { TRIGGER_MIN_HEIGHT } from "./Combobox.constants";
 import {
@@ -36,6 +52,22 @@ import type {
 const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
 const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
 const SELECT_KEYS = ["Enter", " "];
+
+export const getOptionAccessibleLabel = (option?: DefinedOption) => {
+  if (!option) {
+    return undefined;
+  }
+
+  if (typeof option.label === "string" && option.label !== "") {
+    return option.label;
+  }
+
+  if (typeof option.label === "number" || typeof option.label === "bigint") {
+    return String(option.label);
+  }
+
+  return option.value;
+};
 
 type LayoutValue<O> = O extends DefinedOption | string | undefined
   ? never
@@ -64,10 +96,10 @@ export type RootProps<
    * Useful for long lists where you want to start at a specific position.
    */
   defaultScrollToValue?: string;
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
-export const ComboboxContext = React.createContext<
+export const ComboboxContext = createContext<
   Omit<
     RootProps<(Option | Array<Option>) | (string | Array<string>), boolean>,
     "children"
@@ -79,9 +111,9 @@ export const ComboboxContext = React.createContext<
     onOpenToggle: () => void;
     searchQuery?: string;
     setSearchQuery?: (query: string) => void;
-    triggerRef?: React.RefObject<HTMLDivElement>;
-    searchRef?: React.RefObject<HTMLInputElement>;
-    contentRef?: React.RefObject<HTMLDivElement>;
+    triggerRef?: RefObject<HTMLButtonElement>;
+    searchRef?: RefObject<HTMLInputElement>;
+    contentRef?: RefObject<HTMLDivElement>;
     options: Array<DefinedOption>;
     legacyBehavior: boolean;
     defaultScrollToValue?: string;
@@ -122,17 +154,17 @@ const Root = <
   children,
   ...props
 }: RootProps<O, LB>) => {
-  const contentId = React.useId();
-  const triggerId = React.useId();
-  const triggerRef = React.useRef<HTMLDivElement>(null);
-  const searchRef = React.useRef<HTMLInputElement>(null);
-  const contentRef = React.useRef<HTMLDivElement>(null);
+  const contentId = useId();
+  const triggerId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
-  const options = React.useMemo(() => {
+  const options = useMemo(() => {
     return getOptions(children);
   }, [children]);
 
-  const [searchQuery, setSearchQuery] = React.useState<string>("");
+  const [searchQuery, setSearchQuery] = useState<string>("");
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpenProp ?? false,
@@ -145,13 +177,11 @@ const Root = <
     onChange: onValueChangeProp as (value: O) => void,
   });
 
-  const onOpenToggle = React.useCallback(() => {
+  const onOpenToggle = useCallback(() => {
     setOpen((prevOpen) => !prevOpen);
   }, [setOpen]);
 
-  React.useEffect(() => {
-    // If the combobox is closed clear
-    // the search query
+  useEffect(() => {
     if (!open) {
       setSearchQuery("");
     }
@@ -176,9 +206,9 @@ const Root = <
         disabled,
         searchQuery,
         setSearchQuery,
-        triggerRef: triggerRef as React.RefObject<HTMLDivElement>,
-        searchRef: searchRef as React.RefObject<HTMLInputElement>,
-        contentRef: contentRef as React.RefObject<HTMLDivElement>,
+        triggerRef: triggerRef as RefObject<HTMLButtonElement>,
+        searchRef: searchRef as RefObject<HTMLInputElement>,
+        contentRef: contentRef as RefObject<HTMLDivElement>,
         errored,
         layout,
         options,
@@ -217,9 +247,7 @@ type TriggerBaseProps = RemappedOmit<
 
 export type TriggerProps<V extends ChildrenValue> = TriggerBaseProps & {
   placeholder?: string;
-  children?:
-    | React.ReactNode
-    | ((props: { value: ChildrenFnValue<V> }) => React.ReactNode);
+  children?: ReactNode | ((props: { value: ChildrenFnValue<V> }) => ReactNode);
 };
 
 const Trigger = <V extends ChildrenValue>({
@@ -227,10 +255,10 @@ const Trigger = <V extends ChildrenValue>({
   children,
   ...props
 }: TriggerProps<V>) => {
-  const context = React.useContext(ComboboxContext);
+  const context = useContext(ComboboxContext);
   const hasTags = isMultiSelect(context.value) && context.value.length > 0;
 
-  const currentValue = React.useMemo<
+  const currentValue = useMemo<
     DefinedOption | Array<DefinedOption | undefined> | undefined
   >(() => {
     if (!context.value) return undefined;
@@ -249,15 +277,17 @@ const Trigger = <V extends ChildrenValue>({
     return undefined;
   }, [context.value, context.options, context.legacyBehavior]);
 
-  const getAriaLabelString = React.useCallback(() => {
+  const getAriaLabelString = useCallback(() => {
     if (!currentValue) return context.placeholder;
     if (isSingleSelect(currentValue)) {
-      return currentValue?.label || currentValue?.value || context.placeholder;
+      return getOptionAccessibleLabel(currentValue) || context.placeholder;
     }
     if (isMultiSelect(currentValue)) {
       return (
-        currentValue.map((v) => v?.label || v?.value).join(", ") ||
-        context.placeholder
+        currentValue
+          .map((option) => getOptionAccessibleLabel(option))
+          .filter(Boolean)
+          .join(", ") || context.placeholder
       );
     }
 
@@ -267,12 +297,12 @@ const Trigger = <V extends ChildrenValue>({
     <TelegraphMenu.Trigger
       {...props}
       asChild
-      onClick={(event: React.MouseEvent) => {
+      onClick={(event: MouseEvent) => {
         event.preventDefault();
         context.onOpenToggle();
         context.triggerRef?.current?.focus();
       }}
-      onKeyDown={(event: React.KeyboardEvent) => {
+      onKeyDown={(event: ReactKeyboardEvent) => {
         // If the event target isn't exactly the trigger we don't want anything to
         // happen within this event handler. For example, if the `X` icon on a trigger
         // tag is focused and the user presses `Enter`, this keydown event will trigger.
@@ -352,17 +382,17 @@ const Content = <T extends TgphElement = "div">({
   tgphRef,
   ...props
 }: ContentProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const hasInteractedOutside = React.useRef(false);
+  const context = useContext(ComboboxContext);
+  const hasInteractedOutside = useRef(false);
   const composedRef = useComposedRefs<unknown>(tgphRef, context.contentRef);
 
-  const internalContentRef = React.useRef(null);
+  const internalContentRef = useRef(null);
 
-  const [height, setHeight] = React.useState(0);
+  const [height, setHeight] = useState(0);
   const [initialAnimationComplete, setInitialAnimationComplete] =
-    React.useState(false);
+    useState(false);
 
-  const setHeightFromContent = React.useCallback(
+  const setHeightFromContent = useCallback(
     (element: Element) => {
       // Set the initial height of the content after the animation completes
       const rect = element?.getBoundingClientRect();
@@ -377,7 +407,7 @@ const Content = <T extends TgphElement = "div">({
     [initialAnimationComplete],
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const element = entry.target;
@@ -394,7 +424,7 @@ const Content = <T extends TgphElement = "div">({
   }, [initialAnimationComplete, setHeightFromContent]);
 
   // Reset the animation complete state when the combobox is closed
-  React.useEffect(() => {
+  useEffect(() => {
     if (initialAnimationComplete === true && context.open === false) {
       setInitialAnimationComplete(false);
     }
@@ -403,7 +433,7 @@ const Content = <T extends TgphElement = "div">({
   // On open, set the height of the content after the animation completes
   // we add a timeout here to ensure that the DOM element has responded to
   // the state changes first
-  React.useEffect(() => {
+  useEffect(() => {
     let timeout: NodeJS.Timeout;
     if (context.open) {
       timeout = setTimeout(() => {
@@ -462,7 +492,7 @@ const Content = <T extends TgphElement = "div">({
         // Cancel out accessibility attirbutes related to aria menu
         role={undefined}
         aria-orientation={undefined}
-        onKeyDown={(event: React.KeyboardEvent) => {
+        onKeyDown={(event: ReactKeyboardEvent) => {
           // Don't allow the event to bubble up outside of the menu
           event.stopPropagation();
 
@@ -496,12 +526,12 @@ const Options = <T extends TgphElement = "div">({
   tgphRef,
   ...props
 }: OptionsProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const optionsRef = React.useRef<HTMLDivElement>(null);
+  const context = useContext(ComboboxContext);
+  const optionsRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs<unknown>(tgphRef, optionsRef);
 
   // Scroll to the selected option (or defaultScrollToValue) when the combobox opens
-  React.useEffect(() => {
+  useEffect(() => {
     if (context.open && optionsRef.current) {
       // Small delay to ensure the DOM has rendered
       requestAnimationFrame(() => {
@@ -556,7 +586,7 @@ const Options = <T extends TgphElement = "div">({
           "--max-height": !props.maxHeight
             ? "calc(var(--tgph-combobox-content-available-height) - var(--tgph-spacing-12))"
             : undefined,
-        } as React.CSSProperties
+        } as CSSProperties
       }
       // Accessibility attributes
       role="listbox"
@@ -580,10 +610,11 @@ const Option = <T extends TgphElement>({
   selected,
   onSelect,
   children,
+  closeOnClick,
   ...props
 }: OptionProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const [isFocused, setIsFocused] = React.useState(false);
+  const context = useContext(ComboboxContext);
+  const [isFocused, setIsFocused] = useState(false);
   const contextValue = context.value;
 
   const isVisible =
@@ -600,12 +631,12 @@ const Option = <T extends TgphElement>({
       )
     : getValueFromOption(contextValue, context.legacyBehavior) === value;
 
-  const handleSelection = (event: Event | React.KeyboardEvent) => {
+  const handleSelection = (event: Event | ReactKeyboardEvent) => {
     // Don't allow the event to bubble up outside of the menu
     event.stopPropagation();
 
     // Don't do anything if the key isn't a selection key
-    const keyboardEvent = event as React.KeyboardEvent;
+    const keyboardEvent = event as ReactKeyboardEvent;
     if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) return;
 
     // Don't bubble up the event
@@ -659,7 +690,8 @@ const Option = <T extends TgphElement>({
       <TelegraphMenu.Button
         type="button"
         onSelect={handleSelection as (event: Event) => void}
-        onKeyDown={handleSelection as React.KeyboardEventHandler}
+        onKeyDown={handleSelection as ReactKeyboardEventHandler}
+        closeOnClick={closeOnClick ?? context.closeOnSelect}
         // Force null if selected equals null so we
         // can override the icon of the button
         selected={selected === null ? null : (selected ?? isSelected)}
@@ -693,14 +725,14 @@ const Search = ({
   onValueChange: onValueChangeProp,
   ...props
 }: SearchProps) => {
-  const id = React.useId();
-  const context = React.useContext(ComboboxContext);
+  const id = useId();
+  const context = useContext(ComboboxContext);
   const composedRef = useComposedRefs(tgphRef, context.searchRef);
 
   const value = controlledValueProp ?? context.searchQuery;
   const onValueChange = onValueChangeProp ?? context.setSearchQuery;
 
-  React.useEffect(() => {
+  useEffect(() => {
     const handleSearchKeyDown = (event: KeyboardEvent) => {
       if (FIRST_KEYS.includes(event.key)) {
         context.contentRef?.current?.focus({ preventScroll: true });
@@ -735,7 +767,7 @@ const Search = ({
         variant="ghost"
         placeholder={placeholder}
         value={value}
-        onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
           onValueChange(event.target.value);
         }}
         LeadingComponent={<Icon icon={SearchIcon} alt="Search Icon" />}
@@ -772,10 +804,10 @@ const Empty = <T extends TgphElement>({
   children,
   ...props
 }: EmptyProps<T>) => {
-  const context = React.useContext(ComboboxContext);
-  const [isVisible, setIsVisible] = React.useState(false);
+  const context = useContext(ComboboxContext);
+  const [isVisible, setIsVisible] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const options = context.contentRef?.current?.querySelectorAll(
       "[data-tgph-combobox-option]",
     );
@@ -830,9 +862,9 @@ const Create = <T extends TgphElement, LB extends boolean>({
   legacyBehavior = false as LB,
   ...props
 }: CreateProps<T, LB>) => {
-  const context = React.useContext(ComboboxContext);
+  const context = useContext(ComboboxContext);
 
-  const variableAlreadyExists = React.useCallback(
+  const variableAlreadyExists = useCallback(
     (searchQuery: string | undefined) => {
       if (!values || values?.length === 0) return false;
       return values.some(

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -1,6 +1,6 @@
 # 📋 Menu
 
-> Accessible dropdown menu component built on Radix UI with Telegraph design system styling.
+> Accessible dropdown menu component built on Base UI with Telegraph design system styling.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -88,19 +88,26 @@ The trigger element that opens/closes the menu. Must wrap a single focusable ele
 
 The dropdown content container that holds menu items.
 
-| Prop          | Type                                     | Default    | Description                   |
-| ------------- | ---------------------------------------- | ---------- | ----------------------------- |
-| `side`        | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"` | Side to display menu          |
-| `align`       | `"start" \| "center" \| "end"`           | `"center"` | Alignment relative to trigger |
-| `sideOffset`  | `number`                                 | `4`        | Distance from trigger         |
-| `gap`         | `SpacingToken`                           | `"1"`      | Gap between menu items        |
-| `py`          | `SpacingToken`                           | `"1"`      | Vertical padding              |
-| `rounded`     | `RoundedToken`                           | `"4"`      | Border radius                 |
-| `shadow`      | `ShadowToken`                            | `"2"`      | Drop shadow                   |
-| `border`      | `SpacingToken`                           | `"px"`     | Border width                  |
-| `borderColor` | `ColorToken`                             | `"gray-8"` | Border color                  |
+| Prop          | Type                                     | Default    | Description                      |
+| ------------- | ---------------------------------------- | ---------- | -------------------------------- |
+| `side`        | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"` | Side to display menu             |
+| `align`       | `"start" \| "center" \| "end"`           | `"center"` | Alignment relative to trigger    |
+| `sideOffset`  | `number`                                 | `4`        | Distance from trigger            |
+| `gap`         | `SpacingToken`                           | `"1"`      | Gap between menu items           |
+| `py`          | `SpacingToken`                           | `"1"`      | Vertical padding                 |
+| `rounded`     | `RoundedToken`                           | `"4"`      | Border radius                    |
+| `shadow`      | `ShadowToken`                            | `"2"`      | Drop shadow                      |
+| `border`      | `SpacingToken`                           | `"px"`     | Border width                     |
+| `borderColor` | `ColorToken`                             | `"gray-8"` | Border color                     |
+| `forceMount`  | `boolean`                                | `false`    | Keep content mounted when closed |
 
 All Stack props are also supported for additional styling.
+
+`Menu.Content` renders in a portal with `className="tgph"` so Telegraph styles
+and CSS variables remain available outside the local subtree. The package also
+continues to expose Radix-compatible Popper CSS custom properties, such as
+`--radix-popper-anchor-width` and `--radix-popper-available-height`, mapped to
+Base UI's positioning variables for downstream style compatibility.
 
 ### `<Menu.Button>`
 
@@ -125,23 +132,23 @@ Inherits all Button props for additional styling.
 Groups a `Menu.SubTrigger` with its `Menu.SubContent` to create a nested submenu
 that opens on hover/focus. Render it inside a `Menu.Content`.
 
-| Prop           | Type                      | Default     | Description                      |
-| -------------- | ------------------------- | ----------- | -------------------------------- |
-| `open`         | `boolean`                 | `undefined` | Controlled open state            |
-| `defaultOpen`  | `boolean`                 | `false`     | Initial open state (uncontrolled)|
-| `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes |
+| Prop           | Type                      | Default     | Description                       |
+| -------------- | ------------------------- | ----------- | --------------------------------- |
+| `open`         | `boolean`                 | `undefined` | Controlled open state             |
+| `defaultOpen`  | `boolean`                 | `false`     | Initial open state (uncontrolled) |
+| `onOpenChange` | `(open: boolean) => void` | `undefined` | Callback when open state changes  |
 
 ### `<Menu.SubTrigger>`
 
 The item inside a `Menu.Sub` that opens the submenu on hover (or `→` / `Enter`).
 Accepts the same props as `Menu.Button` and defaults to a trailing chevron icon.
 
-| Prop           | Type              | Default        | Description                                   |
-| -------------- | ----------------- | -------------- | --------------------------------------------- |
-| `children`     | `React.ReactNode` | required       | Trigger label                                 |
-| `trailingIcon` | `IconProps`       | `ChevronRight` | Trailing icon; pass your own to override      |
-| `leadingIcon`  | `IconProps`       | `undefined`    | Icon before text                              |
-| `disabled`     | `boolean`         | `false`        | Whether the submenu trigger is disabled       |
+| Prop           | Type              | Default        | Description                              |
+| -------------- | ----------------- | -------------- | ---------------------------------------- |
+| `children`     | `React.ReactNode` | required       | Trigger label                            |
+| `trailingIcon` | `IconProps`       | `ChevronRight` | Trailing icon; pass your own to override |
+| `leadingIcon`  | `IconProps`       | `undefined`    | Icon before text                         |
+| `disabled`     | `boolean`         | `false`        | Whether the submenu trigger is disabled  |
 
 Inherits all `Menu.Button` props.
 
@@ -151,14 +158,14 @@ The container for a submenu's items. Always opens to the side of its trigger
 (`right`, flipping to `left` on collision); `side` and `align` are managed
 automatically and are not accepted.
 
-| Prop          | Type           | Default | Description                           |
-| ------------- | -------------- | ------- | ------------------------------------- |
-| `sideOffset`  | `number`       | `0`     | Distance from the trigger             |
-| `alignOffset` | `number`       | `0`     | Offset along the trigger's edge       |
-| `gap`         | `SpacingToken` | `"1"`   | Gap between menu items                |
-| `py`          | `SpacingToken` | `"1"`   | Vertical padding                      |
-| `rounded`     | `RoundedToken` | `"4"`   | Border radius                         |
-| `shadow`      | `ShadowToken`  | `"2"`   | Drop shadow                           |
+| Prop          | Type           | Default | Description                     |
+| ------------- | -------------- | ------- | ------------------------------- |
+| `sideOffset`  | `number`       | `0`     | Distance from the trigger       |
+| `alignOffset` | `number`       | `0`     | Offset along the trigger's edge |
+| `gap`         | `SpacingToken` | `"1"`   | Gap between menu items          |
+| `py`          | `SpacingToken` | `"1"`   | Vertical padding                |
+| `rounded`     | `RoundedToken` | `"4"`   | Border radius                   |
+| `shadow`      | `ShadowToken`  | `"2"`   | Drop shadow                     |
 
 All Stack props are also supported for additional styling.
 
@@ -338,9 +345,9 @@ const ControlledMenu = () => {
 ### Menu with Custom Components
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Box } from "@telegraph/layout";
 import { Menu } from "@telegraph/menu";
+import { Tag } from "@telegraph/tag";
 
 <Menu.Root>
   <Menu.Trigger>
@@ -486,8 +493,8 @@ import { Copy, Cut, Paste, Redo, Undo } from "lucide-react";
 ### Menu with Loading States
 
 ```tsx
-import { Menu } from "@telegraph/menu";
 import { Spinner } from "@telegraph/icon";
+import { Menu } from "@telegraph/menu";
 import { useState } from "react";
 
 const MenuWithLoading = () => {
@@ -643,9 +650,9 @@ Typeahead is also supported: type the first characters of an item to focus it.
 ### User Profile Menu
 
 ```tsx
-import { Tag } from "@telegraph/tag";
 import { Box, Stack } from "@telegraph/layout";
 import { Menu } from "@telegraph/menu";
+import { Tag } from "@telegraph/tag";
 import { CreditCard, LogOut, Settings, User } from "lucide-react";
 
 export const UserProfileMenu = ({ user }) => (
@@ -667,7 +674,13 @@ export const UserProfileMenu = ({ user }) => (
         leadingComponent={
           <Box as="img" src={user.avatar} alt="" w="5" h="5" rounded="full" />
         }
-        trailingComponent={user.isPro && <Tag size="0" color="accent">Pro</Tag>}
+        trailingComponent={
+          user.isPro && (
+            <Tag size="0" color="accent">
+              Pro
+            </Tag>
+          )
+        }
       >
         {user.name}
       </Menu.Button>
@@ -828,7 +841,7 @@ export const FilterMenu = ({ onFilterChange }) => {
 
 ## References
 
-- [Radix UI Menu](https://www.radix-ui.com/docs/primitives/components/dropdown-menu)
+- [Base UI Menu](https://base-ui.com/react/components/menu)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/menu)
 
 ## Contributing

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -32,9 +32,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-menu": "^2.1.16",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/menu/src/Menu/Menu.helpers.ts
+++ b/packages/menu/src/Menu/Menu.helpers.ts
@@ -1,0 +1,338 @@
+import {
+  type BaseUIChangeDetails,
+  type LegacyDismissHandlers,
+  callLegacyDismissHandlers,
+} from "@telegraph/helpers";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type SyntheticEvent,
+} from "react";
+
+export type PreventableSyntheticEvent = SyntheticEvent & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuContentKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuTriggerKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuButtonKeyDownEvent = ReactKeyboardEvent<HTMLElement> & {
+  preventBaseUIHandler?: () => void;
+};
+
+export type MenuContentCallbacksScope = "root" | "submenu";
+
+export type MenuContentCallbacksEntry = {
+  callbacks: LegacyDismissHandlers;
+  id: symbol;
+  scope: MenuContentCallbacksScope;
+};
+
+export type MenuContentCallbacksRef = {
+  current: MenuContentCallbacksEntry[];
+};
+
+type OpenAutoFocusRestoreTargetParams = {
+  focusedElementAfterHandler: Element | null;
+  previouslyFocusedElement: Element | null;
+};
+
+export const NO_COLLISION_AVOIDANCE = {
+  align: "none",
+  fallbackAxisSide: "none",
+  side: "none",
+} as const;
+
+export const RADIX_POPPER_COMPATIBILITY_VARS = {
+  "--radix-popper-transform-origin": "var(--transform-origin)",
+  "--radix-popper-available-width": "var(--available-width)",
+  "--radix-popper-available-height": "var(--available-height)",
+  "--radix-popper-anchor-width": "var(--anchor-width)",
+  "--radix-popper-anchor-height": "var(--anchor-height)",
+} as const;
+
+export const MENU_SELECTION_KEYS = ["Enter", " "];
+
+// Base UI handles ordinary roving focus; these helpers preserve Telegraph's
+// Radix-era edge cases around nested focusable children and prevented handlers.
+const FIRST_ITEM_KEYS = ["ArrowDown", "PageUp", "Home"];
+const LAST_ITEM_KEYS = ["ArrowUp", "PageDown", "End"];
+const MENU_ITEM_SELECTOR = "[data-tgph-menu-button]";
+
+export const callContentDismissHandlers = (
+  eventDetails: BaseUIChangeDetails,
+  contentCallbacksRef: MenuContentCallbacksRef,
+) => {
+  // Nested content registers after root content, so newest-first gives the
+  // deepest open menu first chance to cancel dismissal.
+  return contentCallbacksRef.current
+    .slice()
+    .reverse()
+    .some((entry) => callLegacyDismissHandlers(eventDetails, entry.callbacks));
+};
+
+export const callLatestContentDismissHandler = (
+  eventDetails: BaseUIChangeDetails,
+  contentCallbacksRef: MenuContentCallbacksRef,
+  scope: MenuContentCallbacksScope,
+) => {
+  const entry = contentCallbacksRef.current
+    .slice()
+    .reverse()
+    .find((contentCallbacksEntry) => {
+      // Submenus should only consult submenu callbacks; otherwise root content
+      // could accidentally cancel a submenu close that Radix kept scoped.
+      return contentCallbacksEntry.scope === scope;
+    });
+
+  return entry
+    ? callLegacyDismissHandlers(eventDetails, entry.callbacks)
+    : false;
+};
+
+export const upsertContentCallbacks = (
+  contentCallbacksRef: MenuContentCallbacksRef,
+  id: symbol,
+  scope: MenuContentCallbacksScope,
+  callbacks: LegacyDismissHandlers,
+) => {
+  const existingIndex = contentCallbacksRef.current.findIndex(
+    (entry) => entry.id === id,
+  );
+
+  if (existingIndex === -1) {
+    contentCallbacksRef.current.push({ callbacks, id, scope });
+    return;
+  }
+
+  contentCallbacksRef.current[existingIndex] = { callbacks, id, scope };
+};
+
+export const removeContentCallbacks = (
+  contentCallbacksRef: MenuContentCallbacksRef,
+  id: symbol,
+) => {
+  const existingIndex = contentCallbacksRef.current.findIndex(
+    (entry) => entry.id === id,
+  );
+
+  if (existingIndex !== -1) {
+    contentCallbacksRef.current.splice(existingIndex, 1);
+  }
+};
+
+export const preventBaseUIHandlerWhenDefaultPrevented = (
+  event: PreventableSyntheticEvent,
+) => {
+  if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+    // Base UI has its own internal handler pipeline, so mirror React prevention
+    // into Base UI's explicit opt-out hook.
+    event.preventBaseUIHandler?.();
+  }
+};
+
+export const labelBaseUIFocusGuards = (ownerDocument: Document) => {
+  ownerDocument
+    .querySelectorAll<HTMLElement>('[data-base-ui-focus-guard][role="button"]')
+    .forEach((focusGuard) => {
+      if (!focusGuard.getAttribute("aria-label")) {
+        // Base UI focus guards are implementation-detail buttons; label them so
+        // accessibility tooling does not report anonymous controls.
+        focusGuard.setAttribute("aria-label", "Focus boundary");
+      }
+    });
+};
+
+export const getOpenAutoFocusRestoreTarget = ({
+  focusedElementAfterHandler,
+  previouslyFocusedElement,
+}: OpenAutoFocusRestoreTargetParams) => {
+  if (
+    focusedElementAfterHandler instanceof HTMLElement &&
+    focusedElementAfterHandler !== previouslyFocusedElement
+  ) {
+    // If the legacy autofocus handler moved focus itself, restore to that
+    // explicit target after Base UI's autofocus work settles.
+    return focusedElementAfterHandler;
+  }
+
+  if (previouslyFocusedElement instanceof HTMLElement) {
+    // Otherwise match Radix's prevented-open-autofocus behavior by restoring the
+    // element that had focus before the menu opened.
+    return previouslyFocusedElement;
+  }
+
+  return null;
+};
+
+const getFocusableMenuItems = (content: HTMLElement) => {
+  return Array.from(
+    content.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+  ).filter((item) => {
+    return (
+      item.getAttribute("aria-disabled") !== "true" &&
+      item.getAttribute("data-disabled") === null &&
+      !item.hasAttribute("disabled")
+    );
+  });
+};
+
+export const focusMenuItemFromContentKeyDown = (
+  event: MenuContentKeyDownEvent,
+) => {
+  if (event.target !== event.currentTarget) {
+    // Nested focusable children handle their own keys; only the content surface
+    // should translate edge keys into first/last menu item focus.
+    return;
+  }
+
+  const items = getFocusableMenuItems(event.currentTarget);
+
+  if (FIRST_ITEM_KEYS.includes(event.key)) {
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    items[0]?.focus();
+    return;
+  }
+
+  if (LAST_ITEM_KEYS.includes(event.key)) {
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    items.at(-1)?.focus();
+  }
+};
+
+const isTriggerOpen = (trigger: HTMLElement) => {
+  return (
+    trigger.getAttribute("aria-expanded") === "true" ||
+    trigger.getAttribute("data-state") === "open" ||
+    trigger.hasAttribute("data-popup-open")
+  );
+};
+
+const isControlledContentOpen = (content: HTMLElement) => {
+  return (
+    content.getAttribute("data-state") === "open" ||
+    Boolean(content.closest('[data-state="open"]'))
+  );
+};
+
+const focusMenuItem = (content: HTMLElement, focusFirstItem: boolean) => {
+  const items = getFocusableMenuItems(content);
+  const item = focusFirstItem ? items[0] : items.at(-1);
+
+  item?.focus();
+
+  return Boolean(item);
+};
+
+const scheduleContentMenuItemFocus = (
+  content: HTMLElement,
+  event: MenuContentKeyDownEvent,
+  focusFirstItem: boolean,
+) => {
+  content.ownerDocument.defaultView?.setTimeout(() => {
+    // Let the nested control finish its keydown first, then bail if user code
+    // prevented during that same turn.
+    if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+      return;
+    }
+
+    focusMenuItem(content, focusFirstItem);
+  }, 0);
+};
+
+export const focusMenuItemFromNestedControlKeyDown = (
+  event: MenuContentKeyDownEvent,
+) => {
+  if (!(event.target instanceof HTMLElement)) {
+    return;
+  }
+
+  if (event.target === event.currentTarget) {
+    return;
+  }
+
+  if (event.target.closest(MENU_ITEM_SELECTOR)) {
+    return;
+  }
+
+  if (FIRST_ITEM_KEYS.includes(event.key)) {
+    // ArrowDown from embedded controls should re-enter menu navigation without
+    // asking Base UI to treat that nested control as the active menu item.
+    scheduleContentMenuItemFocus(event.currentTarget, event, true);
+  }
+};
+
+const scheduleMenuItemFocus = (
+  ownerDocument: Document,
+  contentId: string,
+  focusFirstItem: boolean,
+) => {
+  const focus = () => {
+    const content = ownerDocument.getElementById(contentId);
+
+    if (content) {
+      focusMenuItem(content, focusFirstItem);
+    }
+  };
+
+  const ownerWindow = ownerDocument.defaultView;
+
+  ownerWindow?.setTimeout(focus, 0);
+};
+
+export const focusMenuItemFromOpenTriggerKeyDown = (
+  event: MenuTriggerKeyDownEvent,
+) => {
+  const isFirstItemKey = FIRST_ITEM_KEYS.includes(event.key);
+  const isLastItemKey = LAST_ITEM_KEYS.includes(event.key);
+
+  if (!isFirstItemKey && !isLastItemKey) {
+    return false;
+  }
+
+  const contentId = event.currentTarget.getAttribute("aria-controls");
+  const content = contentId
+    ? event.currentTarget.ownerDocument.getElementById(contentId)
+    : null;
+  const focusFirstItem = isFirstItemKey;
+
+  if (
+    !content &&
+    contentId &&
+    (event.defaultPrevented || event.nativeEvent.defaultPrevented)
+  ) {
+    // The popup may not exist until Base UI processes the trigger key, so defer
+    // first/last item focus until the controlled content is in the document.
+    event.preventDefault();
+    event.preventBaseUIHandler?.();
+    scheduleMenuItemFocus(
+      event.currentTarget.ownerDocument,
+      contentId,
+      focusFirstItem,
+    );
+
+    return true;
+  }
+
+  if (
+    !content ||
+    (!isTriggerOpen(event.currentTarget) && !isControlledContentOpen(content))
+  ) {
+    return false;
+  }
+
+  if (!focusMenuItem(content, focusFirstItem)) {
+    return false;
+  }
+
+  event.preventDefault();
+  event.preventBaseUIHandler?.();
+
+  return true;
+};

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1,12 +1,65 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChevronRight } from "lucide-react";
-import { describe, it } from "vitest";
+import {
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createRef,
+  useEffect,
+  useState,
+} from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Menu } from "./Menu";
 import type {
+  MenuButtonProps,
   MenuContentProps,
   MenuSubContentProps,
   MenuSubProps,
   MenuSubTriggerProps,
 } from "./index";
+
+type TestButtonProps = ComponentPropsWithoutRef<"button"> & {
+  tgphRef?: Ref<HTMLButtonElement>;
+};
+
+const TestButton = ({
+  tgphRef,
+  type = "button",
+  ...props
+}: TestButtonProps) => {
+  return <button ref={tgphRef} type={type} {...props} />;
+};
+
+const renderBasicMenu = ({
+  defaultOpen,
+  onOpenChange,
+}: {
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+} = {}) => {
+  return render(
+    <>
+      <button type="button">Outside</button>
+      <Menu.Root defaultOpen={defaultOpen} onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content data-testid="menu-content">
+          <Menu.Button onClick={() => {}}>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>
+    </>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("Menu", () => {
   describe("type inheritance", () => {
@@ -89,5 +142,772 @@ describe("Menu", () => {
       const invalidProp: MenuSubContentProps = { sideOffset: "4" };
       void invalidProp;
     });
+  });
+
+  it("is accessible when open", async () => {
+    renderBasicMenu({ defaultOpen: true });
+
+    const menu = await screen.findByRole("menu");
+
+    expectToHaveNoViolations(await axe(menu));
+  });
+
+  it("opens and closes with the trigger in uncontrolled mode", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    renderBasicMenu({ onOpenChange });
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    await user.click(trigger);
+
+    expect(await screen.findByRole("menu")).toHaveTextContent(
+      "Manage workflow",
+    );
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("supports controlled open state", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const ControlledMenu = () => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Menu.Root
+          open={open}
+          onOpenChange={(nextOpen) => {
+            onOpenChange(nextOpen);
+            setOpen(nextOpen);
+          }}
+        >
+          <Menu.Trigger>
+            <TestButton>Workflow actions</TestButton>
+          </Menu.Trigger>
+          <Menu.Content>
+            <Menu.Button>Manage workflow</Menu.Button>
+          </Menu.Content>
+        </Menu.Root>
+      );
+    };
+
+    render(<ControlledMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    expect(await screen.findByRole("menu")).toHaveTextContent(
+      "Manage workflow",
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+  });
+
+  it("lets a custom trigger click handler own open state changes", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Menu.Root onOpenChange={onOpenChange}>
+        <Menu.Trigger onClick={onClick}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("dismisses with Escape and outside pointer interactions", async () => {
+    const user = userEvent.setup();
+    const onEscapeKeyDown = vi.fn();
+    const onPointerDownOutside = vi.fn();
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Menu.Root defaultOpen>
+          <Menu.Trigger>
+            <TestButton>Workflow actions</TestButton>
+          </Menu.Trigger>
+          <Menu.Content
+            onEscapeKeyDown={onEscapeKeyDown}
+            onPointerDownOutside={onPointerDownOutside}
+          >
+            <Menu.Button>Manage workflow</Menu.Button>
+          </Menu.Content>
+        </Menu.Root>
+      </>,
+    );
+
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+    await screen.findByRole("menu");
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the menu open when legacy dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content onEscapeKeyDown={(event) => event.preventDefault()}>
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("keeps submenu content open when submenu dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onSubmenuEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+
+    render(
+      <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content data-testid="root-content">
+          <Menu.Sub defaultOpen>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent
+              data-testid="submenu-content"
+              onEscapeKeyDown={onSubmenuEscapeKeyDown}
+            >
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByTestId("submenu-content");
+    screen.getByRole("menuitem", { name: "Copy link" }).focus();
+    await user.keyboard("{Escape}");
+
+    expect(onSubmenuEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("root-content")).toBeInTheDocument();
+    expect(screen.getByTestId("submenu-content")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("lets submenu content close when parent dismissal handlers prevent default", async () => {
+    const user = userEvent.setup();
+    const onRootEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+    const onSubmenuOpenChange = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content
+          data-testid="root-content"
+          onEscapeKeyDown={onRootEscapeKeyDown}
+        >
+          <Menu.Sub defaultOpen onOpenChange={onSubmenuOpenChange}>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent data-testid="submenu-content">
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await screen.findByTestId("submenu-content");
+    screen.getByRole("menuitem", { name: "Copy link" }).focus();
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("submenu-content")).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId("root-content")).toBeInTheDocument();
+    expect(onRootEscapeKeyDown).not.toHaveBeenCalled();
+    expect(onSubmenuOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps parent dismissal handlers after submenu content unmounts", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onPointerDownOutside = vi.fn((event: Event) => {
+      event.preventDefault();
+    });
+
+    const ControlledSubmenu = () => {
+      const [submenuOpen, setSubmenuOpen] = useState(true);
+
+      useEffect(() => {
+        setSubmenuOpen(false);
+      }, []);
+
+      return (
+        <>
+          <button type="button">Outside</button>
+          <Menu.Root defaultOpen onOpenChange={onOpenChange}>
+            <Menu.Trigger>
+              <TestButton>Workflow actions</TestButton>
+            </Menu.Trigger>
+            <Menu.Content onPointerDownOutside={onPointerDownOutside}>
+              <Menu.Button>Parent action</Menu.Button>
+              <Menu.Sub open={submenuOpen} onOpenChange={setSubmenuOpen}>
+                <Menu.SubTrigger>Share</Menu.SubTrigger>
+                <Menu.SubContent data-testid="submenu-content">
+                  <Menu.Button>Copy link</Menu.Button>
+                </Menu.SubContent>
+              </Menu.Sub>
+            </Menu.Content>
+          </Menu.Root>
+        </>
+      );
+    };
+
+    render(<ControlledSubmenu />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("submenu-content")).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Outside" }));
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("returns focus to the trigger after dismissal", async () => {
+    const user = userEvent.setup();
+
+    renderBasicMenu();
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    await screen.findByRole("menu");
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+
+  it("lets legacy open autofocus handlers move focus", async () => {
+    const user = userEvent.setup();
+    const archiveRef = createRef<HTMLElement>();
+    const onOpenAutoFocus = vi.fn((event: Event) => {
+      event.preventDefault();
+      archiveRef.current?.focus();
+    });
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content onOpenAutoFocus={onOpenAutoFocus}>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button tgphRef={archiveRef}>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Workflow actions" }));
+
+    const archiveItem = await screen.findByRole("menuitem", {
+      name: "Archive workflow",
+    });
+
+    await waitFor(() => {
+      expect(archiveItem).toHaveFocus();
+    });
+    expect(onOpenAutoFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders styled content in a scoped portal", async () => {
+    const { container } = renderBasicMenu({ defaultOpen: true });
+
+    const content = await screen.findByTestId("menu-content");
+
+    expect(content).toHaveClass("tgph");
+    expect(content).toHaveAttribute("data-state", "open");
+    expect(content).toHaveAttribute("role", "menu");
+    expect(content).toHaveStyle({
+      transformOrigin: "var(--transform-origin)",
+    });
+    expect(content).toHaveStyle({
+      "--radix-popper-transform-origin": "var(--transform-origin)",
+    });
+    expect(container).not.toContainElement(content);
+  });
+
+  it("forwards trigger and content refs through tgphRef", async () => {
+    const triggerRef = createRef<HTMLElement>();
+    const triggerTgphRef = createRef<HTMLElement>();
+    const contentTgphRef = createRef<HTMLDivElement>();
+    const contentStackRef = createRef<HTMLDivElement>();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger ref={triggerRef} tgphRef={triggerTgphRef}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content
+          contentStackRef={contentStackRef}
+          data-testid="menu-content"
+          tgphRef={contentTgphRef}
+        >
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Workflow actions" });
+    const content = await screen.findByTestId("menu-content");
+
+    expect(triggerRef.current).toBe(trigger);
+    expect(triggerTgphRef.current).toBe(trigger);
+    expect(contentTgphRef.current).toBe(content);
+    expect(contentStackRef.current).toBe(content);
+  });
+
+  it("focuses the first item from an open trigger with ArrowDown", async () => {
+    const user = userEvent.setup();
+
+    renderBasicMenu();
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("focuses the first item when an open trigger consumer prevents ArrowDown", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger onKeyDown={(event) => event.preventDefault()}>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: "Workflow actions",
+    });
+
+    await user.click(trigger);
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("focuses the first item from nested focusable trigger content", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton data-testid="trigger">
+            <span>Workflow actions</span>
+            <span tabIndex={0}>Email tag</span>
+          </TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(screen.getByTestId("trigger"));
+    const firstItem = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    screen.getByText("Email tag").focus();
+    await user.keyboard("[ArrowDown]");
+
+    expect(firstItem).toHaveFocus();
+  });
+
+  it("opens from nested focusable trigger content with Base UI keyboard handling", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root>
+        <Menu.Trigger>
+          <TestButton data-testid="trigger">
+            <span>Workflow actions</span>
+            <span tabIndex={0}>Email tag</span>
+          </TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button>Manage workflow</Menu.Button>
+          <Menu.Button>Archive workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    screen.getByText("Email tag").focus();
+    await user.keyboard("[ArrowDown]");
+
+    expect(await screen.findByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Manage workflow" }),
+    ).toBeInTheDocument();
+  });
+
+  it("fires item handlers once and closes by default", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onClick={onClick} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Manage workflow" }),
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("fires item keyboard handlers from a focused item", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown}>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires keyboard handlers for option-role items", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button
+            aria-selected="true"
+            data-tgph-combobox-option
+            data-tgph-combobox-option-value="email"
+            onKeyDown={onKeyDown}
+            role="option"
+          >
+            Email
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("option", { name: "Email" });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires select once from keyboard selection", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onSelect={onSelect}>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not double-call a shared keydown and select handler", async () => {
+    const user = userEvent.setup();
+    const handleSelection = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button
+            onKeyDown={
+              handleSelection as NonNullable<MenuButtonProps["onKeyDown"]>
+            }
+            onSelect={
+              handleSelection as NonNullable<MenuButtonProps["onSelect"]>
+            }
+          >
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(handleSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to keyboard activation when native keydown propagation is stopped", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.addEventListener("keydown", (event) => event.stopPropagation());
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+    expect(onKeyDown).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    });
+  });
+
+  it("does not reselect from the native keyboard click when keydown prevents default", async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn((event) => event.preventDefault());
+    const onSelect = vi.fn();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onKeyDown={onKeyDown} onSelect={onSelect}>
+            Manage workflow
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const item = await screen.findByRole("menuitem", {
+      name: "Manage workflow",
+    });
+
+    item.focus();
+    await user.keyboard("[Enter]");
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the menu open when item handlers prevent default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button onSelect={(event) => event.preventDefault()}>
+            Keep open
+          </Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Keep open" }),
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("respects closeOnClick=false", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Button closeOnClick={false}>Keep open</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    await user.click(
+      await screen.findByRole("menuitem", { name: "Keep open" }),
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("renders controlled submenu state and compatibility attributes", async () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content>
+          <Menu.Sub defaultOpen>
+            <Menu.SubTrigger>Share</Menu.SubTrigger>
+            <Menu.SubContent data-testid="submenu-content">
+              <Menu.Button>Copy link</Menu.Button>
+            </Menu.SubContent>
+          </Menu.Sub>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const trigger = await screen.findByRole("menuitem", { name: "Share" });
+    const submenu = await screen.findByTestId("submenu-content");
+
+    expect(trigger).toHaveAttribute("data-state", "open");
+    expect(submenu).toHaveClass("tgph");
+    expect(submenu).toHaveAttribute("role", "menu");
+    expect(submenu).toHaveAttribute("data-side", "right");
+    expect(submenu).toHaveAttribute("data-align", "start");
   });
 });

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -1,322 +1,937 @@
-import * as RadixMenu from "@radix-ui/react-menu";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
+import { Menu as BaseMenu } from "@base-ui/react/menu";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
-  RefToTgphRef,
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type TgphComponentProps,
   type TgphElement,
+  createTgphBaseUIRender,
+  getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+  type Ref,
+  cloneElement,
+  createContext,
+  forwardRef,
+  isValidElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+} from "react";
 
 import { MenuItem, type MenuItemProps } from "../MenuItem";
 
-export type RootProps = React.ComponentProps<typeof RadixMenu.Root> & {
-  defaultOpen?: boolean;
-};
+import {
+  MENU_SELECTION_KEYS,
+  type MenuButtonKeyDownEvent,
+  type MenuContentCallbacksEntry,
+  type MenuContentCallbacksRef,
+  type MenuContentCallbacksScope,
+  type MenuContentKeyDownEvent,
+  NO_COLLISION_AVOIDANCE,
+  type PreventableSyntheticEvent,
+  RADIX_POPPER_COMPATIBILITY_VARS,
+  callContentDismissHandlers,
+  callLatestContentDismissHandler,
+  focusMenuItemFromContentKeyDown,
+  focusMenuItemFromNestedControlKeyDown,
+  focusMenuItemFromOpenTriggerKeyDown,
+  getOpenAutoFocusRestoreTarget,
+  labelBaseUIFocusGuards,
+  preventBaseUIHandlerWhenDefaultPrevented,
+  removeContentCallbacks,
+  upsertContentCallbacks,
+} from "./Menu.helpers";
 
-type MenuContextProps = {
+type BaseMenuRootProps = ComponentProps<typeof BaseMenu.Root>;
+type BaseMenuTriggerProps = ComponentPropsWithoutRef<typeof BaseMenu.Trigger>;
+type BaseMenuPortalProps = ComponentPropsWithoutRef<typeof BaseMenu.Portal>;
+type BaseMenuPositionerProps = ComponentPropsWithoutRef<
+  typeof BaseMenu.Positioner
+>;
+type BaseMenuPopupProps = ComponentPropsWithoutRef<typeof BaseMenu.Popup>;
+type BaseMenuItemProps = ComponentPropsWithoutRef<typeof BaseMenu.Item>;
+type BaseMenuSubProps = ComponentProps<typeof BaseMenu.SubmenuRoot>;
+type BaseMenuSubTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseMenu.SubmenuTrigger
+>;
+
+type MenuPopupRenderState = {
   open: boolean;
-  setOpen: (open: boolean) => void;
 };
 
-const MenuContext = React.createContext<MenuContextProps>({
-  open: false,
-  setOpen: () => {},
-});
+type MenuTriggerRenderState = {
+  open: boolean;
+};
+
+type MenuSubTriggerRenderState = {
+  open: boolean;
+};
+
+type MenuPopupContentProps = Omit<
+  TgphComponentProps<typeof Stack>,
+  "children" | "tgphRef"
+> & {
+  children?: ReactNode;
+  contentRef: Ref<HTMLElement>;
+  onOpenAutoFocus?: LegacyDismissEventHandler;
+  popupState: MenuPopupRenderState;
+  tgphRef?: Ref<HTMLElement>;
+};
+
+type MenuContentKeyDownHandler = (event: MenuContentKeyDownEvent) => void;
+type MenuContentKeyDownCaptureHandler = (
+  event: MenuContentKeyDownEvent,
+) => void;
+
+type MenuCompatibilityContextProps = {
+  contentCallbacksRef: MenuContentCallbacksRef;
+};
+
+export type RootProps = Omit<BaseMenuRootProps, "onOpenChange"> & {
+  onOpenChange?: (open: boolean) => void;
+};
+
+const MenuCompatibilityContext =
+  createContext<MenuCompatibilityContextProps | null>(null);
+const MenuContentScopeContext =
+  createContext<MenuContentCallbacksScope>("root");
 
 const Root = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  modal = true,
   children,
+  modal = true,
+  onOpenChange,
   ...props
 }: RootProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
-  });
+  const contentCallbacksRef = useRef<MenuContentCallbacksEntry[]>([]);
+  const handleOpenChange = useCallback<
+    NonNullable<BaseMenuRootProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        callContentDismissHandlers(eventDetails, contentCallbacksRef)
+      ) {
+        // Legacy Radix content callbacks could cancel close, so translate that
+        // prevention into Base UI's cancel API at the root.
+        eventDetails.cancel();
+        return;
+      }
+
+      onOpenChange?.(open);
+    },
+    [onOpenChange],
+  );
+
   return (
-    <MenuContext.Provider value={{ open, setOpen }}>
-      <RadixMenu.Root
-        open={open}
-        onOpenChange={setOpen}
-        modal={modal}
-        {...props}
-      >
+    <MenuCompatibilityContext.Provider value={{ contentCallbacksRef }}>
+      <BaseMenu.Root modal={modal} onOpenChange={handleOpenChange} {...props}>
         {children}
-      </RadixMenu.Root>
-    </MenuContext.Provider>
+      </BaseMenu.Root>
+    </MenuCompatibilityContext.Provider>
   );
 };
 
-type Anchor = React.ComponentProps<typeof RadixMenu.Anchor> & {
-  tgphRef?: React.RefObject<HTMLDivElement>;
-};
+type BaseMenuTriggerCompatibilityProps = Partial<
+  Pick<
+    BaseMenuTriggerProps,
+    | "closeDelay"
+    | "delay"
+    | "disabled"
+    | "handle"
+    | "nativeButton"
+    | "openOnHover"
+    | "payload"
+  >
+>;
 
-const Trigger = ({ asChild = true, tgphRef, children, ...props }: Anchor) => {
-  const context = React.useContext(MenuContext);
-  return (
-    <RadixMenu.Anchor
-      onClick={() => {
-        context.setOpen(!context.open);
-      }}
-      asChild={asChild}
-      {...props}
-      ref={tgphRef}
-    >
-      <RefToTgphRef>{children}</RefToTgphRef>
-    </RadixMenu.Anchor>
-  );
-};
-
-export type ContentProps<T extends TgphElement = "div"> = React.ComponentProps<
-  typeof RadixMenu.Content
+export type TriggerProps = Omit<
+  ComponentPropsWithoutRef<"button">,
+  keyof BaseMenuTriggerCompatibilityProps | "children"
 > &
+  BaseMenuTriggerCompatibilityProps & {
+    asChild?: boolean;
+    children?: ReactNode;
+    tgphRef?: Ref<HTMLButtonElement>;
+  };
+
+const TriggerWithRef = forwardRef<HTMLElement, TriggerProps>(
+  (
+    {
+      asChild = true,
+      children,
+      onClick,
+      onKeyDown,
+      onKeyDownCapture,
+      onMouseDown,
+      tgphRef,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const triggerRef = useComposedRefs<HTMLButtonElement>(
+      forwardedRef as Ref<HTMLButtonElement>,
+      tgphRef,
+    ) as Ref<HTMLButtonElement>;
+    // A custom onClick means callers likely own the trigger activation path, so
+    // avoid also letting Base UI process mousedown as a separate open signal.
+    const shouldSuppressBaseMouseDown = Boolean(onClick);
+    const handleClick = useCallback<
+      NonNullable<BaseMenuTriggerProps["onClick"]>
+    >(
+      (event) => {
+        onClick?.(event);
+
+        if (event.defaultPrevented) {
+          // Radix kept focus on prevented trigger clicks; preserve that for
+          // consumers that prevent open but still expect keyboard continuity.
+          event.currentTarget.focus();
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onClick],
+    );
+    const handleKeyDownCapture = useCallback<
+      NonNullable<BaseMenuTriggerProps["onKeyDownCapture"]>
+    >(
+      (event) => {
+        onKeyDownCapture?.(event);
+
+        if (event.defaultPrevented) {
+          return;
+        }
+
+        if (focusMenuItemFromOpenTriggerKeyDown(event)) {
+          event.stopPropagation();
+        }
+      },
+      [onKeyDownCapture],
+    );
+    const handleKeyDown = useCallback<
+      NonNullable<BaseMenuTriggerProps["onKeyDown"]>
+    >(
+      (event) => {
+        onKeyDown?.(event);
+
+        if (event.target !== event.currentTarget) {
+          // Custom trigger children can receive keydown first; still allow the
+          // open-trigger focus shim to run from the actual trigger wrapper.
+          focusMenuItemFromOpenTriggerKeyDown(event);
+          return;
+        }
+
+        if (focusMenuItemFromOpenTriggerKeyDown(event)) {
+          return;
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onKeyDown],
+    );
+    const handleMouseDown = useCallback<
+      NonNullable<BaseMenuTriggerProps["onMouseDown"]>
+    >(
+      (event) => {
+        onMouseDown?.(event);
+
+        if (shouldSuppressBaseMouseDown) {
+          event.preventBaseUIHandler?.();
+          return;
+        }
+
+        preventBaseUIHandlerWhenDefaultPrevented(event);
+      },
+      [onMouseDown, shouldSuppressBaseMouseDown],
+    );
+    const renderTriggerElement = (state: MenuTriggerRenderState) => {
+      if (asChild && isValidElement(children)) {
+        const child = children as ReactElement<Record<string, unknown>>;
+
+        return cloneElement(child, {
+          "aria-expanded": child.props["aria-expanded"] ?? state.open,
+          "data-state":
+            child.props["data-state"] ?? (state.open ? "open" : "closed"),
+        });
+      }
+
+      return (
+        <button
+          aria-expanded={state.open}
+          data-state={state.open ? "open" : "closed"}
+        >
+          {children}
+        </button>
+      );
+    };
+
+    return (
+      <BaseMenu.Trigger
+        {...props}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        onKeyDownCapture={handleKeyDownCapture}
+        onMouseDown={handleMouseDown}
+        ref={triggerRef}
+        render={createTgphBaseUIRender(renderTriggerElement)}
+      />
+    );
+  },
+);
+
+const Trigger = TriggerWithRef as (props: TriggerProps) => ReactElement | null;
+
+const MenuPopupContent = ({
+  children,
+  contentRef,
+  onOpenAutoFocus,
+  popupState,
+  tgphRef,
+  ...props
+}: MenuPopupContentProps) => {
+  const localContentRef = useRef<HTMLElement>(null);
+  const openAutoFocusHandledRef = useRef(false);
+  const openAutoFocusTimeoutRef = useRef<
+    ReturnType<typeof setTimeout> | undefined
+  >(undefined);
+  const composedContentRef = useComposedRefs<HTMLElement>(
+    tgphRef,
+    contentRef,
+    localContentRef,
+  ) as Ref<HTMLElement>;
+
+  useLayoutEffect(() => {
+    const content = localContentRef.current;
+    const ownerWindow = content?.ownerDocument.defaultView;
+
+    if (!popupState.open) {
+      openAutoFocusHandledRef.current = false;
+
+      if (openAutoFocusTimeoutRef.current !== undefined) {
+        clearTimeout(openAutoFocusTimeoutRef.current);
+        openAutoFocusTimeoutRef.current = undefined;
+      }
+
+      return;
+    }
+
+    if (!content || !onOpenAutoFocus || openAutoFocusHandledRef.current) {
+      return;
+    }
+
+    openAutoFocusHandledRef.current = true;
+
+    const ownerDocument = content.ownerDocument;
+    const previouslyFocusedElement = ownerDocument.activeElement;
+    const event = new Event("openAutoFocus", { cancelable: true });
+    onOpenAutoFocus(event);
+
+    if (!event.defaultPrevented) {
+      return;
+    }
+
+    const restoreTarget = getOpenAutoFocusRestoreTarget({
+      focusedElementAfterHandler: ownerDocument.activeElement,
+      previouslyFocusedElement,
+    });
+
+    openAutoFocusTimeoutRef.current = ownerWindow?.setTimeout(() => {
+      openAutoFocusTimeoutRef.current = undefined;
+
+      if (restoreTarget && ownerDocument.contains(restoreTarget)) {
+        // Base UI has already run its focus pass; now restore the Radix-style
+        // prevented autofocus target without racing its internal handler.
+        restoreTarget.focus();
+      }
+    }, 0);
+  }, [onOpenAutoFocus, popupState.open]);
+
+  return (
+    <Stack
+      {...props}
+      data-state={popupState.open ? "open" : "closed"}
+      tgphRef={
+        composedContentRef as TgphComponentProps<typeof Stack>["tgphRef"]
+      }
+    >
+      {children}
+    </Stack>
+  );
+};
+
+export type ContentProps<T extends TgphElement = "div"> = Partial<
+  Omit<BaseMenuPositionerProps, "children" | "className" | "render" | "style">
+> &
+  Partial<
+    Omit<BaseMenuPopupProps, "children" | "className" | "render" | "style">
+  > &
   Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
-    contentStackRef?: React.RefObject<HTMLDivElement>;
+    avoidCollisions?: boolean;
+    contentStackRef?: Ref<HTMLDivElement>;
+    forceMount?: BaseMenuPortalProps["keepMounted"];
+    hideWhenDetached?: boolean;
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onEscapeKeyDown?: LegacyDismissHandlers["onEscapeKeyDown"];
+    onFocusOutside?: LegacyDismissHandlers["onFocusOutside"];
+    onInteractOutside?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+    onPointerDownOutside?: LegacyDismissHandlers["onPointerDownOutside"];
   };
 
 const Content = <T extends TgphElement = "div">({
-  direction = "column",
-  gap = "1",
-  rounded = "4",
-  py = "1",
-  shadow = "2",
-  sideOffset = 4,
+  align = "center",
+  alignOffset,
+  anchor,
+  arrowPadding,
+  avoidCollisions,
+  bg = "surface-1",
   children,
+  className,
+  collisionAvoidance,
+  collisionBoundary,
+  collisionPadding,
+  contentStackRef,
+  direction = "column",
+  disableAnchorTracking,
+  finalFocus,
+  forceMount,
+  gap = "1",
+  hideWhenDetached,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocusOutside,
   onInteractOutside,
   onKeyDown,
-  onCloseAutoFocus,
+  onKeyDownCapture,
+  onOpenAutoFocus,
+  onPointerDownOutside,
+  positionMethod,
+  py = "1",
+  rounded = "4",
+  shadow = "2",
+  side = "bottom",
+  sideOffset = 4,
+  sticky,
+  style,
   tgphRef,
   ...props
 }: ContentProps<T>) => {
+  const compatibilityContext = useContext(MenuCompatibilityContext);
+  const contentCallbacksScope = useContext(MenuContentScopeContext);
+  const contentCallbacksIdRef = useRef(Symbol("menu-content-callbacks"));
+  const internalContentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    contentStackRef as Ref<HTMLElement>,
+    internalContentRef as Ref<HTMLElement>,
+  ) as Ref<HTMLElement>;
+  const resolvedCollisionAvoidance =
+    collisionAvoidance ??
+    (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
+  const resolvedFinalFocus =
+    finalFocus ??
+    (() => {
+      if (!onCloseAutoFocus) {
+        return true;
+      }
+
+      const event = new Event("closeAutoFocus", { cancelable: true });
+      onCloseAutoFocus(event);
+
+      // Radix used preventDefault on closeAutoFocus; Base UI wants a boolean
+      // finalFocus result, so invert the same cancellation signal.
+      return event.defaultPrevented ? false : true;
+    });
+  const stackProps = props as TgphComponentProps<typeof Stack>;
+
+  useLayoutEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    const contentCallbacksRef = compatibilityContext.contentCallbacksRef;
+    const contentCallbacksId = contentCallbacksIdRef.current;
+
+    // Register a stable slot immediately so root/submenu close events can find
+    // this content even before the first callback-prop effect runs.
+    upsertContentCallbacks(
+      contentCallbacksRef,
+      contentCallbacksId,
+      contentCallbacksScope,
+      {},
+    );
+
+    return () => {
+      removeContentCallbacks(contentCallbacksRef, contentCallbacksId);
+    };
+  }, [compatibilityContext, contentCallbacksScope]);
+
+  useLayoutEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Keep the latest Radix-style dismiss callbacks in shared root state because
+    // Base UI reports dismissal through Root/Submenu onOpenChange details.
+    upsertContentCallbacks(
+      compatibilityContext.contentCallbacksRef,
+      contentCallbacksIdRef.current,
+      contentCallbacksScope,
+      {
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      },
+    );
+  }, [
+    compatibilityContext,
+    contentCallbacksScope,
+    onEscapeKeyDown,
+    onFocusOutside,
+    onInteractOutside,
+    onPointerDownOutside,
+  ]);
+
+  useEffect(() => {
+    const ownerDocument = internalContentRef.current?.ownerDocument;
+
+    if (!ownerDocument) {
+      return;
+    }
+
+    // Base UI can insert focus guards after the popup surface commits, so label
+    // them after each render and on the next tick before axe or screen readers see them.
+    labelBaseUIFocusGuards(ownerDocument);
+
+    const timeout = ownerDocument.defaultView?.setTimeout(() => {
+      labelBaseUIFocusGuards(ownerDocument);
+    }, 0);
+
+    return () => {
+      if (timeout !== undefined) {
+        ownerDocument.defaultView?.clearTimeout(timeout);
+      }
+    };
+  });
+
   return (
-    <RadixMenu.Portal>
-      <RadixMenu.Content
-        onInteractOutside={onInteractOutside}
-        onKeyDown={onKeyDown}
-        onCloseAutoFocus={onCloseAutoFocus}
-        asChild
+    <BaseMenu.Portal keepMounted={forceMount}>
+      <BaseMenu.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        arrowPadding={arrowPadding}
+        collisionAvoidance={resolvedCollisionAvoidance}
+        collisionBoundary={collisionBoundary}
+        collisionPadding={collisionPadding}
+        disableAnchorTracking={disableAnchorTracking}
+        positionMethod={positionMethod}
+        side={side}
         sideOffset={sideOffset}
-        {...props}
-        // Need to cast this type since RadixMenu.Content doesn't accept tgphRef
-        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
+        sticky={sticky}
+        style={(state) =>
+          getBaseUIPositionerVisibilityStyle({
+            anchorHidden: state.anchorHidden,
+            hideWhenDetached,
+            zIndex: "var(--tgph-zIndex-popover)",
+          })
+        }
       >
-        <RefToTgphRef>
-          {/* Keep this Stack surface in sync with `SubContent` below. */}
-          <Stack
-            bg="surface-1"
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-            }}
-            zIndex="popover"
-          >
-            <LazyMotion features={domAnimation}>{children}</LazyMotion>
-          </Stack>
-        </RefToTgphRef>
-      </RadixMenu.Content>
-    </RadixMenu.Portal>
+        <BaseMenu.Popup
+          finalFocus={resolvedFinalFocus}
+          render={createTgphBaseUIRender((state: MenuPopupRenderState) => (
+            <MenuPopupContent
+              bg={bg}
+              className={["tgph", className].filter(Boolean).join(" ")}
+              contentRef={contentRef}
+              data-tgph-menu-content
+              direction={direction}
+              gap={gap}
+              onOpenAutoFocus={onOpenAutoFocus}
+              onKeyDown={(event: MenuContentKeyDownEvent) => {
+                (onKeyDown as MenuContentKeyDownHandler | undefined)?.(event);
+
+                if (!event.defaultPrevented) {
+                  focusMenuItemFromContentKeyDown(event);
+                }
+              }}
+              onKeyDownCapture={(event: MenuContentKeyDownEvent) => {
+                (
+                  onKeyDownCapture as
+                    | MenuContentKeyDownCaptureHandler
+                    | undefined
+                )?.(event);
+
+                if (!event.defaultPrevented) {
+                  focusMenuItemFromNestedControlKeyDown(event);
+                }
+              }}
+              popupState={state}
+              rounded={rounded}
+              py={py}
+              shadow={shadow}
+              style={{
+                overflowY: "auto",
+                transformOrigin: "var(--transform-origin)",
+                ...RADIX_POPPER_COMPATIBILITY_VARS,
+                ...style,
+              }}
+              zIndex="popover"
+              {...stackProps}
+            >
+              <LazyMotion features={domAnimation}>{children}</LazyMotion>
+            </MenuPopupContent>
+          ))}
+        />
+      </BaseMenu.Positioner>
+    </BaseMenu.Portal>
   );
 };
 
-export type ButtonProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof MenuItem<T>
+type MenuButtonItemProps = Omit<
+  MenuItemProps,
+  "onClick" | "onKeyDown" | "tgphRef"
+>;
+
+export type ButtonProps<T extends TgphElement = "button"> = Partial<
+  Omit<
+    BaseMenuItemProps,
+    | "children"
+    | "className"
+    | "onClick"
+    | "onKeyDown"
+    | "onSelect"
+    | "render"
+    | "style"
+  >
 > &
-  React.ComponentProps<typeof RadixMenu.Item>;
+  MenuButtonItemProps & {
+    as?: T;
+    onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
+    onKeyDown?: (event: MenuButtonKeyDownEvent) => void;
+    onSelect?: (event: Event) => void;
+    tgphRef?: Ref<HTMLElement>;
+  };
 
 const Button = <T extends TgphElement = "button">({
+  closeOnClick,
+  disabled,
   mx = "1",
-  asChild = true,
   icon,
   leadingIcon,
+  label,
   trailingIcon,
   leadingComponent,
   trailingComponent,
   selected,
   tgphRef,
   onClick,
+  onKeyDown,
+  onSelect,
+  nativeButton = true,
   ...props
 }: ButtonProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
+  const itemRef = useRef<HTMLElement>(null);
+  const menuItemProps = props as MenuItemProps<T>;
+  // Keyboard selection can arrive through React keydown, native keyup/click, or
+  // Base UI internals; these refs dedupe those paths while preserving cancel.
+  const ignoreNextKeyboardClickRef = useRef(false);
+  const nativeKeyboardClickHandledRef = useRef(false);
+  const nativeKeyboardSelectionPendingRef = useRef(false);
+  const preventNextKeyboardCloseRef = useRef(false);
+  const reactKeyboardSelectionHandledRef = useRef(false);
+  const composedTgphRef = useComposedRefs<HTMLElement>(
+    tgphRef,
+    itemRef,
+  ) as Ref<HTMLElement>;
+
+  useEffect(() => {
+    const item = itemRef.current;
+
+    if (!item || disabled) {
+      return;
+    }
+
+    let fallbackTimeout: ReturnType<typeof setTimeout> | undefined;
+    const resetNativeKeyboardState = () => {
+      nativeKeyboardClickHandledRef.current = false;
+      nativeKeyboardSelectionPendingRef.current = false;
+      reactKeyboardSelectionHandledRef.current = false;
+    };
+    const clearFallbackTimeout = () => {
+      if (fallbackTimeout !== undefined) {
+        item.ownerDocument.defaultView?.clearTimeout(fallbackTimeout);
+        fallbackTimeout = undefined;
+      }
+    };
+    const handleNativeKeyDown = (event: KeyboardEvent) => {
+      if (MENU_SELECTION_KEYS.includes(event.key)) {
+        // Mark the native keyboard path as pending until keyup tells us whether
+        // React/Base UI handled the same selection first.
+        nativeKeyboardClickHandledRef.current = false;
+        nativeKeyboardSelectionPendingRef.current = true;
+        reactKeyboardSelectionHandledRef.current = false;
+      }
+    };
+    const handleNativeKeyUp = (event: KeyboardEvent) => {
+      if (
+        !MENU_SELECTION_KEYS.includes(event.key) ||
+        !nativeKeyboardSelectionPendingRef.current
+      ) {
+        return;
+      }
+
+      clearFallbackTimeout();
+      fallbackTimeout = item.ownerDocument.defaultView?.setTimeout(() => {
+        // Defer one tick so React keydown and Base UI selection can mark their
+        // refs before the native fallback fires a duplicate selection.
+        if (
+          reactKeyboardSelectionHandledRef.current ||
+          nativeKeyboardClickHandledRef.current
+        ) {
+          resetNativeKeyboardState();
+          return;
+        }
+
+        if (onSelect) {
+          onSelect(event);
+          ignoreNextKeyboardClickRef.current = true;
+          preventNextKeyboardCloseRef.current = event.defaultPrevented;
+        }
+
+        // Trigger the normal click path for parity with native button keyboard
+        // activation after the legacy onSelect callback has had a chance to cancel.
+        item.click();
+        resetNativeKeyboardState();
+      }, 0);
+    };
+
+    item.addEventListener("keydown", handleNativeKeyDown);
+    item.addEventListener("keyup", handleNativeKeyUp);
+
+    return () => {
+      clearFallbackTimeout();
+      item.removeEventListener("keydown", handleNativeKeyDown);
+      item.removeEventListener("keyup", handleNativeKeyUp);
+    };
+  }, [disabled, onSelect]);
+
+  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
+    if (event.detail === 0) {
+      // Browsers synthesize detail=0 clicks for keyboard activation.
+      nativeKeyboardClickHandledRef.current = true;
+    }
+
+    if (ignoreNextKeyboardClickRef.current && event.detail === 0) {
+      ignoreNextKeyboardClickRef.current = false;
+      if (preventNextKeyboardCloseRef.current) {
+        (event as PreventableSyntheticEvent).preventBaseUIHandler?.();
+      }
+      preventNextKeyboardCloseRef.current = false;
+      return;
+    }
+
+    ignoreNextKeyboardClickRef.current = false;
+    preventNextKeyboardCloseRef.current = false;
+    onClick?.(event);
+    onSelect?.(event.nativeEvent);
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    const isSelectionKey = MENU_SELECTION_KEYS.includes(event.key);
+
+    (onKeyDown as ((event: MenuButtonKeyDownEvent) => void) | undefined)?.(
+      event as MenuButtonKeyDownEvent,
+    );
+
+    if (isSelectionKey) {
+      reactKeyboardSelectionHandledRef.current = true;
+
+      const keyDownPrevented =
+        event.defaultPrevented || event.nativeEvent.defaultPrevented;
+
+      if (!keyDownPrevented && onSelect !== (onKeyDown as unknown)) {
+        // Preserve the old API where Enter/Space could invoke onSelect during
+        // keydown, while avoiding double-calling when onKeyDown is the handler.
+        onSelect?.(event.nativeEvent);
+      }
+
+      ignoreNextKeyboardClickRef.current = true;
+      preventNextKeyboardCloseRef.current =
+        keyDownPrevented ||
+        event.defaultPrevented ||
+        event.nativeEvent.defaultPrevented;
+    }
+
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+
   return (
-    <RadixMenu.Item
-      {...props}
-      asChild={asChild}
-      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-    >
-      <RefToTgphRef>
-        <MenuItem
-          onClick={
-            onClick as React.MouseEventHandler<HTMLButtonElement> | undefined
-          }
+    <BaseMenu.Item
+      closeOnClick={closeOnClick}
+      disabled={disabled}
+      label={label}
+      nativeButton={nativeButton}
+      render={createTgphBaseUIRender(
+        <MenuItem<T>
+          {...menuItemProps}
+          onClick={handleClick as MenuItemProps<T>["onClick"]}
+          onKeyDown={handleKeyDown as MenuItemProps<T>["onKeyDown"]}
           selected={selected}
           leadingIcon={combinedLeadingIcon}
           trailingIcon={trailingIcon}
           leadingComponent={leadingComponent}
           trailingComponent={trailingComponent}
           data-tgph-menu-button
+          disabled={disabled}
           mx={mx}
           style={{
             flexShrink: 0,
+            ...menuItemProps.style,
           }}
-          {...props}
-        />
-      </RefToTgphRef>
-    </RadixMenu.Item>
+          tgphRef={composedTgphRef as MenuItemProps<T>["tgphRef"]}
+        />,
+      )}
+    />
   );
 };
 
-export type SubProps = React.ComponentProps<typeof RadixMenu.Sub> & {
-  defaultOpen?: boolean;
+export type SubProps = Partial<Omit<BaseMenuSubProps, "onOpenChange">> & {
+  onOpenChange?: (open: boolean) => void;
 };
 
-/**
- * Groups a `SubTrigger` with its `SubContent` to form a nested submenu that
- * opens on hover/focus. Works uncontrolled by default; pass `open`/`onOpenChange`
- * to control it, or `defaultOpen` to set the initial state.
- *
- * Note: the underlying `RadixMenu.Sub` is controlled-only (it has no internal
- * uncontrolled state), so we manage open state here via `useControllableState`,
- * mirroring `Menu.Root`. Without this the submenu would never open on hover.
- */
-const Sub = ({
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  defaultOpen: defaultOpenProp,
-  children,
-  ...props
-}: SubProps) => {
-  const [open = false, setOpen] = useControllableState({
-    prop: openProp,
-    defaultProp: defaultOpenProp ?? false,
-    onChange: onOpenChangeProp,
-  });
+const Sub = ({ children, onOpenChange, ...props }: SubProps) => {
+  const compatibilityContext = useContext(MenuCompatibilityContext);
+  const handleOpenChange = useCallback<
+    NonNullable<BaseMenuSubProps["onOpenChange"]>
+  >(
+    (open, eventDetails) => {
+      if (
+        !open &&
+        compatibilityContext &&
+        callLatestContentDismissHandler(
+          eventDetails,
+          compatibilityContext.contentCallbacksRef,
+          "submenu",
+        )
+      ) {
+        // Submenu close should only honor submenu content callbacks, not root
+        // callbacks, which matches Radix's scoped dismissal behavior.
+        eventDetails.cancel();
+        return;
+      }
+
+      onOpenChange?.(open);
+    },
+    [compatibilityContext, onOpenChange],
+  );
+
   return (
-    <RadixMenu.Sub open={open} onOpenChange={setOpen} {...props}>
+    <BaseMenu.SubmenuRoot onOpenChange={handleOpenChange} {...props}>
       {children}
-    </RadixMenu.Sub>
+    </BaseMenu.SubmenuRoot>
   );
 };
 
-export type SubTriggerProps<T extends TgphElement = "button"> =
-  MenuItemProps<T> & React.ComponentProps<typeof RadixMenu.SubTrigger>;
+type MenuSubTriggerItemProps = Omit<MenuItemProps, "onClick" | "tgphRef">;
+
+export type SubTriggerProps<T extends TgphElement = "button"> = Partial<
+  Omit<
+    BaseMenuSubTriggerProps,
+    "children" | "className" | "onClick" | "render" | "style"
+  >
+> &
+  MenuSubTriggerItemProps & {
+    as?: T;
+    onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
+    tgphRef?: Ref<HTMLElement>;
+  };
 
 const SubTrigger = <T extends TgphElement = "button">({
+  closeDelay,
+  delay,
+  disabled,
   mx = "1",
-  asChild = true,
   icon,
   leadingIcon,
+  label,
   trailingIcon,
   leadingComponent,
   trailingComponent,
+  openOnHover,
   tgphRef,
   onClick,
+  nativeButton = true,
   ...props
 }: SubTriggerProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
-  // Default to a chevron so the item reads as "opens a submenu". Only apply it
-  // when the caller supplies neither a trailing icon nor a trailing component —
-  // `MenuItemTrailing` renders `trailingIcon` in preference to
-  // `trailingComponent`, so an unconditional default would hide a caller's
-  // `trailingComponent`. Annotating with `typeof trailingIcon` keeps
-  // `aria-hidden` as the literal `true` the icon type requires instead of
-  // widening it to `boolean`.
+  const menuItemProps = props as MenuItemProps<T>;
   const combinedTrailingIcon: typeof trailingIcon =
     trailingIcon === undefined && trailingComponent === undefined
       ? { icon: ChevronRight, "aria-hidden": true }
       : trailingIcon;
+  const handleClick = (event: ReactMouseEvent<HTMLElement>) => {
+    onClick?.(event);
+    preventBaseUIHandlerWhenDefaultPrevented(event);
+  };
+
   return (
-    <RadixMenu.SubTrigger
-      {...props}
-      asChild={asChild}
-      ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-    >
-      <RefToTgphRef>
-        <MenuItem
-          // Pass onClick only to MenuItem (not also via {...props} to
-          // RadixMenu.SubTrigger) so RefToTgphRef doesn't compose a
-          // caller-supplied handler twice. Mirrors Menu.Button.
-          onClick={
-            onClick as React.MouseEventHandler<HTMLButtonElement> | undefined
-          }
+    <BaseMenu.SubmenuTrigger
+      closeDelay={closeDelay}
+      delay={delay}
+      disabled={disabled}
+      label={label}
+      nativeButton={nativeButton}
+      openOnHover={openOnHover}
+      render={createTgphBaseUIRender((state: MenuSubTriggerRenderState) => (
+        <MenuItem<T>
+          {...menuItemProps}
+          onClick={handleClick as MenuItemProps<T>["onClick"]}
           leadingIcon={combinedLeadingIcon}
           trailingIcon={combinedTrailingIcon}
           leadingComponent={leadingComponent}
           trailingComponent={trailingComponent}
+          data-state={state.open ? "open" : "closed"}
           data-tgph-menu-button
+          disabled={disabled}
           mx={mx}
           style={{
             flexShrink: 0,
+            ...menuItemProps.style,
           }}
-          {...props}
+          tgphRef={tgphRef as MenuItemProps<T>["tgphRef"]}
         />
-      </RefToTgphRef>
-    </RadixMenu.SubTrigger>
+      ))}
+    />
   );
 };
 
-export type SubContentProps<T extends TgphElement = "div"> =
-  React.ComponentProps<typeof RadixMenu.SubContent> &
-    Omit<TgphComponentProps<typeof Stack<T>>, "align">;
+export type SubContentProps<T extends TgphElement = "div"> = Omit<
+  ContentProps<T>,
+  "align" | "side"
+>;
 
 const SubContent = <T extends TgphElement = "div">({
-  direction = "column",
-  gap = "1",
-  rounded = "4",
-  py = "1",
-  shadow = "2",
-  // Submenus open to the side with no gap by default; `side`/`align` are
-  // managed by Radix and intentionally not accepted here.
   sideOffset = 0,
-  children,
-  onInteractOutside,
-  onKeyDown,
-  tgphRef,
   ...props
 }: SubContentProps<T>) => {
   return (
-    <RadixMenu.Portal>
-      <RadixMenu.SubContent
-        onInteractOutside={onInteractOutside}
-        onKeyDown={onKeyDown}
-        asChild
-        sideOffset={sideOffset}
-        {...props}
-        // Need to cast this type since RadixMenu.SubContent doesn't accept tgphRef
-        ref={tgphRef as React.LegacyRef<HTMLDivElement>}
-      >
-        <RefToTgphRef>
-          {/* Keep this Stack surface in sync with `Content` above. */}
-          <Stack
-            bg="surface-1"
-            // Add tgph class so that this always works in portals
-            className="tgph"
-            direction={direction}
-            gap={gap}
-            rounded={rounded}
-            py={py}
-            shadow={shadow}
-            style={{
-              overflowY: "auto",
-            }}
-            zIndex="popover"
-          >
-            <LazyMotion features={domAnimation}>{children}</LazyMotion>
-          </Stack>
-        </RefToTgphRef>
-      </RadixMenu.SubContent>
-    </RadixMenu.Portal>
+    <MenuContentScopeContext.Provider value="submenu">
+      <Content align="start" side="right" sideOffset={sideOffset} {...props} />
+    </MenuContentScopeContext.Provider>
   );
 };
 

--- a/packages/menu/src/MenuItem/MenuItem.stories.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.stories.tsx
@@ -77,7 +77,7 @@ export const Default: Story = {
       : undefined;
 
     const selected = type === "selectable" ? selectedProp : undefined;
-    console.log(selected, type, args);
+
     return (
       <>
         <TelegraphMenuItem

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -1,16 +1,24 @@
 import { Button } from "@telegraph/button";
-import { TgphComponentProps, TgphElement } from "@telegraph/helpers";
+import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Check } from "lucide-react";
 import * as motion from "motion/react-m";
+import type { ReactNode } from "react";
+
+type MenuItemIconProps = {
+  icon?: TgphComponentProps<typeof Button.Icon>;
+  leadingIcon?: TgphComponentProps<typeof Button.Icon>;
+  trailingIcon?: TgphComponentProps<typeof Button.Icon>;
+};
 
 export type MenuItemProps<T extends TgphElement = "button"> =
-  TgphComponentProps<typeof Button<T>> & {
-    selected?: boolean | null;
-    leadingComponent?: React.ReactNode;
-    trailingComponent?: React.ReactNode;
-    textProps?: TgphComponentProps<typeof Button.Text>;
-  };
+  TgphComponentProps<typeof Button.Root<T>> &
+    MenuItemIconProps & {
+      selected?: boolean | null;
+      leadingComponent?: ReactNode;
+      trailingComponent?: ReactNode;
+      textProps?: TgphComponentProps<typeof Button.Text>;
+    };
 
 const MenuItem = <T extends TgphElement = "button">({
   variant = "ghost",
@@ -28,6 +36,8 @@ const MenuItem = <T extends TgphElement = "button">({
   textProps,
   ...props
 }: MenuItemProps<T>) => {
+  const rootProps = props as TgphComponentProps<typeof Button.Root>;
+
   return (
     <Button.Root
       size={size}
@@ -36,7 +46,7 @@ const MenuItem = <T extends TgphElement = "button">({
       px={px}
       justify={justify}
       w={w}
-      {...props}
+      {...rootProps}
     >
       <Stack gap={gap} align="center" w="full">
         <MenuItemLeading
@@ -46,13 +56,13 @@ const MenuItem = <T extends TgphElement = "button">({
           leadingComponent={leadingComponent}
         />
         <Button.Text
-          weight={props?.fontWeight || "medium"}
+          weight={rootProps.fontWeight || "medium"}
           w="full"
           overflow="hidden"
           textOverflow="ellipsis"
           {...textProps}
         >
-          {props.children}
+          {rootProps.children}
         </Button.Text>
       </Stack>
       <MenuItemTrailing

--- a/packages/menu/src/default.css
+++ b/packages/menu/src/default.css
@@ -3,10 +3,15 @@
   outline: none;
 }
 
+[data-tgph-menu-content]:focus,
+[data-tgph-menu-content]:focus-visible {
+  outline: none;
+}
+
 /* Keep a submenu trigger highlighted while its submenu is open, so it stays
-   clear which parent item the open submenu belongs to. Radix sets
-   data-state="open" on the active SubTrigger; we reuse the button's own hover
-   background so the highlight matches its color/variant automatically. */
+   clear which parent item the open submenu belongs to. Telegraph re-emits the
+   Radix-era data-state="open" attribute from Base UI state; we reuse the
+   button's own hover background so the highlight matches automatically. */
 [data-tgph-menu-button][data-state="open"] {
   background-color: var(--hover--background-color, var(--background-color));
 }

--- a/packages/menu/vitest.config.mts
+++ b/packages/menu/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "menu",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4478,11 +4478,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/menu@workspace:packages/menu"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-menu": "npm:^2.1.16"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #842.
- Linear: [KNO-13670](https://linear.app/knock/issue/KNO-13670).

## What changed

- Migrates `@telegraph/menu` from Radix Menu to Base UI Menu while preserving the existing compound API.
- Reuses shared overlay compatibility helpers from `@telegraph/helpers` and keeps Menu-specific keyboard compatibility in `Menu.helpers.ts`.
- Preserves trigger/content refs, `tgphRef`, Radix-compatible popper CSS variables, preventable dismissal, focus return, submenu behavior, and item selection semantics.
- Preserves Combobox usage of Menu buttons, including `closeOnSelect={false}` multi-select behavior and accessible-label fallback when an option label is an empty string.
- Scopes menu content dismissal callbacks so root dismissal handlers do not block submenu Escape/close behavior.
- Preserves nested focusable trigger keyboard behavior without suppressing Base UI handlers unnecessarily.
- Updates Menu docs, tests, dependencies, changeset, and the Storybook script to avoid auto-opening a browser.

## Why

- Removes Menu's Radix runtime dependency while keeping published behavior and downstream Combobox usage stable.
- Keeps only the Telegraph-specific keyboard and dismissal edge cases local to Menu.
- Ensures stacked/nested menu interactions and Combobox menu-item selection keep matching the pre-migration behavior after moving to Base UI.

## Verification

- `yarn test packages/menu/src/Menu/Menu.test.tsx`
- `yarn test packages/combobox/src/Combobox/Combobox.test.tsx -t getOptionAccessibleLabel`
- `yarn workspace @telegraph/menu build`
- Latest stack-wide pass: `yarn format:check`, `yarn manypkg:check`, `yarn build:packages`, `yarn test`, `yarn lint`, `yarn build:storybook`, `git diff --check`
