### PR TITLE
refactor(modal): migrate Modal to Base UI

### DIFF
--- a/.changeset/slow-modals-dream.md
+++ b/.changeset/slow-modals-dream.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/modal": minor
+---
+
+Migrate Modal to Base UI Dialog primitives while preserving Telegraph stacking, dismissal callbacks, autofocus callbacks, `tgphRef`, and portal styling. `trapped={false}` continues to disable focus trapping without opting out of Telegraph's modal overlay or document scroll lock behavior.

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -1,6 +1,6 @@
 # 🪟 Modal
 
-> Accessible modal dialog component with stacking support, animations, and focus management built on Radix UI.
+> Accessible modal dialog component with stacking support, animations, and focus management built on Base UI Dialog.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -31,6 +31,11 @@ import "@telegraph/modal/default.css";
 ```
 
 > Then, include `className="tgph"` on the farthest parent element wrapping the telegraph components
+
+`Modal` is implemented with Base UI Dialog primitives and Telegraph-rendered
+layout surfaces. It keeps the long-standing Telegraph API while preserving
+accessible titles/descriptions, portal style scoping, focus management, outside
+click dismissal, Escape dismissal, and stacked modal behavior.
 
 ## Quick Start
 
@@ -76,17 +81,17 @@ export const BasicModal = () => {
 
 The root modal container that manages state and provides context.
 
-| Prop                 | Type                      | Default     | Description                                |
-| -------------------- | ------------------------- | ----------- | ------------------------------------------ |
-| `open`               | `boolean`                 | `undefined` | Controlled open state                      |
-| `defaultOpen`        | `boolean`                 | `false`     | Default open state                         |
-| `onOpenChange`       | `(open: boolean) => void` | `undefined` | Callback when open state changes           |
-| `a11yTitle`          | `string`                  | required    | Accessible title for screen readers        |
-| `a11yDescription`    | `string`                  | `undefined` | Accessible description for screen readers  |
-| `trapped`            | `boolean`                 | `true`      | Whether focus should be trapped            |
-| `onMountAutoFocus`   | `(event: Event) => void`  | `undefined` | Called when modal opens and focuses        |
-| `onUnmountAutoFocus` | `(event: Event) => void`  | `undefined` | Called when modal closes and focus returns |
-| `layer`              | `number`                  | `undefined` | Layer index for stacked modals             |
+| Prop                 | Type                      | Default     | Description                                                                                      |
+| -------------------- | ------------------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `open`               | `boolean`                 | `undefined` | Controlled open state                                                                            |
+| `defaultOpen`        | `boolean`                 | `false`     | Default open state                                                                               |
+| `onOpenChange`       | `(open: boolean) => void` | `undefined` | Callback when open state changes                                                                 |
+| `a11yTitle`          | `string`                  | required    | Accessible title for screen readers                                                              |
+| `a11yDescription`    | `string`                  | `undefined` | Accessible description for screen readers                                                        |
+| `trapped`            | `boolean`                 | top layer   | Whether focus should be trapped. `false` keeps the modal overlay and document scroll lock active |
+| `onMountAutoFocus`   | `(event: Event) => void`  | `undefined` | Called when modal opens and focuses                                                              |
+| `onUnmountAutoFocus` | `(event: Event) => void`  | `undefined` | Called when modal closes and focus returns                                                       |
+| `layer`              | `number`                  | `undefined` | Layer index for stacked modals                                                                   |
 
 Inherits all Stack props for additional styling.
 
@@ -134,11 +139,11 @@ Inherits all Stack props for layout and styling.
 
 Standardized heading component for modal titles with consistent styling.
 
-| Prop     | Type                                              | Default    | Description        |
-| -------- | ------------------------------------------------- | ---------- | ------------------ |
-| `as`     | `TgphElement`                                     | `"h2"`     | HTML element type  |
-| `size`   | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| ... ` | `"3"`      | Heading size       |
-| `weight` | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight        |
+| Prop     | Type                                             | Default    | Description       |
+| -------- | ------------------------------------------------ | ---------- | ----------------- |
+| `as`     | `TgphElement`                                    | `"h2"`     | HTML element type |
+| `size`   | `"0" \| "1" \| "2" \| "3" \| "4" \| "5" \| ... ` | `"3"`      | Heading size      |
+| `weight` | `"regular" \| "medium" \| "semi-bold" \| "bold"` | `"medium"` | Font weight       |
 
 Inherits all Heading props from `@telegraph/typography` for additional styling.
 
@@ -694,6 +699,10 @@ The modal component uses Telegraph design tokens for consistent styling:
 - ✅ **Backdrop Interaction**: Click outside to close
 - ✅ **Focus Restoration**: Returns focus to trigger element
 
+When modals are stacked with `ModalStackingProvider`, only the top layer handles
+Escape and backdrop dismissal. Lower layers stay mounted visually but do not
+own the active focus trap unless `trapped` is explicitly set.
+
 ### Keyboard Shortcuts
 
 | Key               | Action                                 |
