### PR TITLE
refactor(segmented-control): migrate to Base UI

### DIFF
--- a/.changeset/green-segments-press.md
+++ b/.changeset/green-segments-press.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/segmented-control": minor
+---
+
+Migrate SegmentedControl to Base UI ToggleGroup primitives while preserving Telegraph value shapes, empty-string values, scroll controls, `tgphRef`, and disabled option styling. Group-level `disabled` now propagates to every rendered option button so visual disabled state matches blocked interaction.

--- a/packages/segmented-control/README.md
+++ b/packages/segmented-control/README.md
@@ -67,16 +67,23 @@ The container component that manages the selection state and layout.
 | `rovingFocus`   | `boolean`                             | `true`         | Enable keyboard navigation              |
 | `loop`          | `boolean`                             | `true`         | Loop focus when reaching ends           |
 
+`SegmentedControl.Root` is implemented with Base UI ToggleGroup primitives. The
+Telegraph API keeps the previous value contract: `type="single"` uses a string
+value and `type="multiple"` uses a string array, even though Base UI normalizes
+toggle-group state internally as arrays. Root and option `tgphRef` props continue
+to resolve to the rendered DOM elements, and overflowing horizontal controls keep
+the same scroll-button behavior.
+
 ### `<SegmentedControl.Option>`
 
 Individual option button within the segmented control.
 
-| Prop       | Type                              | Default | Description                       |
-| ---------- | --------------------------------- | ------- | --------------------------------- |
-| `value`    | `string`                          | -       | Unique identifier for this option |
-| `disabled` | `boolean`                         | `false` | Disable this specific option      |
+| Prop       | Type                       | Default | Description                       |
+| ---------- | -------------------------- | ------- | --------------------------------- |
+| `value`    | `string`                   | -       | Unique identifier for this option |
+| `disabled` | `boolean`                  | `false` | Disable this specific option      |
 | `size`     | `"0" \| "1" \| "2" \| "3"` | `"1"`   | Button size                       |
-| `children` | `ReactNode`                       | -       | Content of the option             |
+| `children` | `ReactNode`                | -       | Content of the option             |
 
 ## Usage Patterns
 
