### PR TITLE
refactor(toggle): remove Radix utility dependencies

### DIFF
--- a/.changeset/gentle-toggles-hide.md
+++ b/.changeset/gentle-toggles-hide.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/toggle": patch
+---
+
+refactor(toggle): remove Radix utility dependencies

--- a/packages/toggle/README.md
+++ b/packages/toggle/README.md
@@ -65,6 +65,12 @@ The default Toggle component provides a simple API for common use cases.
 
 Additionally, all native HTML input attributes are supported (`aria-label`, `aria-describedby`, etc.)
 
+`Toggle` owns its controlled/uncontrolled state and visually hidden input
+styling locally and no longer depends on Radix. It still renders a native
+checkbox for form submission, validation, keyboard interaction, and screen
+reader semantics while the visible switch, label, and indicator remain Telegraph
+components.
+
 ### Composition API
 
 For advanced use cases, use the composition API:

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -32,8 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",

--- a/packages/toggle/src/Toggle/Toggle.test.tsx
+++ b/packages/toggle/src/Toggle/Toggle.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { FormEvent } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
@@ -209,7 +210,11 @@ describe("Toggle", () => {
     );
     const label = screen.getByText("Enable notifications");
     expect(label).toBeInTheDocument();
-    // Label exists for screen readers but is visually hidden
+    expect(label).toHaveStyle({
+      position: "absolute",
+      overflow: "hidden",
+      whiteSpace: "nowrap",
+    });
   });
 
   it("supports custom aria-label", () => {
@@ -230,6 +235,28 @@ describe("Toggle", () => {
     );
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveAttribute("name", "notifications");
+  });
+
+  it("submits the native checkbox value with forms", async () => {
+    const user = userEvent.setup();
+    const handleSubmit = vi.fn((event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      const formData = new FormData(event.currentTarget);
+      expect(formData.get("notifications")).toBe("on");
+    });
+
+    render(
+      <form onSubmit={handleSubmit}>
+        <Toggle.Default label="Enable notifications" name="notifications" />
+        <button type="submit">Submit</button>
+      </form>,
+    );
+
+    await user.click(screen.getByText("Enable notifications"));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(handleSubmit).toHaveBeenCalledTimes(1);
   });
 
   it("applies checked state to visual toggle", () => {

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -1,17 +1,23 @@
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button } from "@telegraph/button";
-import type {
-  PolymorphicPropsWithTgphRef,
-  TgphComponentProps,
-  TgphElement,
+import {
+  type PolymorphicPropsWithTgphRef,
+  type TgphComponentProps,
+  type TgphElement,
+  VisuallyHidden,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
 import { Stack } from "@telegraph/layout";
 import { Tag } from "@telegraph/tag";
 import { Text } from "@telegraph/typography";
 import { CheckCircle2, Circle } from "lucide-react";
-import React, { Fragment } from "react";
+import {
+  type ReactNode,
+  createContext,
+  useContext,
+  useId,
+  useRef,
+} from "react";
 
 import {
   INDICATOR_SIZE_MAP,
@@ -33,7 +39,7 @@ type InternalContextType = {
   "aria-label"?: string;
 };
 
-const ToggleContext = React.createContext<InternalContextType>({
+const ToggleContext = createContext<InternalContextType>({
   size: "2",
   value: false,
   disabled: false,
@@ -83,7 +89,7 @@ const Root = <T extends TgphElement = "div">({
     onChange: onValueChangeProp,
   });
 
-  const generatedId = React.useId();
+  const generatedId = useId();
   const id = idProp || generatedId;
   const labelId = `${id}-label`;
 
@@ -125,14 +131,13 @@ const Root = <T extends TgphElement = "div">({
 export type SwitchProps = TgphComponentProps<typeof Button.Root>;
 
 const Switch = ({ as, className, style, ...props }: SwitchProps) => {
-  const context = React.useContext(ToggleContext);
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const context = useContext(ToggleContext);
+  const inputRef = useRef<HTMLInputElement>(null);
   const { iconSize, ...sizeConfig } = TOGGLE_SIZE_MAP[context.size];
 
   return (
     <Stack position="relative" align="center">
-      {/* Hidden native checkbox for accessibility */}
-      <VisuallyHidden.Root>
+      <VisuallyHidden>
         <input
           type="checkbox"
           id={context.id}
@@ -146,8 +151,7 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
           aria-label={context["aria-label"]}
           data-tgph-toggle-input
         />
-      </VisuallyHidden.Root>
-      {/* Visual toggle */}
+      </VisuallyHidden>
       <Button.Root
         as="label"
         className={className}
@@ -203,33 +207,50 @@ const Label = <T extends TgphElement = "label">({
   style,
   ...props
 }: LabelProps<T>) => {
-  const context = React.useContext(ToggleContext);
-  const Wrapper = hidden ? VisuallyHidden.Root : Fragment;
+  const context = useContext(ToggleContext);
+
+  if (hidden) {
+    return (
+      <VisuallyHidden asChild>
+        <Text
+          as={(as || "label") as T}
+          htmlFor={context.id}
+          id={context.labelId}
+          size={LABEL_SIZE_MAP[context.size]}
+          data-tgph-toggle-label
+          data-tgph-toggle-disabled={context.disabled}
+          style={{
+            cursor: context.disabled ? "not-allowed" : "pointer",
+            ...style,
+          }}
+          {...props}
+        />
+      </VisuallyHidden>
+    );
+  }
 
   return (
-    <Wrapper asChild>
-      <Text
-        as={(as || "label") as T}
-        htmlFor={context.id}
-        id={context.labelId}
-        size={LABEL_SIZE_MAP[context.size]}
-        data-tgph-toggle-label
-        data-tgph-toggle-disabled={context.disabled}
-        style={{
-          cursor: context.disabled ? "not-allowed" : "pointer",
-          ...style,
-        }}
-        {...props}
-      />
-    </Wrapper>
+    <Text
+      as={(as || "label") as T}
+      htmlFor={context.id}
+      id={context.labelId}
+      size={LABEL_SIZE_MAP[context.size]}
+      data-tgph-toggle-label
+      data-tgph-toggle-disabled={context.disabled}
+      style={{
+        cursor: context.disabled ? "not-allowed" : "pointer",
+        ...style,
+      }}
+      {...props}
+    />
   );
 };
 
 export type IndicatorProps<T extends TgphElement = "span"> = TgphComponentProps<
   typeof Tag<T>
 > & {
-  enabledContent?: React.ReactNode;
-  disabledContent?: React.ReactNode;
+  enabledContent?: ReactNode;
+  disabledContent?: ReactNode;
 };
 
 const Indicator = <T extends TgphElement = "span">({
@@ -240,9 +261,8 @@ const Indicator = <T extends TgphElement = "span">({
   children,
   ...props
 }: IndicatorProps<T>) => {
-  const context = React.useContext(ToggleContext);
+  const context = useContext(ToggleContext);
 
-  // Determine what content to show
   const content =
     children || (context.value ? enabledContent : disabledContent);
   const size = INDICATOR_SIZE_MAP[context.size];
@@ -266,7 +286,7 @@ const Indicator = <T extends TgphElement = "span">({
 };
 
 export type DefaultProps<T extends TgphElement = "div"> = RootProps<T> & {
-  label?: React.ReactNode;
+  label?: ReactNode;
   labelProps?: Omit<LabelProps<"label">, "as">;
   indicator?: boolean;
   indicatorProps?: Omit<IndicatorProps<"span">, "as">;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4773,8 +4773,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #844.
- Linear: [KNO-13672](https://linear.app/knock/issue/KNO-13672).

## What changed

- Removes Toggle's Radix controllable-state and visually-hidden utility dependencies.
- Replaces them with shared `@telegraph/helpers` `useControllableState` and `VisuallyHidden`.
- Keeps the native checkbox path for labels, forms, validation, keyboard behavior, and screen readers.
- Updates README, tests, package metadata, lockfile, and changeset.

## Why

- Moves Toggle off Radix utility packages without changing public behavior.
- Reuses shared migration helpers instead of package-local compatibility code.

## Verification

- `yarn test packages/toggle/src/Toggle/Toggle.test.tsx`
- `yarn workspace @telegraph/toggle build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