@@ -885,7 +894,12 @@ export const ImageGalleryModal = ({
     <Modal.Root open={open} onOpenChange={onClose} a11yTitle="Image Gallery">
       <Modal.Content w="screen" maxW="screen" h="screen" rounded="0" p="0">
         <Modal.Header px="6" py="4">
-          <Stack direction="row" align="center" justify="space-between" w="full">
+          <Stack
+            direction="row"
+            align="center"
+            justify="space-between"
+            w="full"
+          >
             <Modal.Heading>
               {currentImage?.title || `Image ${currentIndex + 1}`}
             </Modal.Heading>
@@ -1040,7 +1054,9 @@ export const ExportModal = ({ open, onClose, onExport }) => {
                   <input
                     type="checkbox"
                     checked={includeHeaders}
-                    onChange={(event) => setIncludeHeaders(event.target.checked)}
+                    onChange={(event) =>
+                      setIncludeHeaders(event.target.checked)
+                    }
                   />
                   Include column headers
                 </label>
@@ -1048,7 +1064,9 @@ export const ExportModal = ({ open, onClose, onExport }) => {
                   <input
                     type="checkbox"
                     checked={includeMetadata}
-                    onChange={(event) => setIncludeMetadata(event.target.checked)}
+                    onChange={(event) =>
+                      setIncludeMetadata(event.target.checked)
+                    }
                   />
                   Include metadata
                 </label>
@@ -1071,7 +1089,7 @@ export const ExportModal = ({ open, onClose, onExport }) => {
 
 ## References
 
-- [Radix UI Dialog](https://www.radix-ui.com/docs/primitives/components/dialog)
+- [Base UI Dialog](https://base-ui.com/react/components/dialog)
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/modal)
 
 ## Contributing

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,11 +29,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-dialog": "^1.1.15",
-    "@radix-ui/react-focus-scope": "^1.1.8",
-    "@radix-ui/react-portal": "^1.1.10",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
+    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/modal/src/Modal/Modal.helpers.ts
+++ b/packages/modal/src/Modal/Modal.helpers.ts
@@ -1,0 +1,18 @@
+import { type SyntheticEvent } from "react";
+
+export type BaseUIPreventableEvent = (Event | SyntheticEvent) & {
+  nativeEvent?: Event;
+  preventBaseUIHandler?: () => void;
+  stopPropagation?: () => void;
+};
+
+export const callAutoFocusHandler = (
+  handler: ((event: Event) => void) | undefined,
+  eventName: string,
+) => {
+  // Radix passed cancelable autofocus lifecycle events; synthesize the same
+  // event shape and return whether the legacy handler prevented it.
+  const event = new Event(eventName, { cancelable: true });
+  handler?.(event);
+  return event.defaultPrevented;
+};

--- a/packages/modal/src/Modal/Modal.test.tsx
+++ b/packages/modal/src/Modal/Modal.test.tsx
@@ -1,13 +1,405 @@
-import { describe, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
 
 import { Modal } from "./Modal";
+import { ModalStackingProvider } from "./ModalStacking";
 import type {
   ModalBodyProps,
   ModalFooterProps,
   ModalHeaderProps,
 } from "./index";
 
+const TestModal = ({
+  a11yTitle = "Settings",
+  open = true,
+  onOpenChange = vi.fn(),
+  onEscapeKeyDown,
+  onPointerDownOutside,
+  trapped,
+}: {
+  a11yTitle?: string;
+  onEscapeKeyDown?: (event: KeyboardEvent) => void;
+  onOpenChange?: (open: boolean) => void;
+  onPointerDownOutside?: (
+    event: MouseEvent | PointerEvent | TouchEvent,
+  ) => void;
+  open?: boolean;
+  trapped?: boolean;
+}) => {
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      a11yTitle={a11yTitle}
+      a11yDescription="Configure notification settings"
+      trapped={trapped}
+    >
+      <Modal.Content
+        onEscapeKeyDown={onEscapeKeyDown}
+        onPointerDownOutside={onPointerDownOutside}
+      >
+        <Modal.Header>
+          <Modal.Heading>{a11yTitle}</Modal.Heading>
+          <Modal.Close />
+        </Modal.Header>
+        <Modal.Body>Modal body</Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+};
+
 describe("Modal", () => {
+  it("renders an accessible dialog with hidden title and description", async () => {
+    render(<TestModal />);
+
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    expect(dialog).toHaveAccessibleDescription(
+      "Configure notification settings",
+    );
+    expect(screen.getByText("Modal body")).toBeInTheDocument();
+  });
+
+  it("opens without ref or transform-origin warnings", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      render(<TestModal />);
+
+      await screen.findByRole("dialog", { name: "Settings" });
+
+      const consoleOutput = [...errorSpy.mock.calls, ...warnSpy.mock.calls]
+        .flat()
+        .join("\n");
+
+      expect(consoleOutput).not.toMatch(
+        /Function components cannot be given refs|transformOrigin/,
+      );
+    } finally {
+      errorSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("calls onOpenChange when the close button is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestModal onOpenChange={onOpenChange} />);
+
+    await user.click(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("dedupes repeated uncontrolled open changes before rerender", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Modal.Root
+        defaultOpen
+        onOpenChange={onOpenChange}
+        a11yTitle="Settings"
+        a11yDescription="Configure notification settings"
+      >
+        <Modal.Content>
+          <Modal.Header>
+            <Modal.Heading>Settings</Modal.Heading>
+            <Modal.Close />
+          </Modal.Header>
+          <Modal.Body>Modal body</Modal.Body>
+        </Modal.Content>
+      </Modal.Root>,
+    );
+
+    await user.dblClick(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the modal open when escape dismissal is prevented", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+    render(
+      <TestModal
+        onOpenChange={onOpenChange}
+        onEscapeKeyDown={onEscapeKeyDown}
+      />,
+    );
+
+    await user.keyboard("{Escape}");
+
+    expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps document scroll locked when focus trapping is disabled", async () => {
+    const previousOverflow = document.body.style.overflow;
+
+    try {
+      render(<TestModal trapped={false} />);
+
+      await screen.findByRole("dialog", { name: "Settings" });
+
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+    } finally {
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it("keeps document scroll locked while stacked non-trapped modals remain open", async () => {
+    const user = userEvent.setup();
+    const previousOverflow = document.body.style.overflow;
+
+    const StatefulStackedNonTrappedModals = () => {
+      const [firstOpen, setFirstOpen] = useState(true);
+      const [secondOpen, setSecondOpen] = useState(true);
+
+      return (
+        <ModalStackingProvider>
+          <TestModal
+            a11yTitle="First modal"
+            open={firstOpen}
+            onOpenChange={setFirstOpen}
+            trapped={false}
+          />
+          <TestModal
+            a11yTitle="Second modal"
+            open={secondOpen}
+            onOpenChange={setSecondOpen}
+            trapped={false}
+          />
+        </ModalStackingProvider>
+      );
+    };
+
+    try {
+      render(<StatefulStackedNonTrappedModals />);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+      });
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+
+      const overlay = document.querySelector("[data-tgph-modal-overlay]");
+      expect(overlay).toBeInTheDocument();
+
+      await user.click(overlay as HTMLElement);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+      });
+      expect(document.body).toHaveStyle({ overflow: "hidden" });
+
+      await user.click(overlay as HTMLElement);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(0);
+      });
+      expect(document.body.style.overflow).toBe(previousOverflow);
+    } finally {
+      document.body.style.overflow = previousOverflow;
+    }
+  });
+
+  it("calls onOpenChange when the backdrop is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(<TestModal onOpenChange={onOpenChange} />);
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not suppress the next close after a prevented backdrop dismissal", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onPointerDownOutside = vi.fn(
+      (event: MouseEvent | PointerEvent | TouchEvent) => {
+        event.preventDefault();
+      },
+    );
+
+    render(
+      <TestModal
+        onOpenChange={onOpenChange}
+        onPointerDownOutside={onPointerDownOutside}
+      />,
+    );
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onPointerDownOutside).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Close Modal" }));
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("only closes the top layer when stacked modals receive escape", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="First modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Second modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    await user.keyboard("{Escape}");
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call escape handlers for lower stacked layers", async () => {
+    const user = userEvent.setup();
+    const onFirstEscapeKeyDown = vi.fn();
+    const onSecondEscapeKeyDown = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal
+          a11yTitle="First modal"
+          onEscapeKeyDown={onFirstEscapeKeyDown}
+        />
+        <TestModal
+          a11yTitle="Second modal"
+          onEscapeKeyDown={onSecondEscapeKeyDown}
+        />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    await user.keyboard("{Escape}");
+
+    expect(onSecondEscapeKeyDown).toHaveBeenCalledTimes(1);
+    expect(onFirstEscapeKeyDown).not.toHaveBeenCalled();
+  });
+
+  it("only closes the top layer when stacked modals receive backdrop clicks", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="First modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Second modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps modals with duplicate accessible titles as independent stack layers", async () => {
+    const user = userEvent.setup();
+    const onFirstOpenChange = vi.fn();
+    const onSecondOpenChange = vi.fn();
+
+    render(
+      <ModalStackingProvider>
+        <TestModal a11yTitle="Shared modal" onOpenChange={onFirstOpenChange} />
+        <TestModal a11yTitle="Shared modal" onOpenChange={onSecondOpenChange} />
+      </ModalStackingProvider>,
+    );
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlays = document.querySelectorAll("[data-tgph-modal-overlay]");
+    expect(overlays).toHaveLength(1);
+
+    await user.click(overlays[0] as HTMLElement);
+
+    expect(onSecondOpenChange).toHaveBeenCalledTimes(1);
+    expect(onSecondOpenChange).toHaveBeenCalledWith(false);
+    expect(onFirstOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress the next escape after a stacked backdrop dismissal", async () => {
+    const user = userEvent.setup();
+
+    const StatefulStackedModals = () => {
+      const [firstOpen, setFirstOpen] = useState(true);
+      const [secondOpen, setSecondOpen] = useState(true);
+
+      return (
+        <ModalStackingProvider>
+          <TestModal
+            a11yTitle="First modal"
+            open={firstOpen}
+            onOpenChange={setFirstOpen}
+          />
+          <TestModal
+            a11yTitle="Second modal"
+            open={secondOpen}
+            onOpenChange={setSecondOpen}
+          />
+        </ModalStackingProvider>
+      );
+    };
+
+    render(<StatefulStackedModals />);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    });
+
+    const overlay = document.querySelector("[data-tgph-modal-overlay]");
+    expect(overlay).toBeInTheDocument();
+
+    await user.click(overlay as HTMLElement);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(1);
+    });
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(0);
+    });
+  });
+
   describe("type inheritance", () => {
     it("accepts valid polymorphic props on Body", () => {
       const validProps: ModalBodyProps<"section"> = {

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -1,31 +1,128 @@
-import * as Dialog from "@radix-ui/react-dialog";
-import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
-import { FocusScope } from "@radix-ui/react-focus-scope";
-import * as Portal from "@radix-ui/react-portal";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
+import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import { Button } from "@telegraph/button";
+import { useComposedRefs } from "@telegraph/compose-refs";
 import {
+  type LegacyDismissEventHandler,
+  type LegacyDismissHandlers,
   type PolymorphicProps,
   RefToTgphRef,
   RemappedOmit,
   type TgphComponentProps,
   type TgphElement,
+  VisuallyHidden,
+  callLegacyDismissHandlers,
+  createTgphBaseUIRender,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { Heading as TelegraphHeading } from "@telegraph/typography";
 import { X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type ComponentPropsWithoutRef,
+  type Ref,
+  createContext,
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+} from "react";
 
+import {
+  type BaseUIPreventableEvent,
+  callAutoFocusHandler,
+} from "./Modal.helpers";
 import { useModalStacking } from "./ModalStacking";
 
-export type RootProps = Omit<
-  React.ComponentPropsWithoutRef<typeof Dialog.Root>,
-  "modal"
-> &
-  React.ComponentPropsWithoutRef<typeof FocusScope> &
+const BASE_UI_OUTSIDE_PRESS_DISMISS_REASON = "outside-press";
+const ROOT_OUTSIDE_DISMISS_SUPPRESSION_DELAY_MS = 100;
+
+type BaseDialogRootProps = ComponentProps<typeof BaseDialog.Root>;
+type BaseDialogPopupProps = ComponentPropsWithoutRef<typeof BaseDialog.Popup>;
+type BaseDialogCloseProps = ComponentPropsWithoutRef<typeof BaseDialog.Close>;
+
+type LegacyFocusScopeProps = {
+  loop?: boolean;
+  onMountAutoFocus?: (event: Event) => void;
+  onUnmountAutoFocus?: (event: Event) => void;
+  trapped?: boolean;
+};
+
+type ModalCompatibilityContextProps = {
+  contentCallbacksRef: {
+    current: LegacyDismissHandlers;
+  };
+  requestPointerDismiss: (event: BaseUIPreventableEvent) => void;
+  rootFocusCallbacksRef: {
+    current: Pick<
+      LegacyFocusScopeProps,
+      "onMountAutoFocus" | "onUnmountAutoFocus"
+    >;
+  };
+};
+
+type RootDialogProps = {
+  children?: BaseDialogRootProps["children"];
+  defaultOpen?: BaseDialogRootProps["defaultOpen"];
+  open?: BaseDialogRootProps["open"];
+  onOpenChange?: (open: boolean) => void;
+};
+
+const ModalCompatibilityContext =
+  createContext<ModalCompatibilityContextProps | null>(null);
+
+const bodyScrollLockLayers = new Set<string>();
+let bodyScrollLockPreviousOverflow: string | undefined;
+
+const lockBodyScroll = (layerId: string) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  if (bodyScrollLockLayers.size === 0) {
+    bodyScrollLockPreviousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  }
+
+  bodyScrollLockLayers.add(layerId);
+};
+
+const unlockBodyScroll = (layerId: string) => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  bodyScrollLockLayers.delete(layerId);
+
+  if (bodyScrollLockLayers.size === 0) {
+    document.body.style.overflow = bodyScrollLockPreviousOverflow ?? "";
+    bodyScrollLockPreviousOverflow = undefined;
+  }
+};
+
+const useBodyScrollLock = (layerId: string, enabled: boolean) => {
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    // Multiple non-trapped stacked dialogs can need the fallback lock at once.
+    // Keep the body locked until the last owning layer releases it.
+    lockBodyScroll(layerId);
+
+    return () => {
+      unlockBodyScroll(layerId);
+    };
+  }, [enabled, layerId]);
+};
+
+export type RootProps = RootDialogProps &
+  LegacyFocusScopeProps &
   TgphComponentProps<typeof Stack> & {
     a11yTitle: string;
     a11yDescription?: string;
@@ -45,162 +142,356 @@ const Root = ({
   });
 
   const stacking = useModalStacking();
-  const id = props.a11yTitle;
+  const stackId = useId();
 
-  React.useEffect(() => {
-    if (!open && stacking.layers.includes(id)) {
-      stacking.removeLayer(id);
+  useEffect(() => {
+    if (!open && stacking.layers.includes(stackId)) {
+      stacking.removeLayer(stackId);
     }
-  }, [id, stacking, open]);
+  }, [stackId, stacking, open]);
 
   // Prevent rendering anything within the modal if it is not open
   if (!open) return;
 
-  return <RootComponent open={open} onOpenChange={onOpenChange} {...props} />;
+  return (
+    <RootComponent
+      open={open}
+      onOpenChange={onOpenChange}
+      stackId={stackId}
+      {...props}
+    />
+  );
 };
 
 type RootComponentProps = RootProps & {
   open: boolean;
   onOpenChange: (value: boolean) => void;
+  stackId: string;
 };
 
 const RootComponent = ({
   open,
   onOpenChange,
+  stackId,
   a11yTitle,
   a11yDescription,
   children,
-  // Focus scope props
+  // The previous Radix implementation accepted `loop` through FocusScope
+  // types but did not wire it through. Keep consuming it as a no-op
+  // compatibility prop so existing callers do not leak it to the DOM.
+  loop: _loop,
   trapped,
   onMountAutoFocus,
   onUnmountAutoFocus,
   ...props
 }: RootComponentProps) => {
-  // We use the a11yTitle as the id for the modal as it is unique
-  // and can be used to identify the modal in the stacking context.
-  // Without the need to generate a random id and manage between
-  // different modal rendering patterns.
-  const id = a11yTitle;
+  const layerId = stackId;
   const stacking = useModalStacking();
-  React.useEffect(() => {
-    if (!stacking || !open || stacking.layers.includes(id)) return;
-    stacking.addLayer(id);
-  }, [id, stacking, open]);
+  const contentCallbacksRef = useRef<LegacyDismissHandlers>({});
+  // Shared backdrop clicks can be translated into a manual stack close. Keep
+  // this scoped to Base UI outside-press reports so it cannot cancel the next
+  // unrelated Escape or close-button request.
+  const suppressNextRootOutsideDismissRef = useRef(false);
+  const rootFocusCallbacksRef = useRef<
+    ModalCompatibilityContextProps["rootFocusCallbacksRef"]["current"]
+  >({});
 
-  const layer = stacking.layers?.indexOf(id) || 0;
+  // Keep the latest Root-level autofocus callbacks available to Content, where
+  // Base UI actually asks for initial/final focus decisions.
+  rootFocusCallbacksRef.current = {
+    onMountAutoFocus,
+    onUnmountAutoFocus,
+  };
+
+  useLayoutEffect(() => {
+    if (!stacking || !open || stacking.layers.includes(layerId)) return;
+    stacking.addLayer(layerId);
+  }, [layerId, stacking, open]);
+
+  const layerIndex = stacking.layers.indexOf(layerId);
+  const layer = layerIndex === -1 ? 0 : layerIndex;
   const layersLength = stacking.layers?.length || 0;
   const isStacked = layer !== 0;
-  const isTopLayer = id === stacking.layers[stacking.layers.length - 1];
+  const isTopLayer =
+    layersLength === 0 ||
+    layerId === stacking.layers[stacking.layers.length - 1];
+  const trappedFocus = typeof trapped === "boolean" ? trapped : isTopLayer;
+  const shouldLockScroll = open && trapped === false;
+
+  useBodyScrollLock(layerId, shouldLockScroll);
+
+  const requestClose = useCallback(() => {
+    const hasLayers = stacking?.layers?.length > 0;
+
+    if (hasLayers) {
+      if (layerId !== stacking.layers[stacking.layers.length - 1]) {
+        // Non-top layers stay open when a shared backdrop event reaches them.
+        return false;
+      }
+
+      // The modal stack owns layer bookkeeping; only then do we mirror the
+      // close through Telegraph's public open state.
+      stacking.removeLayer(layerId);
+      onOpenChange(false);
+      return true;
+    }
+
+    onOpenChange(false);
+    return true;
+  }, [layerId, onOpenChange, stacking]);
+  const suppressNextRootOutsideDismiss = useCallback(() => {
+    suppressNextRootOutsideDismissRef.current = true;
+
+    globalThis.setTimeout(() => {
+      suppressNextRootOutsideDismissRef.current = false;
+    }, ROOT_OUTSIDE_DISMISS_SUPPRESSION_DELAY_MS);
+  }, []);
+  const closeFromPointerDismiss = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      const nativeEvent = (event.nativeEvent ?? event) as Event;
+      const legacyDismissPrevented = callLegacyDismissHandlers(
+        {
+          event: nativeEvent,
+          reason: BASE_UI_OUTSIDE_PRESS_DISMISS_REASON,
+        },
+        contentCallbacksRef.current,
+      );
+
+      if (legacyDismissPrevented || event.defaultPrevented) {
+        // Preserve Radix's cancelable outside-interaction callbacks and stop
+        // Base UI from closing after legacy code has prevented dismissal.
+        suppressNextRootOutsideDismiss();
+        event.preventDefault();
+        event.stopPropagation?.();
+        event.preventBaseUIHandler?.();
+        return false;
+      }
+
+      // We handle pointer dismissal through Telegraph's stack so only the top
+      // modal closes and lower layers do not each process the same event.
+      event.preventDefault();
+      event.stopPropagation?.();
+      event.preventBaseUIHandler?.();
+      const didRequestClose = requestClose();
+
+      if (didRequestClose) {
+        suppressNextRootOutsideDismiss();
+      }
+
+      return didRequestClose;
+    },
+    [requestClose, suppressNextRootOutsideDismiss],
+  );
+  const requestPointerDismiss = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      const nativeEvent = (event.nativeEvent ?? event) as Event;
+
+      const hasLayers = stacking?.layers?.length > 0;
+
+      // Base UI sees each dialog independently. Telegraph's stacked modal
+      // backdrop is shared, so backdrop clicks need to close only the top layer.
+      if (
+        hasLayers &&
+        layerId !== stacking.layers[stacking.layers.length - 1]
+      ) {
+        // A backdrop click can originate over a lower layer. Suppress every
+        // non-top layer, then ask the stack to dismiss only the top layer.
+        stacking.layers
+          .filter(
+            (currentLayerId) =>
+              currentLayerId !== stacking.layers[stacking.layers.length - 1],
+          )
+          .forEach((currentLayerId) => {
+            stacking.suppressNextDismissForLayer(currentLayerId);
+          });
+        stacking.ignorePointerDismissEvent(nativeEvent);
+        stacking.dismissTopLayerWithPointer(nativeEvent);
+        suppressNextRootOutsideDismiss();
+        event.preventDefault();
+        event.stopPropagation?.();
+        event.preventBaseUIHandler?.();
+        return;
+      }
+
+      closeFromPointerDismiss(event);
+    },
+    [
+      closeFromPointerDismiss,
+      layerId,
+      stacking,
+      suppressNextRootOutsideDismiss,
+    ],
+  );
+
+  const handleOpenChange = useCallback<
+    NonNullable<BaseDialogRootProps["onOpenChange"]>
+  >(
+    (value, eventDetails) => {
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        suppressNextRootOutsideDismissRef.current
+      ) {
+        // requestPointerDismiss already handled this outside press.
+        suppressNextRootOutsideDismissRef.current = false;
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        stacking.consumeSuppressedDismiss(layerId)
+      ) {
+        // Lower layers marked by the shared backdrop path should not react to
+        // the same outside-press details from Base UI.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        eventDetails.reason === BASE_UI_OUTSIDE_PRESS_DISMISS_REASON &&
+        stacking.shouldIgnorePointerDismissEvent(eventDetails.event)
+      ) {
+        // The stack has already consumed this pointer event while dismissing the
+        // top layer, so ignore duplicate root notifications.
+        eventDetails.cancel();
+        return;
+      }
+
+      const hasLayers = stacking?.layers?.length > 0;
+
+      if (
+        !value &&
+        hasLayers &&
+        layerId !== stacking.layers[stacking.layers.length - 1]
+      ) {
+        // Lower stacked layers are inert; cancel before running consumer
+        // dismissal callbacks so only the active top layer sees Escape.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (
+        !value &&
+        callLegacyDismissHandlers(eventDetails, contentCallbacksRef.current)
+      ) {
+        // Content-level legacy dismissal handlers still get final say on close.
+        eventDetails.cancel();
+        return;
+      }
+
+      if (hasLayers) {
+        if (
+          value === false &&
+          layerId === stacking.layers[stacking.layers.length - 1]
+        ) {
+          stacking.removeLayer(layerId);
+          onOpenChange(false);
+          return;
+        }
+
+        if (value === false) {
+          // A lower stacked layer should remain open if Base UI asks it to close
+          // while a higher layer is still present.
+          eventDetails.cancel();
+        }
+
+        return;
+      }
+
+      onOpenChange(value);
+    },
+    [layerId, onOpenChange, stacking],
+  );
+
+  useEffect(() => {
+    return stacking.registerPointerDismissHandler(
+      layerId,
+      closeFromPointerDismiss,
+    );
+  }, [closeFromPointerDismiss, layerId, stacking]);
 
   return (
     <LazyMotion features={domAnimation}>
-      <DismissableLayer
-        onEscapeKeyDown={(event) => {
-          if (!isTopLayer) return;
-          event.preventDefault();
-          stacking.removeTopLayer();
-          onOpenChange(false);
-        }}
-        onPointerDownOutside={(event) => {
-          if (!isTopLayer) return;
-          event.preventDefault();
-          stacking.removeTopLayer();
-          onOpenChange(false);
+      <ModalCompatibilityContext.Provider
+        value={{
+          contentCallbacksRef,
+          requestPointerDismiss,
+          rootFocusCallbacksRef,
         }}
       >
-        <Dialog.Root
+        <BaseDialog.Root
           open={open}
-          onOpenChange={(value) => {
-            const hasLayers = stacking?.layers?.length > 0;
-
-            if (hasLayers) {
-              if (
-                value === false &&
-                id === stacking.layers[stacking.layers.length - 1]
-              ) {
-                stacking.removeLayer(id);
-                return onOpenChange(false);
-              }
-              // If the modal is not the top layer, do not call onOpenChange
-              // when we are stacking the modals
-              return;
-            }
-
-            onOpenChange(value);
-          }}
-          key={id}
+          onOpenChange={handleOpenChange}
+          modal={trappedFocus}
+          disablePointerDismissal={!isTopLayer}
+          key={layerId}
         >
-          <VisuallyHidden.Root>
-            <Dialog.Title>{a11yTitle}</Dialog.Title>
+          <VisuallyHidden>
+            <BaseDialog.Title>{a11yTitle}</BaseDialog.Title>
             {a11yDescription && (
-              <Dialog.Description>{a11yDescription}</Dialog.Description>
+              <BaseDialog.Description>{a11yDescription}</BaseDialog.Description>
             )}
-          </VisuallyHidden.Root>
+          </VisuallyHidden>
           {open && (
             // We add the className "tgph" here so that styles within
             // the portal get scoped properly to telegraph
-            <Portal.Root className="tgph">
+            <BaseDialog.Portal className="tgph">
               <Overlay layer={layer}>
-                <FocusScope
-                  trapped={typeof trapped === "boolean" ? trapped : isTopLayer}
-                  onMountAutoFocus={onMountAutoFocus}
-                  onUnmountAutoFocus={onUnmountAutoFocus}
-                  asChild
-                >
-                  <RefToTgphRef>
+                <RefToTgphRef>
+                  <Stack
+                    as={motion.div}
+                    initial={{
+                      top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layersLength - 1})`,
+                    }}
+                    animate={{
+                      top: isStacked
+                        ? `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer} )`
+                        : "var(--tgph-spacing-16)",
+                    }}
+                    exit={{ top: 0 }}
+                    transition={{ type: "spring", duration: 0.3, bounce: 0 }}
+                    w="full"
+                    justify="center"
+                    style={{
+                      position: "fixed",
+                      left: 0,
+                      maxHeight: "calc(100vh - var(--tgph-spacing-32))",
+                      maxWidth: "calc(100vw - var(--tgph-spacing-8))",
+                      zIndex: `calc(var(--tgph-zIndex-modal) + ${layer})`,
+                    }}
+                    key={`container-${layerId}`}
+                  >
                     <Stack
                       as={motion.div}
-                      initial={{
-                        top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layersLength - 1})`,
-                      }}
+                      direction="column"
                       animate={{
-                        top: isStacked
-                          ? `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer} )`
-                          : "var(--tgph-spacing-16)",
+                        scale: 1.02 - Math.abs(layersLength - layer) * 0.02,
                       }}
-                      exit={{ top: 0 }}
-                      transition={{ type: "spring", duration: 0.3, bounce: 0 }}
-                      w="full"
-                      justify="center"
-                      style={{
-                        position: "fixed",
-                        left: 0,
-                        maxHeight: "calc(100vh - var(--tgph-spacing-32))",
-                        maxWidth: "calc(100vw - var(--tgph-spacing-8))",
-                        zIndex: `calc(var(--tgph-zIndex-modal) + ${layer})`,
+                      transition={{
+                        duration: 0.2,
+                        bounce: 0,
+                        type: "spring",
                       }}
-                      key={`container-${id}`}
+                      maxW={props.maxW ?? "160"}
+                      w={props.w ?? "full"}
+                      bg="surface-1"
+                      rounded="4"
+                      shadow="3"
+                      key={`content-${layerId}`}
+                      {...props}
                     >
-                      <Stack
-                        direction="column"
-                        as={motion.div}
-                        animate={{
-                          scale: 1.02 - Math.abs(layersLength - layer) * 0.02,
-                          transformOrigin: "center center",
-                        }}
-                        transition={{
-                          duration: 0.2,
-                          bounce: 0,
-                          type: "spring",
-                        }}
-                        maxW={props.maxW ?? "160"}
-                        w={props.w ?? "full"}
-                        bg="surface-1"
-                        rounded="4"
-                        shadow="3"
-                        key={`content-${id}`}
-                        {...props}
-                      >
-                        {children}
-                      </Stack>
+                      {children}
                     </Stack>
-                  </RefToTgphRef>
-                </FocusScope>
+                  </Stack>
+                </RefToTgphRef>
               </Overlay>
-            </Portal.Root>
+            </BaseDialog.Portal>
           )}
-        </Dialog.Root>
-      </DismissableLayer>
+        </BaseDialog.Root>
+      </ModalCompatibilityContext.Provider>
     </LazyMotion>
   );
 };