@@ -318,8 +325,8 @@ export const ConditionalSegmentedControl = ({ userRole, permissions }) => {
 ### Loading State
 
 ```tsx
-import { SegmentedControl } from "@telegraph/segmented-control";
 import { Box } from "@telegraph/layout";
+import { SegmentedControl } from "@telegraph/segmented-control";
 
 export const SegmentedControlWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -594,7 +601,7 @@ export const ProjectSettingsForm = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/segmented-control)
-- [Radix UI Toggle Group](https://www.radix-ui.com/primitives/docs/components/toggle-group)
+- [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group)
 
 ## Contributing
 

--- a/packages/segmented-control/package.json
+++ b/packages/segmented-control/package.json
@@ -32,8 +32,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-toggle-group": "^1.1.11",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/layout": "workspace:^",
     "@telegraph/truncate": "workspace:^",

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.helpers.ts
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.helpers.ts
@@ -1,0 +1,84 @@
+type SegmentedControlType = "single" | "multiple";
+type SegmentedControlValue<
+  T extends SegmentedControlType = SegmentedControlType,
+> = T extends "multiple" ? string[] : string;
+type AnySegmentedControlValue = SegmentedControlValue<SegmentedControlType>;
+
+const ROVING_FOCUS_KEYS = [
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "End",
+  "Home",
+];
+
+const PRIVATE_VALUE_PREFIX = "__tgph_segmented_control_value__";
+const EMPTY_STRING_VALUE = `${PRIVATE_VALUE_PREFIX}empty`;
+const ESCAPED_VALUE_PREFIX = `${PRIVATE_VALUE_PREFIX}escaped__`;
+
+const getBaseToggleValue = (value: string) => {
+  if (value === "") {
+    // Base UI ToggleGroup treats empty string as no value, but Telegraph has
+    // historically allowed it as a real option value.
+    return EMPTY_STRING_VALUE;
+  }
+
+  if (value.startsWith(PRIVATE_VALUE_PREFIX)) {
+    // Escape caller values that look like our sentinel values so round-tripping
+    // never turns a real user value into an internal marker.
+    return `${ESCAPED_VALUE_PREFIX}${value}`;
+  }
+
+  return value;
+};
+
+const getLegacyToggleValue = (value: string) => {
+  if (value === EMPTY_STRING_VALUE) {
+    // Decode the sentinel back to the public Telegraph value shape.
+    return "";
+  }
+
+  if (value.startsWith(ESCAPED_VALUE_PREFIX)) {
+    // Remove only the escape prefix, leaving the caller's original private-looking
+    // value intact.
+    return value.slice(ESCAPED_VALUE_PREFIX.length);
+  }
+
+  return value;
+};
+
+const getBaseToggleGroupValue = (
+  value: AnySegmentedControlValue | undefined,
+): readonly string[] | undefined => {
+  if (value === undefined) {
+    // Leave undefined alone so Base UI can stay uncontrolled.
+    return undefined;
+  }
+
+  return Array.isArray(value)
+    ? value.map(getBaseToggleValue)
+    : [getBaseToggleValue(value)];
+};
+
+const getLegacyToggleGroupValue = (
+  type: SegmentedControlType,
+  value: string[],
+): AnySegmentedControlValue => {
+  // Base UI always reports an array; Telegraph's single mode reports one value.
+  return type === "multiple"
+    ? value.map(getLegacyToggleValue)
+    : getLegacyToggleValue(value[0] ?? "");
+};
+
+export {
+  ROVING_FOCUS_KEYS,
+  getBaseToggleValue,
+  getBaseToggleGroupValue,
+  getLegacyToggleGroupValue,
+};
+export type {
+  AnySegmentedControlValue,
+  SegmentedControlType,
+  SegmentedControlValue,
+};

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Box, Stack } from "@telegraph/layout";
 import { AlignCenter, AlignLeft, AlignRight } from "lucide-react";
-import React from "react";
+import { type ComponentProps, useState } from "react";
 
 import { SegmentedControl as TelegraphSegmentedControl } from "./SegmentedControl";
 
@@ -21,45 +21,54 @@ const meta: Meta<typeof TelegraphSegmentedControl.Root> = {
 };
 
 type Story = StoryObj<typeof TelegraphSegmentedControl.Root>;
+type SegmentedControlRootProps = ComponentProps<
+  typeof TelegraphSegmentedControl.Root
+>;
 
 export default meta;
 
-export const Default: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState("left");
-    return (
-      <Box maxW="140">
-        <TelegraphSegmentedControl.Root
-          value={value}
-          onValueChange={setValue}
-          {...args}
+const DefaultStory = (args: SegmentedControlRootProps) => {
+  const [value, setValue] = useState("left");
+
+  return (
+    <Box maxW="140">
+      <TelegraphSegmentedControl.Root
+        value={value}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue(nextValue);
+          }
+        }}
+        {...args}
+      >
+        <TelegraphSegmentedControl.Option
+          value="left"
+          icon={{ icon: AlignLeft, "aria-hidden": true }}
         >
-          <TelegraphSegmentedControl.Option
-            value="left"
-            icon={{ icon: AlignLeft, "aria-hidden": true }}
-          >
-            Left
-          </TelegraphSegmentedControl.Option>
-          <TelegraphSegmentedControl.Option
-            value="center"
-            icon={{ icon: AlignCenter, "aria-hidden": true }}
-          >
-            Center
-          </TelegraphSegmentedControl.Option>
-          <TelegraphSegmentedControl.Option
-            value="right"
-            icon={{ icon: AlignRight, "aria-hidden": true }}
-          >
-            Right
-          </TelegraphSegmentedControl.Option>
-        </TelegraphSegmentedControl.Root>
-      </Box>
-    );
-  },
+          Left
+        </TelegraphSegmentedControl.Option>
+        <TelegraphSegmentedControl.Option
+          value="center"
+          icon={{ icon: AlignCenter, "aria-hidden": true }}
+        >
+          Center
+        </TelegraphSegmentedControl.Option>
+        <TelegraphSegmentedControl.Option
+          value="right"
+          icon={{ icon: AlignRight, "aria-hidden": true }}
+        >
+          Right
+        </TelegraphSegmentedControl.Option>
+      </TelegraphSegmentedControl.Root>
+    </Box>
+  );
 };
 
-const optionsList = [
+export const Default: Story = {
+  render: (args) => <DefaultStory {...args} />,
+};
+
+const OPTIONS_LIST = [
   { value: "Workflow", label: "Workflow" },
   { value: "Recipient", label: "Recipient" },
   { value: "Actor", label: "Actor" },
@@ -85,53 +94,62 @@ const optionsList = [
   { value: "Call", label: "Call" },
 ];
 
-export const Scrollable: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value1, setValue1] = React.useState("Workflow");
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value2, setValue2] = React.useState("Task");
-    return (
-      <Stack
-        maxW="80"
-        h="80"
-        border="px"
-        rounded="3"
-        p="4"
-        direction="column"
-        gap="4"
+const ScrollableStory = (args: SegmentedControlRootProps) => {
+  const [value1, setValue1] = useState("Workflow");
+  const [value2, setValue2] = useState("Task");
+
+  return (
+    <Stack
+      maxW="80"
+      h="80"
+      border="px"
+      rounded="3"
+      p="4"
+      direction="column"
+      gap="4"
+    >
+      <TelegraphSegmentedControl.Root
+        size="1"
+        value={value1}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue1(nextValue);
+          }
+        }}
+        {...args}
       >
-        <TelegraphSegmentedControl.Root
-          size="1"
-          value={value1}
-          onValueChange={setValue1}
-          {...args}
-        >
-          {optionsList.map((option) => (
-            <TelegraphSegmentedControl.Option
-              key={option.value}
-              value={option.value}
-            >
-              {option.label}
-            </TelegraphSegmentedControl.Option>
-          ))}
-        </TelegraphSegmentedControl.Root>
-        <TelegraphSegmentedControl.Root
-          size="1"
-          value={value2}
-          onValueChange={setValue2}
-          {...args}
-        >
-          {optionsList.map((option) => (
-            <TelegraphSegmentedControl.Option
-              key={option.value}
-              value={option.value}
-            >
-              {option.label}
-            </TelegraphSegmentedControl.Option>
-          ))}
-        </TelegraphSegmentedControl.Root>
-      </Stack>
-    );
-  },
+        {OPTIONS_LIST.map((option) => (
+          <TelegraphSegmentedControl.Option
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </TelegraphSegmentedControl.Option>
+        ))}
+      </TelegraphSegmentedControl.Root>
+      <TelegraphSegmentedControl.Root
+        size="1"
+        value={value2}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            setValue2(nextValue);
+          }
+        }}
+        {...args}
+      >
+        {OPTIONS_LIST.map((option) => (
+          <TelegraphSegmentedControl.Option
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </TelegraphSegmentedControl.Option>
+        ))}
+      </TelegraphSegmentedControl.Root>
+    </Stack>
+  );
+};
+
+export const Scrollable: Story = {
+  render: (args) => <ScrollableStory {...args} />,
 };

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
@@ -1,0 +1,385 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createRef, useState } from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { SegmentedControl } from "./SegmentedControl";
+
+class ResizeObserverMock implements ResizeObserver {
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+}
+
+const SegmentedControlFixture = ({
+  defaultValue = "left",
+}: {
+  defaultValue?: string;
+}) => {
+  return (
+    <SegmentedControl.Root defaultValue={defaultValue}>
+      <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+      <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      <SegmentedControl.Option value="right" disabled>
+        Right
+      </SegmentedControl.Option>
+    </SegmentedControl.Root>
+  );
+};
+
+describe("SegmentedControl", () => {
+  beforeAll(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the default option with Telegraph state attributes", () => {
+    render(<SegmentedControlFixture />);
+
+    const activeOption = screen.getByRole("button", { name: "Left" });
+
+    expect(activeOption).toHaveAttribute("data-tgph-segmented-control-option");
+    expect(activeOption).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(activeOption).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("supports controlled single values and legacy string callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("left");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+          <SegmentedControl.Option value="center">
+            Center
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Center" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("center");
+    expect(screen.getByRole("button", { name: "Center" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+  });
+
+  it("does not clear a controlled single value when the active option is clicked again", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root value="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Left" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("does not clear an uncontrolled single value when the active option is clicked again", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Left" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("supports an empty string as a controlled single value", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("left");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="">None</SegmentedControl.Option>
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "None" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("");
+    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+  });
+
+  it("does not collide with option values that match the empty-string sentinel", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const emptyStringSentinel = "__tgph_segmented_control_value__empty";
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState("");
+
+      return (
+        <SegmentedControl.Root
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string);
+          }}
+        >
+          <SegmentedControl.Option value="">None</SegmentedControl.Option>
+          <SegmentedControl.Option value={emptyStringSentinel}>
+            Sentinel
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Sentinel" }));
+
+    expect(onValueChange).toHaveBeenCalledWith(emptyStringSentinel);
+    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "inactive",
+    );
+    expect(screen.getByRole("button", { name: "Sentinel" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("supports controlled multiple values and legacy array callbacks", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    const ControlledSegmentedControl = () => {
+      const [value, setValue] = useState(["left"]);
+
+      return (
+        <SegmentedControl.Root
+          type="multiple"
+          value={value}
+          onValueChange={(nextValue) => {
+            onValueChange(nextValue);
+            setValue(nextValue as string[]);
+          }}
+        >
+          <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+          <SegmentedControl.Option value="center">
+            Center
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>
+      );
+    };
+
+    render(<ControlledSegmentedControl />);
+
+    await user.click(screen.getByRole("button", { name: "Center" }));
+
+    expect(onValueChange).toHaveBeenCalledWith(["left", "center"]);
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+    expect(screen.getByRole("button", { name: "Center" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("does not activate disabled options", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root value="left" onValueChange={onValueChange}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="right" disabled>
+          Right
+        </SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Right" }));
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+      "data-tgph-segmented-control-option-status",
+      "active",
+    );
+  });
+
+  it("visually and functionally disables every option when the root is disabled", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+
+    render(
+      <SegmentedControl.Root
+        defaultValue="left"
+        disabled
+        onValueChange={onValueChange}
+      >
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const centerOption = screen.getByRole("button", { name: "Center" });
+
+    expect(leftOption).toBeDisabled();
+    expect(leftOption).toHaveAttribute("data-tgph-button-state", "disabled");
+    expect(centerOption).toBeDisabled();
+    expect(centerOption).toHaveAttribute("data-tgph-button-state", "disabled");
+
+    await user.click(centerOption);
+
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("moves focus with arrow keys by default", async () => {
+    const user = userEvent.setup();
+
+    render(<SegmentedControlFixture />);
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const centerOption = screen.getByRole("button", { name: "Center" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(centerOption).toHaveFocus();
+  });
+
+  it("loops focus with arrow keys by default", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left">
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+        <SegmentedControl.Option value="right">Right</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    const rightOption = screen.getByRole("button", { name: "Right" });
+
+    rightOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("honors loop=false for arrow-key focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" loop={false}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowLeft}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("preserves legacy opt-out support for roving focus", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <SegmentedControl.Root defaultValue="left" rovingFocus={false}>
+        <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
+        <SegmentedControl.Option value="center">Center</SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+
+    leftOption.focus();
+    await user.keyboard("{ArrowRight}");
+
+    expect(leftOption).toHaveFocus();
+  });
+
+  it("forwards tgphRef through Base UI render props", () => {
+    const rootRef = createRef<HTMLDivElement>();
+    const optionRef = createRef<HTMLButtonElement>();
+
+    render(
+      <SegmentedControl.Root
+        data-testid="segmented-control-root"
+        defaultValue="left"
+        tgphRef={rootRef}
+      >
+        <SegmentedControl.Option value="left" tgphRef={optionRef}>
+          Left
+        </SegmentedControl.Option>
+      </SegmentedControl.Root>,
+    );
+
+    expect(rootRef.current).toBe(screen.getByTestId("segmented-control-root"));
+    expect(optionRef.current).toBe(
+      screen.getByRole("button", { name: "Left" }),
+    );
+  });
+});

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -1,46 +1,139 @@
-import * as ToggleGroup from "@radix-ui/react-toggle-group";
+import {
+  DirectionProvider,
+  type TextDirection,
+} from "@base-ui/react/direction-provider";
+import { Toggle as BaseToggle } from "@base-ui/react/toggle";
+import { ToggleGroup as BaseToggleGroup } from "@base-ui/react/toggle-group";
 import { Button } from "@telegraph/button";
-import { RefToTgphRef, type TgphComponentProps } from "@telegraph/helpers";
+import { useComposedRefs } from "@telegraph/compose-refs";
+import {
+  type TgphComponentProps,
+  createTgphBaseUIRender,
+  useControllableState,
+} from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { useTruncate } from "@telegraph/truncate";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import { div as MotionDiv } from "motion/react-m";
-import React from "react";
+import {
+  type ComponentPropsWithoutRef,
+  type Dispatch,
+  type KeyboardEvent,
+  type ReactNode,
+  type Ref,
+  type RefObject,
+  type SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  type AnySegmentedControlValue,
+  ROVING_FOCUS_KEYS,
+  type SegmentedControlType,
+  type SegmentedControlValue,
+  getBaseToggleGroupValue,
+  getBaseToggleValue,
+  getLegacyToggleGroupValue,
+} from "./SegmentedControl.helpers";
 
 // Use a tolerance of 1px to account for subpixel rendering and floating-point precision
 const SCROLL_TOLERANCE = 1;
 const SCROLL_OFFSET = 24;
 
-const SegmentedControlContextState = React.createContext<{
-  value?: React.ComponentProps<typeof ToggleGroup.Root>["value"];
-  size?: React.ComponentProps<typeof Button.Root>["size"];
+type BaseToggleGroupProps = ComponentPropsWithoutRef<typeof BaseToggleGroup>;
+type SegmentedControlOptionStatus = "active" | "inactive";
+type SegmentedControlRootKeyDownEvent = KeyboardEvent<HTMLDivElement> & {
+  preventBaseUIHandler?: () => void;
+};
+type SegmentedControlChangeValue<
+  T extends SegmentedControlType,
+  Value extends AnySegmentedControlValue,
+> = T extends "multiple"
+  ? string[]
+  : Extract<Value, string> extends never
+    ? string
+    : Extract<Value, string>;
+type SegmentedControlValueChangeHandler<
+  T extends SegmentedControlType,
+  Value extends AnySegmentedControlValue,
+> = {
+  bivarianceHack(value: SegmentedControlChangeValue<T, Value>): void;
+}["bivarianceHack"];
+
+const SegmentedControlContextState = createContext<{
+  disabled?: boolean;
+  size?: ComponentPropsWithoutRef<typeof Button.Root>["size"];
   showScrollButtons?: boolean;
   activeOptionRef?: HTMLButtonElement | null;
-  setActiveOptionRef?: React.Dispatch<
-    React.SetStateAction<HTMLButtonElement | null>
-  >;
+  setActiveOptionRef?: Dispatch<SetStateAction<HTMLButtonElement | null>>;
 }>({
-  value: "",
+  disabled: false,
   size: "1",
   showScrollButtons: false,
   activeOptionRef: null,
   setActiveOptionRef: () => {},
 });
 
-export type RootProps = Omit<
-  React.ComponentProps<typeof ToggleGroup.Root>,
-  "type"
+export type RootProps<
+  T extends SegmentedControlType = "single",
+  Value extends AnySegmentedControlValue = SegmentedControlValue<T>,
+> = Omit<
+  BaseToggleGroupProps,
+  | "children"
+  | "className"
+  | "defaultValue"
+  | "disabled"
+  | "loopFocus"
+  | "multiple"
+  | "onKeyDown"
+  | "onValueChange"
+  | "orientation"
+  | "render"
+  | "style"
+  | "value"
 > &
-  TgphComponentProps<typeof Stack> & {
-    type?: React.ComponentProps<typeof ToggleGroup.Root>["type"];
-    size?: React.ComponentProps<typeof Button.Root>["size"];
+  Omit<TgphComponentProps<typeof Stack>, "defaultValue" | "dir"> & {
+    defaultValue?: Value;
+    dir?: TextDirection;
+    disabled?: boolean;
+    loop?: boolean;
+    onValueChange?: SegmentedControlValueChangeHandler<T, Value>;
+    orientation?: BaseToggleGroupProps["orientation"];
+    rovingFocus?: boolean;
     scrollControls?: "arrows" | "none";
+    size?: ComponentPropsWithoutRef<typeof Button.Root>["size"];
+    type?: T;
+    value?: Value;
   };
 
-const Root = ({
-  // ToggleGroup.Root Props
-  type = "single",
+type SegmentedControlDirectionProviderProps = {
+  children: ReactNode;
+  dir?: TextDirection;
+};
+
+const SegmentedControlDirectionProvider = ({
+  children,
+  dir,
+}: SegmentedControlDirectionProviderProps) => {
+  if (!dir) {
+    return <>{children}</>;
+  }
+
+  return <DirectionProvider direction={dir}>{children}</DirectionProvider>;
+};
+
+const Root = <
+  T extends SegmentedControlType = "single",
+  Value extends AnySegmentedControlValue = SegmentedControlValue<T>,
+>({
+  type: typeProp,
   size = "1",
   scrollControls = "arrows",
   value,
@@ -50,28 +143,88 @@ const Root = ({
   rovingFocus,
   orientation,
   dir,
-  loop,
+  loop = true,
   children,
+  onKeyDown,
+  tgphRef,
   ...props
-}: RootProps) => {
-  const containerId = React.useId();
+}: RootProps<T, Value>) => {
+  const containerId = useId();
 
   // Automatically show the scroll buttons when the content of the
   // segmented control is too wide to fit within the container.
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const composedContainerRef = useComposedRefs(
+    tgphRef as Ref<HTMLDivElement> | undefined,
+    containerRef,
+  );
   const { truncated } = useTruncate({ tgphRef: containerRef });
-  const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
+  const scrollButtonRef = useRef<HTMLButtonElement>(null);
   const showScrollButtons = scrollControls === "arrows" && truncated;
+  // Only load the motion/measurement work once overflow is detected.
+  const shouldRenderScrollButtons = showScrollButtons;
+  const type = typeProp ?? "single";
+  const isMultiple = type === "multiple";
+  // Encode Telegraph values before they reach Base UI so empty strings and
+  // private-looking values can round-trip safely through ToggleGroup.
+  const [currentValue, setCurrentValue] = useControllableState<
+    AnySegmentedControlValue | undefined
+  >({
+    prop: value,
+    defaultProp: defaultValue,
+    onChange: onValueChange as
+      | ((nextValue: AnySegmentedControlValue | undefined) => void)
+      | undefined,
+  });
+  const baseValue = getBaseToggleGroupValue(currentValue) ?? [];
+  const handleValueChange = useCallback<
+    NonNullable<BaseToggleGroupProps["onValueChange"]>
+  >(
+    (nextValue) => {
+      if (!isMultiple && nextValue.length === 0) {
+        // Radix single ToggleGroup did not let the active option clear itself.
+        return;
+      }
+
+      // Base UI always emits arrays; convert back to Telegraph's single or
+      // multiple public value shape before notifying consumers.
+      setCurrentValue(
+        getLegacyToggleGroupValue(type, nextValue) as AnySegmentedControlValue,
+      );
+    },
+    [isMultiple, setCurrentValue, type],
+  );
+  const handleKeyDown = useCallback(
+    (event: SegmentedControlRootKeyDownEvent) => {
+      onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        event.preventBaseUIHandler?.();
+        return;
+      }
+
+      if (rovingFocus !== false) {
+        return;
+      }
+
+      if (ROVING_FOCUS_KEYS.includes(event.key)) {
+        // `rovingFocus={false}` used to leave arrow keys to the page/caller, so
+        // block Base UI's default roving handler after user code has run.
+        event.preventBaseUIHandler?.();
+      }
+    },
+    [onKeyDown, rovingFocus],
+  );
 
   // We store the active option ref as a state value so that we can respond to it
   // changing via an effect vs doing complicated ref status chasing.
   const [activeOptionRef, setActiveOptionRef] =
-    React.useState<HTMLButtonElement | null>(null);
-  const [scrollStatus, setScrollStatus] = React.useState<
+    useState<HTMLButtonElement | null>(null);
+  const [scrollStatus, setScrollStatus] = useState<
     "flushLeft" | "flushRight" | "middle" | null
   >(null);
 
-  const onScrollClick = React.useCallback((direction: "left" | "right") => {
+  const onScrollClick = useCallback((direction: "left" | "right") => {
     if (!containerRef.current) return;
 
     // We get the currentWidth so that we can scroll a meaningful amount.
@@ -90,7 +243,7 @@ const Root = ({
   }, []);
 
   // Derive what the `scrollStatus` should be based on the current scroll position.
-  const deriveScrollStatus = React.useCallback(
+  const deriveScrollStatus = useCallback(
     (
       currentScrollPosition: number,
     ): "flushLeft" | "flushRight" | "middle" | null => {
@@ -118,14 +271,14 @@ const Root = ({
   );
 
   // Update the `scrollStatus` on mount and each time the container is scrolled.
-  const handleScroll = React.useCallback(() => {
+  const handleScroll = useCallback(() => {
     if (!containerRef.current) return;
     const newScrollPosition = containerRef.current.scrollLeft;
     const newScrollStatus = deriveScrollStatus(newScrollPosition);
     setScrollStatus(newScrollStatus);
   }, [deriveScrollStatus]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
 
@@ -138,8 +291,8 @@ const Root = ({
   }, [handleScroll]);
 
   // When the active option is changed, ensure that it is in view.
-  const [hasRan, setHasRan] = React.useState(false);
-  React.useEffect(() => {
+  const [hasRan, setHasRan] = useState(false);
+  useEffect(() => {
     if (showScrollButtons && activeOptionRef) {
       const optionOffsetLeft = activeOptionRef.offsetLeft;
       // Determine what the scroll status would be if the active option was scrolled into view.
@@ -160,7 +313,7 @@ const Root = ({
       containerRef.current?.scrollTo({
         left: newScrollPosition,
         // If this is the first time we've run this effect, we choose to scroll to the active
-        // option instantly. This avoid animating to that value on mount.
+        // option instantly. This avoids animating to that value on mount.
         behavior: hasRan ? "smooth" : "instant",
       });
 
@@ -178,49 +331,46 @@ const Root = ({
     >
       <SegmentedControlContextState.Provider
         value={{
-          value,
           size,
+          disabled,
           showScrollButtons,
           activeOptionRef,
           setActiveOptionRef,
         }}
       >
-        {/* @ts-expect-error: radix's type props doesn't seem to be typed correctly, could be a bug? */}
-        <ToggleGroup.Root
-          asChild={true}
-          type={type}
-          value={value}
-          defaultValue={defaultValue}
-          onValueChange={onValueChange}
-          disabled={disabled}
-          rovingFocus={rovingFocus}
-          orientation={orientation}
-          dir={dir}
-          loop={loop}
-        >
-          <RefToTgphRef>
-            <Stack
-              id={containerId}
-              bg="gray-3"
-              rounded="2"
-              align="center"
-              justify="space-between"
-              // We use overflow hidden here to totally hide any overflow while also
-              // hiding any scroll bars. The buttons that appear when the container is truncated
-              // control the scroll. This means we don't need to worry about the browser's default
-              // scroll bar overlapping the segmented control.
-              overflow={showScrollButtons ? "hidden" : "visible"}
-              position="relative"
-              tgphRef={containerRef}
-              {...props}
-            >
-              {children}
-            </Stack>
-          </RefToTgphRef>
-        </ToggleGroup.Root>
+        <SegmentedControlDirectionProvider dir={dir}>
+          <BaseToggleGroup
+            value={baseValue}
+            onValueChange={handleValueChange}
+            disabled={disabled}
+            multiple={isMultiple}
+            orientation={orientation}
+            loopFocus={loop}
+            render={createTgphBaseUIRender(
+              <Stack
+                id={containerId}
+                bg="gray-3"
+                rounded="2"
+                align="center"
+                justify="space-between"
+                // We use overflow hidden here to totally hide any overflow while also
+                // hiding any scroll bars. The buttons that appear when the container is truncated
+                // control the scroll. This means we don't need to worry about the browser's default
+                // scroll bar overlapping the segmented control.
+                overflow={showScrollButtons ? "hidden" : "visible"}
+                position="relative"
+                dir={dir}
+                tgphRef={composedContainerRef}
+                onKeyDown={handleKeyDown}
+                {...props}
+              >
+                {children}
+              </Stack>,
+            )}
+          />
+        </SegmentedControlDirectionProvider>
       </SegmentedControlContextState.Provider>
-      {/* We only load any of the truncation logic when the container is truncated. */}
-      {showScrollButtons && (
+      {shouldRenderScrollButtons && (
         <LazyMotion features={domAnimation}>
           <Box
             key="left-scroll-button"
@@ -286,7 +436,7 @@ const Root = ({
 };
 
 const ButtonStyleProps: Record<
-  string,
+  SegmentedControlOptionStatus,
   TgphComponentProps<typeof Button.Root>
 > = {
   active: {
@@ -299,49 +449,73 @@ const ButtonStyleProps: Record<
   },
 };
 
-export type OptionProps = React.ComponentProps<typeof ToggleGroup.Item> &
-  TgphComponentProps<typeof Button>;
+export type OptionProps = Omit<TgphComponentProps<typeof Button>, "value"> & {
+  value: string;
+};
 
-const Option = ({
-  // ToggleGroup.Item Props
-  value,
+type OptionButtonProps = Omit<OptionProps, "value"> & {
+  buttonRef: RefObject<HTMLButtonElement | null>;
+  status: SegmentedControlOptionStatus;
+};
+
+const OptionButton = ({
+  buttonRef,
   disabled,
-  // Button Props
   size = "1",
+  status,
   style,
+  tgphRef,
   ...props
-}: OptionProps) => {
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
-  const { setActiveOptionRef, ...context } = React.useContext(
+}: OptionButtonProps) => {
+  const { setActiveOptionRef, ...context } = useContext(
     SegmentedControlContextState,
   );
-  const status = context.value === value ? "active" : "inactive";
   const derivedSize = context.size ?? size;
+  const derivedDisabled = Boolean(context.disabled || disabled);
+  const composedButtonRef = useComposedRefs(
+    tgphRef as Ref<HTMLButtonElement> | undefined,
+    buttonRef,
+  );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (status === "active") {
       setActiveOptionRef?.(buttonRef.current);
     }
-  }, [status, setActiveOptionRef]);
+  }, [buttonRef, status, setActiveOptionRef]);
 
   return (
-    <ToggleGroup.Item asChild={true} value={value} disabled={disabled}>
-      <RefToTgphRef>
-        <Button
-          size={derivedSize}
-          {...ButtonStyleProps[status]}
-          style={{
-            // Make the button take up all availabel space
-            flexGrow: 1,
-            ...style,
-          }}
-          data-tgph-segmented-control-option
-          data-tgph-segmented-control-option-status={status}
-          tgphRef={buttonRef}
+    <Button
+      size={derivedSize}
+      disabled={derivedDisabled}
+      {...ButtonStyleProps[status]}
+      style={{
+        flexGrow: 1,
+        ...style,
+      }}
+      data-tgph-segmented-control-option
+      data-tgph-segmented-control-option-status={status}
+      tgphRef={composedButtonRef}
+      {...props}
+    />
+  );
+};
+
+const Option = ({ value, disabled, ...props }: OptionProps) => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  return (
+    <BaseToggle
+      value={getBaseToggleValue(value)}
+      disabled={disabled}
+      render={createTgphBaseUIRender((state) => (
+        <OptionButton
+          buttonRef={buttonRef}
+          disabled={state.disabled || disabled}
+          status={state.pressed ? "active" : "inactive"}
           {...props}
         />
-      </RefToTgphRef>
-    </ToggleGroup.Item>
+      ))}
+    />
   );
 };
 

--- a/packages/segmented-control/vitest.config.mts
+++ b/packages/segmented-control/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "segmented-control",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,52 +3505,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-toggle-group@npm:^1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-toggle-group@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-toggle": "npm:1.1.10"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c8cbccda3e25754ed9f3145c67792df2d5d0ee1a910bde6dc07c4577ab508d4b939f145569d4e2af5b17dc4a5c701473380d8695248f8620cf0a372c05b8e958
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-toggle@npm:1.1.10":
-  version: 1.1.10
-  resolution: "@radix-ui/react-toggle@npm:1.1.10"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/5406cdf5dd7299ae6cfdb4865dc5fd43ca3c475ebcd4e86830bd296d734255b61f749c9bde452ebfaad126033f92dd1112ee9d95982344ffad34491238dcc9b1
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-use-callback-ref@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
@@ -4636,10 +4590,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/segmented-control@workspace:packages/segmented-control"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-toggle-group": "npm:^1.1.11"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #843.
- Linear: [KNO-13671](https://linear.app/knock/issue/KNO-13671).

## What changed

- Migrates `@telegraph/segmented-control` from Radix ToggleGroup to Base UI ToggleGroup primitives.
- Moves value conversion and keyboard constants into `SegmentedControl.helpers.ts`.
- Encodes empty string values and Telegraph-private internal values so real option values cannot collide with Base UI adapter sentinels.
- Preserves single and multiple value shapes, `type`, `loop`, `orientation`, `dir`, `disabled`, `rovingFocus`, `tgphRef`, overflow controls, and Telegraph data attributes.
- Defaults `loop` to `true` before passing it to Base UI `loopFocus`, matching the documented Radix-compatible default while still honoring `loop={false}`.
- Keeps single-select values selected when the active option is clicked again, for both controlled and uncontrolled roots.
- Updates stories, README reference, dependencies, tests, and changeset.

## Why

- Removes the Radix ToggleGroup runtime dependency while keeping Radix-shaped values, refs, focus behavior, and visuals backwards compatible.
- Preserves Radix's single-select no-clear behavior on active-option re-clicks.
- Keeps conversion and keyboard compatibility logic out of the main component.
- Protects consumers that use empty string values or values matching Telegraph's private adapter prefix.
- Closes the Cursor review finding around omitted `loop` no longer behaving like the documented default.

## Verification

- `yarn test packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx`
- `yarn workspace @telegraph/segmented-control lint`
- `yarn workspace @telegraph/segmented-control build`
- `yarn prettier --check packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx`
- Stack-wide: `yarn build:packages`
- Stack-wide: `yarn lint`