@@ -210,46 +501,154 @@ export type OverlayProps = TgphComponentProps<typeof Box> & {
 };
 
 const Overlay = ({ layer, children }: OverlayProps) => {
+  const compatibilityContext = useContext(ModalCompatibilityContext);
+
   // If the layer is greater than 0, we don't want to show this
   // overlay as to not stack the overlays on top of each other.
   if (layer > 0) return children;
+
   return (
-    <Dialog.Overlay>
-      <Box
-        as={motion.div}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3, bounce: 0, type: "spring" }}
-        bg="alpha-black-6"
-        w="full"
-        h="full"
-        zIndex="overlay"
-        style={{
-          position: "fixed",
-          cursor: "pointer",
-          inset: "0px",
-        }}
+    <>
+      <BaseDialog.Backdrop
+        render={createTgphBaseUIRender(
+          <Box
+            as={motion.div}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3, bounce: 0, type: "spring" }}
+            bg="alpha-black-6"
+            w="full"
+            h="full"
+            zIndex="overlay"
+            data-tgph-modal-overlay
+            onPointerDownCapture={(event) => {
+              compatibilityContext?.requestPointerDismiss(event);
+            }}
+            style={{
+              position: "fixed",
+              cursor: "pointer",
+              inset: "0px",
+            }}
+          />,
+        )}
       />
       {children}
-    </Dialog.Overlay>
+    </>
   );
 };
 
-export type ContentProps = React.ComponentPropsWithoutRef<
-  typeof Dialog.Content
+export type ContentProps = Partial<
+  Omit<
+    BaseDialogPopupProps,
+    | "children"
+    | "className"
+    | "finalFocus"
+    | "initialFocus"
+    | "render"
+    | "style"
+  >
 > &
-  TgphComponentProps<typeof Stack>;
-type ContentRef = React.ElementRef<typeof Dialog.Content>;
+  LegacyDismissHandlers & {
+    onCloseAutoFocus?: LegacyDismissEventHandler;
+    onOpenAutoFocus?: LegacyDismissEventHandler;
+  } & TgphComponentProps<typeof Stack>;
+type ContentRef = HTMLDivElement;
 
-const Content = React.forwardRef<ContentRef, ContentProps>(
-  ({ children, ...props }, forwardedRef) => {
+type ModalContentStackProps = TgphComponentProps<typeof Stack> & {
+  tgphRef?: Ref<ContentRef>;
+};
+
+const ModalContentStack = forwardRef<ContentRef, ModalContentStackProps>(
+  ({ tgphRef, ...props }, forwardedRef) => {
+    const composedRef = useComposedRefs(forwardedRef, tgphRef);
+
+    return <Stack tgphRef={composedRef} {...props} />;
+  },
+);
+
+ModalContentStack.displayName = "ModalContentStack";
+
+const Content = forwardRef<ContentRef, ContentProps>(
+  (
+    {
+      children,
+      onCloseAutoFocus,
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onOpenAutoFocus,
+      onPointerDownOutside,
+      ...props
+    },
+    forwardedRef,
+  ) => {
+    const compatibilityContext = useContext(ModalCompatibilityContext);
+    const resolvedInitialFocus = useCallback(() => {
+      // Combine Root and Content autofocus callbacks before converting their
+      // Radix-style preventDefault result into Base UI's boolean focus API.
+      const rootFocusPrevented = callAutoFocusHandler(
+        compatibilityContext?.rootFocusCallbacksRef.current.onMountAutoFocus,
+        "mountAutoFocus",
+      );
+      const contentFocusPrevented = callAutoFocusHandler(
+        onOpenAutoFocus,
+        "openAutoFocus",
+      );
+
+      return rootFocusPrevented || contentFocusPrevented ? false : true;
+    }, [compatibilityContext, onOpenAutoFocus]);
+    const resolvedFinalFocus = useCallback(() => {
+      // Close autofocus follows the same Radix preventDefault contract as open
+      // autofocus, but maps to Base UI's finalFocus callback.
+      const rootFocusPrevented = callAutoFocusHandler(
+        compatibilityContext?.rootFocusCallbacksRef.current.onUnmountAutoFocus,
+        "unmountAutoFocus",
+      );
+      const contentFocusPrevented = callAutoFocusHandler(
+        onCloseAutoFocus,
+        "closeAutoFocus",
+      );
+
+      return rootFocusPrevented || contentFocusPrevented ? false : true;
+    }, [compatibilityContext, onCloseAutoFocus]);
+
+    useEffect(() => {
+      if (!compatibilityContext) {
+        return;
+      }
+
+      // Store the latest content dismiss callbacks where Root can consult them
+      // from Base UI's single onOpenChange details callback.
+      compatibilityContext.contentCallbacksRef.current = {
+        onEscapeKeyDown,
+        onFocusOutside,
+        onInteractOutside,
+        onPointerDownOutside,
+      };
+
+      return () => {
+        compatibilityContext.contentCallbacksRef.current = {};
+      };
+    }, [
+      compatibilityContext,
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onPointerDownOutside,
+    ]);
+
     return (
-      <Dialog.Content ref={forwardedRef} asChild {...props}>
-        <Stack direction="column" h="full" {...props}>
-          {children}
-        </Stack>
-      </Dialog.Content>
+      <BaseDialog.Popup
+        ref={forwardedRef}
+        initialFocus={resolvedInitialFocus}
+        finalFocus={resolvedFinalFocus}
+        render={createTgphBaseUIRender(
+          <ModalContentStack direction="column" h="full" {...props}>
+            {children}
+          </ModalContentStack>,
+        )}
+      />
     );
   },
 );
@@ -257,21 +656,41 @@ const Content = React.forwardRef<ContentRef, ContentProps>(
 export type CloseProps<T extends TgphElement = "button"> = TgphComponentProps<
   typeof Button<T>
 > &
-  Omit<React.ComponentPropsWithoutRef<typeof Dialog.Close>, "color">;
+  Omit<BaseDialogCloseProps, "children" | "color" | "render">;
 const Close = <T extends TgphElement = "button">({
+  disabled,
+  onClick,
   size = "1",
   variant = "ghost",
   ...props
 }: CloseProps<T>) => {
+  const handleClick = useCallback(
+    (event: BaseUIPreventableEvent) => {
+      onClick?.(event);
+
+      if (event.defaultPrevented) {
+        // Prevented custom close clicks should also opt out of Base UI's close
+        // handler, matching Radix Close asChild behavior.
+        event.preventBaseUIHandler?.();
+      }
+    },
+    [onClick],
+  );
+
   return (
-    <Dialog.Close asChild>
-      <Button
-        icon={{ icon: X, alt: "Close Modal" }}
-        variant={variant}
-        size={size}
-        {...props}
-      />
-    </Dialog.Close>
+    <BaseDialog.Close
+      disabled={disabled}
+      render={createTgphBaseUIRender(
+        <Button
+          disabled={disabled}
+          icon={{ icon: X, alt: "Close Modal" }}
+          onClick={handleClick}
+          variant={variant}
+          size={size}
+          {...props}
+        />,
+      )}
+    />
   );
 };
 
@@ -357,14 +776,14 @@ const Heading = <T extends TgphElement = "h2">({
   weight = "medium",
   ...props
 }: HeadingProps<T>) => {
-  return (
-    <TelegraphHeading
-      as={(as || "h2") as T}
-      size={size}
-      weight={weight}
-      {...props}
-    />
-  );
+  const headingProps = {
+    as: (as || "h2") as T,
+    size,
+    weight,
+    ...props,
+  } as TgphComponentProps<typeof TelegraphHeading<T>>;
+
+  return <TelegraphHeading {...headingProps} />;
 };
 
 const Modal = {} as {

--- a/packages/modal/src/Modal/ModalStacking.tsx
+++ b/packages/modal/src/Modal/ModalStacking.tsx
@@ -1,43 +1,152 @@
-import React from "react";
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
-const ModalStackingContext = React.createContext<{
+type PointerDismissHandler = (event: Event) => void;
+
+const SUPPRESSED_POINTER_DISMISS_RESET_DELAY_MS = 100;
+
+const ModalStackingContext = createContext<{
+  dismissTopLayerWithPointer: (event: Event) => void;
+  ignorePointerDismissEvent: (event: Event) => void;
   layers: Array<string>;
-  setLayers: React.Dispatch<React.SetStateAction<Array<string>>>;
+  setLayers: Dispatch<SetStateAction<Array<string>>>;
   addLayer: (id: string) => void;
+  consumeSuppressedDismiss: (id: string) => boolean;
+  registerPointerDismissHandler: (
+    id: string,
+    handler: PointerDismissHandler,
+  ) => () => void;
   removeLayer: (id: string) => void;
   removeTopLayer: () => void;
+  shouldIgnorePointerDismissEvent: (event: Event) => boolean;
+  suppressNextDismissForLayer: (id: string) => void;
 }>({
+  dismissTopLayerWithPointer: () => {},
+  ignorePointerDismissEvent: () => {},
   layers: [],
   setLayers: () => {},
   addLayer: () => {},
+  consumeSuppressedDismiss: () => false,
+  registerPointerDismissHandler: () => () => {},
   removeLayer: () => {},
   removeTopLayer: () => {},
+  shouldIgnorePointerDismissEvent: () => false,
+  suppressNextDismissForLayer: () => {},
 });
 
 type ModalStackingProviderProps = {
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 const ModalStackingProvider = ({ children }: ModalStackingProviderProps) => {
-  const [layers, setLayers] = React.useState<Array<string>>([]);
+  const [layers, setLayers] = useState<Array<string>>([]);
+  const layersRef = useRef<Array<string>>([]);
+  const ignoredPointerDismissEventsRef = useRef(new WeakSet<Event>());
+  const pointerDismissHandlersRef = useRef(
+    new Map<string, PointerDismissHandler>(),
+  );
+  const suppressedDismissLayersRef = useRef(new Set<string>());
+
+  useEffect(() => {
+    layersRef.current = layers;
+  }, [layers]);
 
   const addLayer = (id: string) => {
-    setLayers((current) => [...current, id]);
+    setLayers((current) => {
+      const nextLayers = current.includes(id) ? current : [...current, id];
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
 
   const removeLayer = (id: string) => {
-    setLayers(layers.filter((layer) => layer !== id));
+    setLayers((current) => {
+      const nextLayers = current.filter((layer) => layer !== id);
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
 
   const removeTopLayer = () => {
-    const id = layers[layers.length - 1];
-    if (!id) return;
-    removeLayer(id);
+    setLayers((current) => {
+      const nextLayers = current.slice(0, -1);
+      layersRef.current = nextLayers;
+
+      return nextLayers;
+    });
   };
+
+  const registerPointerDismissHandler = useCallback(
+    (id: string, handler: PointerDismissHandler) => {
+      pointerDismissHandlersRef.current.set(id, handler);
+
+      return () => {
+        if (pointerDismissHandlersRef.current.get(id) === handler) {
+          pointerDismissHandlersRef.current.delete(id);
+        }
+      };
+    },
+    [],
+  );
+
+  const dismissTopLayerWithPointer = useCallback((event: Event) => {
+    const topLayer = layersRef.current[layersRef.current.length - 1];
+
+    if (!topLayer) {
+      return;
+    }
+
+    pointerDismissHandlersRef.current.get(topLayer)?.(event);
+  }, []);
+  const ignorePointerDismissEvent = useCallback((event: Event) => {
+    ignoredPointerDismissEventsRef.current.add(event);
+  }, []);
+  const shouldIgnorePointerDismissEvent = useCallback((event: Event) => {
+    return ignoredPointerDismissEventsRef.current.has(event);
+  }, []);
+  const suppressNextDismissForLayer = useCallback((id: string) => {
+    suppressedDismissLayersRef.current.add(id);
+
+    globalThis.setTimeout(() => {
+      suppressedDismissLayersRef.current.delete(id);
+    }, SUPPRESSED_POINTER_DISMISS_RESET_DELAY_MS);
+  }, []);
+  const consumeSuppressedDismiss = useCallback((id: string) => {
+    const isSuppressed = suppressedDismissLayersRef.current.has(id);
+
+    if (isSuppressed) {
+      suppressedDismissLayersRef.current.delete(id);
+    }
+
+    return isSuppressed;
+  }, []);
 
   return (
     <ModalStackingContext.Provider
-      value={{ layers, setLayers, addLayer, removeLayer, removeTopLayer }}
+      value={{
+        dismissTopLayerWithPointer,
+        ignorePointerDismissEvent,
+        layers,
+        setLayers,
+        addLayer,
+        consumeSuppressedDismiss,
+        registerPointerDismissHandler,
+        removeLayer,
+        removeTopLayer,
+        shouldIgnorePointerDismissEvent,
+        suppressNextDismissForLayer,
+      }}
     >
       {children}
     </ModalStackingContext.Provider>
@@ -45,7 +154,7 @@ const ModalStackingProvider = ({ children }: ModalStackingProviderProps) => {
 };
 
 const useModalStacking = () => {
-  return React.useContext(ModalStackingContext);
+  return useContext(ModalStackingContext);
 };
 
 export { ModalStackingProvider, useModalStacking };

--- a/packages/modal/vitest.config.mts
+++ b/packages/modal/vitest.config.mts
@@ -1,0 +1,13 @@
+import { defineProject, mergeConfig } from "vitest/config";
+
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "modal",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,38 +3148,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dialog@npm:^1.1.15":
-  version: 1.1.15
-  resolution: "@radix-ui/react-dialog@npm:1.1.15"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/2f2c88e3c281acaea2fd9b96fa82132d59177d3aa5da2e7c045596fd4028e84e44ac52ac28f4f236910605dd7d9338c2858ba44a9ced2af2e3e523abbfd33014
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-direction@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-direction@npm:1.1.1"
@@ -3247,27 +3215,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:^1.1.8":
-  version: 1.1.8
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.8"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.4"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/ce316ffa868ca618a581e0154ca3385c2726d73632a9b32f2fa61d8fa611c1331685b1de44de3605822785bc3e79a612399177e0e78b4923bf35b0203f5b3167
   languageName: node
   linkType: hard
 
@@ -4461,14 +4408,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@telegraph/modal@workspace:packages/modal"
   dependencies:
+    "@base-ui/react": "npm:^1.5.0"
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-dialog": "npm:^1.1.15"
-    "@radix-ui/react-focus-scope": "npm:^1.1.8"
-    "@radix-ui/react-portal": "npm:^1.1.10"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
+    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #845.
- Linear: [KNO-13673](https://linear.app/knock/issue/KNO-13673).

## What changed

- Migrates `@telegraph/modal` from Radix Dialog, FocusScope, Portal, and VisuallyHidden to Base UI Dialog primitives.
- Reuses shared dismiss helpers while keeping Modal-specific autofocus and stacked-layer behavior local.
- Uses an internal stable stack id for modal layering so duplicate `a11yTitle` values remain independent stack layers.
- Shares body scroll locking across stacked non-trapped modals so closing one layer does not unlock scrolling while another remains open.
- Lets Base UI own close-button dismissal unless a consumer prevents default.
- Scopes duplicate backdrop-dismiss suppression to the next Base UI outside-press report only, so a prevented backdrop dismiss cannot cancel the next close-button or Escape close.
- Updates README, tests, dependencies, lockfile, and changeset.

## Why

- Removes Modal's Radix dependencies while preserving focus, dismissal, portal, stacked modal, body scroll lock, and `tgphRef` behavior.
- Keeps `a11yTitle` as the accessible label instead of treating it as a unique instance key.
- Keeps custom code only where Telegraph's stacked overlay semantics require it.
- Closes the Cursor review finding where a prevented backdrop dismiss could leave stale suppression behind for the next close.

## Verification

- `yarn test packages/modal/src/Modal/Modal.test.tsx`
- `yarn workspace @telegraph/modal lint`
- `yarn workspace @telegraph/modal build`
- `yarn prettier --check packages/modal/src/Modal/Modal.tsx packages/modal/src/Modal/Modal.test.tsx`
- Stack-wide: `yarn build:packages`
- Stack-wide: `yarn lint`
