### PR TITLE
refactor(combobox): migrate Combobox to Base UI

### DIFF
--- a/.changeset/curvy-comboboxes-grin.md
+++ b/.changeset/curvy-comboboxes-grin.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": minor
+---
+
+Migrate Combobox off direct Radix runtime dependencies while preserving Telegraph menu layering, focus restoration, CSS compatibility variables, legacy option objects, and controlled/uncontrolled value behavior. Adds Base UI-backed dismissal handling, including `onEscapeKeyDown`, and documents that stay-open multi-select keeps focus on the selected option.

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -59,6 +59,21 @@ export const SingleSelectExample = () => {
 
 ## API Reference
 
+## Implementation Notes
+
+Combobox keeps the existing Telegraph compound API while using the Base UI-backed
+Telegraph Menu primitives for popup positioning, portal rendering, dismissal,
+and focus restoration. The package no longer depends on Radix directly.
+
+The public value contracts remain unchanged: string values are the recommended
+mode, `legacyBehavior` still supports `{ value, label }` objects for backwards
+compatibility, and single- vs multi-select behavior is still inferred from the
+shape of `value` / `defaultValue`.
+
+When `closeOnSelect={false}`, the dropdown stays open after selection and focus
+remains on the selected option so keyboard users can continue through the list
+without returning to the trigger first.
+
 ### `<Combobox.Root>`
 
 The root component that manages the state and context for the combobox.
@@ -83,11 +98,11 @@ The root component that manages the state and context for the combobox.
 
 The button that triggers the combobox dropdown.
 
-| Prop          | Type                | Default     | Description            |
-| ------------- | ------------------- | ----------- | ---------------------- |
-| `size`        | `"0" \| "1" \| "2" \| "3"` | `"1"` | Size of the trigger    |
-| `placeholder` | `string`            | `undefined` | Placeholder text       |
-| `children`    | `ReactNode`         | `undefined` | Custom trigger content |
+| Prop          | Type                       | Default     | Description            |
+| ------------- | -------------------------- | ----------- | ---------------------- |
+| `size`        | `"0" \| "1" \| "2" \| "3"` | `"1"`       | Size of the trigger    |
+| `placeholder` | `string`                   | `undefined` | Placeholder text       |
+| `children`    | `ReactNode`                | `undefined` | Custom trigger content |
 
 ### Other Components
 
@@ -325,9 +340,9 @@ export const CustomTrigger = () => (
 
 Individual selectable option item.
 
-| Prop       | Type      | Default     | Description          |
-| ---------- | --------- | ----------- | -------------------- |
-| `value`    | `string`  | required    | Option value         |
+| Prop       | Type                  | Default     | Description          |
+| ---------- | --------------------- | ----------- | -------------------- |
+| `value`    | `string`              | required    | Option value         |
 | `label`    | `string \| ReactNode` | `undefined` | Display label        |
 | `selected` | `boolean \| null`     | `undefined` | Force selected state |
 
@@ -410,6 +425,7 @@ const [value, setValue] = useState<{ value: string; label?: string }>();
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/combobox)
+- [Base UI Menu](https://base-ui.com/react/components/menu/)
 - [ARIA Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
 
 ## Contributing

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -32,11 +32,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@radix-ui/react-dismissable-layer": "^1.1.11",
-    "@radix-ui/react-menu": "^2.1.16",
-    "@radix-ui/react-portal": "^1.1.10",
-    "@radix-ui/react-use-controllable-state": "^1.2.2",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@telegraph/button": "workspace:^",
     "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -2,6 +2,10 @@ import React from "react";
 
 import type { DefinedOption, Option } from "./Combobox.types";
 
+export const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
+export const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
+export const SELECT_KEYS = ["Enter", " "];
+
 export const isMultiSelect = (
   value: Option | Array<Option> | undefined,
 ): value is Array<Option> => {
@@ -23,16 +27,18 @@ export const getOptions = (children: React.ReactNode): Array<DefinedOption> => {
     children: React.ReactNode,
     options: Array<React.ReactNode> = [],
   ) => {
+    // Options can be wrapped in grouping/layout components, so walk the child
+    // tree instead of assuming direct Combobox.Option children.
     const childrenArray = React.Children.toArray(children);
 
     childrenArray.forEach((child) => {
       if (React.isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
         if (childProps.value) {
-          // If it has a value prop, it's an option
+          // Combobox.Option is identified by its public value prop.
           options.push(child);
         } else if (childProps.children) {
-          // If it has children, recursively search them
+          // Non-option wrappers may still contain options further down.
           recursivelyFindOptionElements(
             childProps.children as React.ReactNode,
             options,
@@ -69,10 +75,29 @@ export const getValueFromOption = (
   if (!option) return undefined;
 
   if (legacyBehavior === true) {
+    // Legacy callers store selected values as { value, label } objects.
     return (option as DefinedOption)?.value;
   }
 
+  // Newer callers store the selected value directly as a string.
   return option as string;
+};
+
+export const getOptionAccessibleLabel = (option?: DefinedOption) => {
+  if (!option) {
+    return undefined;
+  }
+
+  if (typeof option.label === "string" && option.label !== "") {
+    return option.label;
+  }
+
+  if (typeof option.label === "number" || typeof option.label === "bigint") {
+    // aria-label needs text; React labels fall back to value below.
+    return String(option.label);
+  }
+
+  return option.value;
 };
 
 export const getCurrentOption = (
@@ -103,6 +128,8 @@ export const doesOptionMatchSearchQuery = ({
   value,
   searchQuery,
 }: DoesOptionMatchSearchQueryProps) => {
+  // Search both the option value and any rendered text because labels can be
+  // supplied through nested React children.
   const childStrings = findStringNodes(children);
 
   return (

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -20,15 +20,15 @@ export default meta;
 
 type Story = StoryObj<TgphComponentProps<typeof TelegraphCombobox>>;
 
-const labels = ["Email", "SMS", "Push", "In-App", "Webhook"];
+const LABELS = ["Email", "SMS", "Push", "In-App", "Webhook"];
 
-const values = ["email", "sms", "push", "inapp", "webhook"];
-const firstValue = values[0] as string;
+const VALUES = ["email", "sms", "push", "inapp", "webhook"];
+const FIRST_VALUE = VALUES[0] as string;
 
 export const SingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -42,9 +42,9 @@ export const SingleSelect: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -58,7 +58,7 @@ export const SingleSelect: Story = {
 export const SingleSelectWithSearch: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -72,9 +72,9 @@ export const SingleSelectWithSearch: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -89,7 +89,7 @@ export const SingleSelectWithSearch: Story = {
 export const SingleSelectWithLongLabel: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
     return (
       <Box w="80">
         <TelegraphCombobox.Root
@@ -104,9 +104,9 @@ export const SingleSelectWithLongLabel: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]} with more content to make the label longer
+                  {LABELS[index]} with more content to make the label longer
                   than the trigger width
                 </TelegraphCombobox.Option>
               ))}
@@ -122,7 +122,7 @@ export const SingleSelectWithLongLabel: Story = {
 export const MultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -141,9 +141,9 @@ export const MultiSelect: Story = {
           >
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -158,7 +158,7 @@ export const MultiSelect: Story = {
 export const MultiSelectWithWrapLayout: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -174,9 +174,9 @@ export const MultiSelectWithWrapLayout: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -206,15 +206,15 @@ export const SingleSelectWithCreate: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create<"div", false>
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
-                  values.push(createdValue);
+                  VALUES.push(createdValue);
                   setValue(createdValue);
                 }}
               />
@@ -229,7 +229,7 @@ export const SingleSelectWithCreate: Story = {
 export const MultiSelectWithCreate: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<Array<string>>([firstValue]);
+    const [value, setValue] = React.useState<Array<string>>([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -245,15 +245,15 @@ export const MultiSelectWithCreate: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
-                  values.push(createdValue);
+                  VALUES.push(createdValue);
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
               />
@@ -268,7 +268,7 @@ export const MultiSelectWithCreate: Story = {
 export const MultiSelectWithClear: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -285,13 +285,13 @@ export const MultiSelectWithClear: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
               <TelegraphCombobox.Create
-                values={values}
+                values={VALUES}
                 onCreate={(createdValue) => {
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
@@ -309,7 +309,7 @@ export const ComboboxInModal: Story = {
     // eslint-disable-next-line
     const [open, setOpen] = React.useState(false);
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
     return (
       <>
         <Button size="1" variant="outline" onClick={() => setOpen(true)}>
@@ -339,15 +339,15 @@ export const ComboboxInModal: Story = {
                 <TelegraphCombobox.Content>
                   <TelegraphCombobox.Search />
                   <TelegraphCombobox.Options>
-                    {values.map((v, index) => (
+                    {VALUES.map((v, index) => (
                       <TelegraphCombobox.Option value={v}>
-                        {labels[index]}
+                        {LABELS[index]}
                       </TelegraphCombobox.Option>
                     ))}
                     <TelegraphCombobox.Create
-                      values={values}
+                      values={VALUES}
                       onCreate={(createdValue) => {
-                        values.push(createdValue);
+                        VALUES.push(createdValue);
                         setValue((prevValue) => [createdValue, ...prevValue]);
                       }}
                     />
@@ -363,7 +363,7 @@ export const ComboboxInModal: Story = {
 };
 
 type Option = { value: string; label?: string };
-const legacyValues = [
+const LEGACY_VALUES = [
   { value: "email", label: "Email" },
   { value: "sms", label: "SMS" },
   { value: "push", label: "Push" },
@@ -371,12 +371,12 @@ const legacyValues = [
   { value: "webhook", label: "Webhook" },
 ] as Array<Option>;
 
-const firstLegacyValue = legacyValues[0] as Option;
+const FIRST_LEGACY_VALUE = LEGACY_VALUES[0] as Option;
 
 export const LegacyComboboxSingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstLegacyValue);
+    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -391,7 +391,7 @@ export const LegacyComboboxSingleSelect: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
             </TelegraphCombobox.Options>
@@ -406,7 +406,7 @@ export const LegacyComboboxSingleSelect: Story = {
 export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstLegacyValue);
+    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -425,7 +425,7 @@ export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
           <TelegraphCombobox.Trigger size="1" />
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
             </TelegraphCombobox.Options>
@@ -440,7 +440,7 @@ export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
 export const LegacyComboboxMultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstLegacyValue]);
+    const [value, setValue] = React.useState([FIRST_LEGACY_VALUE]);
 
     return (
       <Box w="80">
@@ -458,14 +458,14 @@ export const LegacyComboboxMultiSelect: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
-              {legacyValues.map((v) => (
+              {LEGACY_VALUES.map((v) => (
                 <TelegraphCombobox.Option value={v.value} label={v.label} />
               ))}
               <TelegraphCombobox.Create
                 legacyBehavior={true}
-                values={legacyValues}
+                values={LEGACY_VALUES}
                 onCreate={(createdValue) => {
-                  legacyValues.push(createdValue);
+                  LEGACY_VALUES.push(createdValue);
                   setValue((prevValue) => [createdValue, ...prevValue]);
                 }}
               />
@@ -480,7 +480,7 @@ export const LegacyComboboxMultiSelect: Story = {
 export const SingleSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(firstValue);
+    const [value, setValue] = React.useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -500,9 +500,9 @@ export const SingleSelectWithCustomTrigger: Story = {
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -517,7 +517,7 @@ export const SingleSelectWithCustomTrigger: Story = {
 export const MultiSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([firstValue]);
+    const [value, setValue] = React.useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -537,9 +537,9 @@ export const MultiSelectWithCustomTrigger: Story = {
           </TelegraphCombobox.Trigger>
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Options>
-              {values.map((v, index) => (
+              {VALUES.map((v, index) => (
                 <TelegraphCombobox.Option value={v}>
-                  {labels[index]}
+                  {LABELS[index]}
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>
@@ -552,7 +552,7 @@ export const MultiSelectWithCustomTrigger: Story = {
 };
 
 // Generate years from 1960 to 2060
-const years = Array.from({ length: 101 }, (_, i) => String(1960 + i));
+const YEARS = Array.from({ length: 101 }, (_, i) => String(1960 + i));
 
 export const YearPicker: Story = {
   render: ({ ...args }) => {
@@ -567,7 +567,7 @@ export const YearPicker: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options maxHeight="64">
-              {years.map((year) => (
+              {YEARS.map((year) => (
                 <TelegraphCombobox.Option key={year} value={year}>
                   {year}
                 </TelegraphCombobox.Option>
@@ -599,7 +599,7 @@ export const YearPickerWithScrollToValue: Story = {
           <TelegraphCombobox.Content>
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options maxHeight="64">
-              {years.map((year) => (
+              {YEARS.map((year) => (
                 <TelegraphCombobox.Option key={year} value={year}>
                   {year}
                 </TelegraphCombobox.Option>

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -1,12 +1,16 @@
 import { render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import React from "react";
+import { useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
-import { Combobox, getOptionAccessibleLabel } from "./Combobox";
-import { findStringNodes } from "./Combobox.helpers";
-import type { ComboboxContentProps, ComboboxOptionsProps } from "./index";
+import { Combobox } from "./Combobox";
+import { findStringNodes, getOptionAccessibleLabel } from "./Combobox.helpers";
+import type {
+  ComboboxContentProps,
+  ComboboxOptionProps,
+  ComboboxOptionsProps,
+} from "./index";
 
 type Option = { value: string; label?: string };
 
@@ -19,8 +23,8 @@ beforeAll(() => {
   };
 });
 
-const values = ["email", "sms", "push", "inapp", "webhook"];
-const labels = ["Email", "SMS", "Push", "In-App", "Webhook"];
+const VALUES = ["email", "sms", "push", "inapp", "webhook"];
+const LABELS = ["Email", "SMS", "Push", "In-App", "Webhook"];
 
 // Utility to query elements rendered in a portal
 const queryPortalElement = (selector: string) =>
@@ -29,15 +33,15 @@ const queryPortalElements = (selector: string) =>
   document.querySelectorAll(selector);
 
 const ComboboxSingleSelect = ({ ...props }) => {
-  const [value, setValue] = React.useState<string>(values[0]!);
+  const [value, setValue] = useState<string>(VALUES[0]!);
   return (
     <Combobox.Root value={value} onValueChange={setValue} {...props}>
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -48,19 +52,16 @@ const ComboboxSingleSelect = ({ ...props }) => {
 };
 
 const ComboboxMultiSelect = () => {
-  const [value, setValue] = React.useState<Array<string>>([
-    values[0]!,
-    values[1]!,
-  ]);
+  const [value, setValue] = useState<Array<string>>([VALUES[0]!, VALUES[1]!]);
   return (
     <Combobox.Root value={value} onValueChange={setValue}>
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Search />
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -71,7 +72,7 @@ const ComboboxMultiSelect = () => {
 };
 
 const CustomTriggerCombobox = () => {
-  const [value, setValue] = React.useState<Option>(valuesLegacy[0]!);
+  const [value, setValue] = useState<Option>(valuesLegacy[0]!);
   return (
     <Combobox.Root value={value} onValueChange={setValue} legacyBehavior={true}>
       <Combobox.Trigger>
@@ -90,6 +91,40 @@ const CustomTriggerCombobox = () => {
     </Combobox.Root>
   );
 };
+
+const ControlledOpenCombobox = ({
+  onOpenChange,
+}: {
+  onOpenChange?: (open: boolean) => void;
+}) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
+
+  return (
+    <div>
+      <button data-testid="open-combobox" onClick={() => setOpen(true)}>
+        Open combobox
+      </button>
+      <Combobox.Root open={open} onOpenChange={handleOpenChange}>
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </div>
+  );
+};
+
 describe("Combobox", () => {
   describe("Single Select", () => {
     it("combobox is accessible", async () => {
@@ -334,6 +369,53 @@ describe("Combobox", () => {
       expect(options.length).toBe(1);
     });
 
+    it("keeps focus on the selected option when closeOnSelect is false", async () => {
+      const user = userEvent.setup();
+
+      const StayOpenMultiSelect = () => {
+        const [value, setValue] = useState<Array<string>>([VALUES[0]!]);
+
+        return (
+          <Combobox.Root
+            closeOnSelect={false}
+            value={value}
+            onValueChange={setValue}
+          >
+            <Combobox.Trigger />
+            <Combobox.Content>
+              <Combobox.Search />
+              <Combobox.Options>
+                {VALUES.map((option, index) => (
+                  <Combobox.Option key={option} value={option}>
+                    {LABELS[index]}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+
+      const { container } = render(<StayOpenMultiSelect />);
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      const getSmsOption = () =>
+        Array.from(queryPortalElements("[data-tgph-combobox-option]")).find(
+          (option) => option.textContent === "SMS",
+        ) as HTMLElement | undefined;
+
+      await user.click(getSmsOption()!);
+
+      await waitFor(() => expect(trigger?.textContent).toBe("EmailSMS"));
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(getSmsOption()).toHaveFocus();
+    });
+
     it("empty state should show when there are no results", async () => {
       const user = userEvent.setup();
       const { container } = render(<ComboboxMultiSelect />);
@@ -439,6 +521,128 @@ describe("Combobox", () => {
       expect(isOpen).toBe(wasOpen);
     });
   });
+
+  describe("open state", () => {
+    it("supports controlled open state", async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      const { container, getByTestId } = render(
+        <ControlledOpenCombobox onOpenChange={onOpenChange} />,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+      await user.click(getByTestId("open-combobox"));
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("false"),
+      );
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    });
+
+    it("keeps the combobox open when escape dismissal is prevented", async () => {
+      const user = userEvent.setup();
+      const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+        event.preventDefault();
+      });
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content onEscapeKeyDown={onEscapeKeyDown}>
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.keyboard("[Escape]");
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("keeps the combobox open when search escape dismissal is prevented", async () => {
+      const user = userEvent.setup();
+      const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => {
+        event.preventDefault();
+      });
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content onEscapeKeyDown={onEscapeKeyDown}>
+            <Combobox.Search />
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      await user.keyboard("[Escape]");
+
+      expect(onEscapeKeyDown).toHaveBeenCalledTimes(1);
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+    });
+
+    it("closes the combobox when Escape is pressed from search input", async () => {
+      const user = userEvent.setup();
+      const { container } = render(
+        <Combobox.Root>
+          <Combobox.Trigger />
+          <Combobox.Content>
+            <Combobox.Search />
+            <Combobox.Options>
+              {VALUES.map((option, index) => (
+                <Combobox.Option key={option} value={option}>
+                  {LABELS[index]}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>,
+      );
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+      );
+
+      expect(queryPortalElement("[data-tgph-combobox-search]")).toHaveFocus();
+
+      await user.keyboard("[Escape]");
+
+      await waitFor(() =>
+        expect(trigger?.getAttribute("aria-expanded")).toBe("false"),
+      );
+    });
+  });
 });
 
 const valuesLegacy: Array<Option> = [
@@ -450,7 +654,7 @@ const valuesLegacy: Array<Option> = [
 ];
 
 const ComboboxSingleSelectLegacy = ({ ...props }) => {
-  const [value, setValue] = React.useState<Option>(valuesLegacy[0]!);
+  const [value, setValue] = useState<Option>(valuesLegacy[0]!);
   return (
     <Combobox.Root
       value={value}
@@ -471,7 +675,7 @@ const ComboboxSingleSelectLegacy = ({ ...props }) => {
   );
 };
 const ComboboxMultiSelectLegacy = () => {
-  const [value, setValue] = React.useState<Array<Option>>([
+  const [value, setValue] = useState<Array<Option>>([
     valuesLegacy[0]!,
     valuesLegacy[1]!,
   ]);
@@ -717,6 +921,26 @@ describe("findStringNodes", () => {
 });
 
 describe("getOptionAccessibleLabel", () => {
+  it("returns undefined when no option is provided", () => {
+    expect(getOptionAccessibleLabel()).toBeUndefined();
+  });
+
+  it("uses text-like LABELS as the accessible label", () => {
+    expect(getOptionAccessibleLabel({ value: "email", label: "Email" })).toBe(
+      "Email",
+    );
+    expect(getOptionAccessibleLabel({ value: "sms", label: 123 })).toBe("123");
+  });
+
+  it("falls back to the option value for non-text LABELS", () => {
+    expect(
+      getOptionAccessibleLabel({
+        value: "push",
+        label: <span>Push</span>,
+      }),
+    ).toBe("push");
+  });
+
   it("falls back to the option value when the label is an empty string", () => {
     expect(getOptionAccessibleLabel({ value: "email", label: "" })).toBe(
       "email",
@@ -800,9 +1024,9 @@ const ComboboxWithDefaultValue = ({
       <Combobox.Trigger />
       <Combobox.Content>
         <Combobox.Options>
-          {values.map((option, index) => (
+          {VALUES.map((option, index) => (
             <Combobox.Option key={option} value={option}>
-              {labels[index]}
+              {LABELS[index]}
             </Combobox.Option>
           ))}
         </Combobox.Options>
@@ -873,9 +1097,9 @@ describe("defaultValue", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -897,9 +1121,9 @@ describe("defaultValue", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -955,7 +1179,7 @@ describe("scroll to selected", () => {
     // - Double quotes: Option "A"
     // - Brackets: Option [B]
     // - Backslashes: Option \C
-    const specialValues = [
+    const SPECIAL_VALUES = [
       'Option "A"',
       "Option [B]",
       "Option \\C",
@@ -968,7 +1192,7 @@ describe("scroll to selected", () => {
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {specialValues.map((val) => (
+            {SPECIAL_VALUES.map((val) => (
               <Combobox.Option key={val} value={val}>
                 {val}
               </Combobox.Option>
@@ -1007,7 +1231,7 @@ const ComboboxWithDefaultScrollToValue = ({
   defaultScrollToValue: string;
 }) => {
   const years = Array.from({ length: 101 }, (_, i) => String(1960 + i));
-  const [value, setValue] = React.useState<string | undefined>(undefined);
+  const [value, setValue] = useState<string | undefined>(undefined);
 
   return (
     <Combobox.Root
@@ -1114,7 +1338,7 @@ const ControlledComboboxWrapper = ({
   initialValue: string;
   onValueChange?: (value: string) => void;
 }) => {
-  const [value, setValue] = React.useState(initialValue);
+  const [value, setValue] = useState(initialValue);
 
   const handleValueChange = (newValue: string) => {
     setValue(newValue);
@@ -1143,9 +1367,9 @@ const ControlledComboboxWrapper = ({
         <Combobox.Trigger />
         <Combobox.Content>
           <Combobox.Options>
-            {values.map((option, index) => (
+            {VALUES.map((option, index) => (
               <Combobox.Option key={option} value={option}>
-                {labels[index]}
+                {LABELS[index]}
               </Combobox.Option>
             ))}
           </Combobox.Options>
@@ -1278,6 +1502,14 @@ describe("Combobox type inheritance", () => {
     const validProps: ComboboxOptionsProps = {
       gap: "2",
       padding: "1",
+    };
+    void validProps;
+  });
+
+  it("accepts React node labels on Option", () => {
+    const validProps: ComboboxOptionProps = {
+      value: "email",
+      label: <span>Email</span>,
     };
     void validProps;
   });

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1,12 +1,11 @@
-import { DismissableLayer } from "@radix-ui/react-dismissable-layer";
-import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { Button as TelegraphButton } from "@telegraph/button";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type RemappedOmit,
   type TgphComponentProps,
   type TgphElement,
+  VisuallyHidden,
+  useControllableState,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
 import { Input as TelegraphInput } from "@telegraph/input";
@@ -21,6 +20,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type KeyboardEventHandler as ReactKeyboardEventHandler,
   type ReactNode,
+  type Ref,
   type RefObject,
   createContext,
   useCallback,
@@ -34,8 +34,12 @@ import {
 
 import { TRIGGER_MIN_HEIGHT } from "./Combobox.constants";
 import {
+  FIRST_KEYS,
+  LAST_KEYS,
+  SELECT_KEYS,
   doesOptionMatchSearchQuery,
   getCurrentOption,
+  getOptionAccessibleLabel,
   getOptions,
   getValueFromOption,
   isMultiSelect,
@@ -48,26 +52,6 @@ import type {
   Option,
   SingleSelect,
 } from "./Combobox.types";
-
-const FIRST_KEYS = ["ArrowDown", "PageUp", "Home"];
-const LAST_KEYS = ["ArrowUp", "PageDown", "End"];
-const SELECT_KEYS = ["Enter", " "];
-
-export const getOptionAccessibleLabel = (option?: DefinedOption) => {
-  if (!option) {
-    return undefined;
-  }
-
-  if (typeof option.label === "string" && option.label !== "") {
-    return option.label;
-  }
-
-  if (typeof option.label === "number" || typeof option.label === "bigint") {
-    return String(option.label);
-  }
-
-  return option.value;
-};
 
 type LayoutValue<O> = O extends DefinedOption | string | undefined
   ? never
@@ -91,10 +75,8 @@ export type RootProps<
   clearable?: boolean;
   disabled?: boolean;
   legacyBehavior?: LB;
-  /**
-   * The value to scroll to when the combobox opens, if no value is selected.
-   * Useful for long lists where you want to start at a specific position.
-   */
+  // The value to scroll to when the combobox opens if no value is selected.
+  // Useful for long lists where you want to start at a specific position.
   defaultScrollToValue?: string;
   children?: ReactNode;
 };
@@ -114,6 +96,7 @@ export const ComboboxContext = createContext<
     triggerRef?: RefObject<HTMLButtonElement>;
     searchRef?: RefObject<HTMLInputElement>;
     contentRef?: RefObject<HTMLDivElement>;
+    onEscapeKeyDown?: (event: KeyboardEvent) => void;
     options: Array<DefinedOption>;
     legacyBehavior: boolean;
     defaultScrollToValue?: string;
@@ -165,12 +148,16 @@ const Root = <
   }, [children]);
 
   const [searchQuery, setSearchQuery] = useState<string>("");
+  // Keep open state controllable like the old menu-backed implementation while
+  // still allowing uncontrolled usage through defaultOpen.
   const [open = false, setOpen] = useControllableState({
     prop: openProp,
     defaultProp: defaultOpenProp ?? false,
     onChange: onOpenChangeProp,
   });
 
+  // The selected value can be a string, legacy option object, or array of
+  // either; this shared helper preserves that public contract.
   const [value, setValue] = useControllableState({
     prop: valueProp,
     defaultProp: defaultValueProp as O,
@@ -193,9 +180,8 @@ const Root = <
         contentId,
         triggerId,
         value,
-        // Need to cast this to avoid type errors
-        // because the type of onValueChange is not
-        // consistent with the value type
+        // Context consumers handle the runtime single/multi branches below, so
+        // expose one setter shape here and narrow it at the selection site.
         onValueChange: setValue as (value: Option | Array<Option>) => void,
         placeholder,
         open,
@@ -263,6 +249,8 @@ const Trigger = <V extends ChildrenValue>({
   >(() => {
     if (!context.value) return undefined;
     if (isSingleSelect(context.value)) {
+      // Convert the public selected value back to the option object so custom
+      // trigger render functions receive the same shape as before the rewrite.
       return getCurrentOption(
         context.value,
         context.options,
@@ -270,6 +258,8 @@ const Trigger = <V extends ChildrenValue>({
       );
     }
     if (isMultiSelect(context.value)) {
+      // Preserve array order from the selected value while resolving each entry
+      // against the current option list.
       return context.value.map((v) =>
         getCurrentOption(v, context.options, context.legacyBehavior),
       );
@@ -280,9 +270,13 @@ const Trigger = <V extends ChildrenValue>({
   const getAriaLabelString = useCallback(() => {
     if (!currentValue) return context.placeholder;
     if (isSingleSelect(currentValue)) {
+      // The visible option label may be a React node, so derive a text-only
+      // fallback before assigning it to aria-label.
       return getOptionAccessibleLabel(currentValue) || context.placeholder;
     }
     if (isMultiSelect(currentValue)) {
+      // Multi-select trigger text is rendered as tags; expose the same selected
+      // values as a comma-separated text label for assistive tech.
       return (
         currentValue
           .map((option) => getOptionAccessibleLabel(option))
@@ -311,6 +305,14 @@ const Trigger = <V extends ChildrenValue>({
         // Lets the user tab in and out of the combobox as usual
         if (event.key === "Tab") {
           event.stopPropagation();
+          return;
+        }
+
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          event.preventDefault();
+          context.setOpen(false);
+          context.triggerRef?.current?.focus();
           return;
         }
 
@@ -379,11 +381,15 @@ export type ContentProps<T extends TgphElement = "div"> = TgphComponentProps<
 const Content = <T extends TgphElement = "div">({
   style,
   children,
+  onEscapeKeyDown,
   tgphRef,
   ...props
 }: ContentProps<T>) => {
   const context = useContext(ComboboxContext);
+  const { open, setOpen, triggerRef } = context;
   const hasInteractedOutside = useRef(false);
+  const handledEscapeKeyDownRef = useRef(false);
+  const handledEscapeKeyDownTimeoutRef = useRef<number | undefined>(undefined);
   const composedRef = useComposedRefs<unknown>(tgphRef, context.contentRef);
 
   const internalContentRef = useRef(null);
@@ -391,6 +397,53 @@ const Content = <T extends TgphElement = "div">({
   const [height, setHeight] = useState(0);
   const [initialAnimationComplete, setInitialAnimationComplete] =
     useState(false);
+
+  const markEscapeKeyDownHandled = useCallback(() => {
+    handledEscapeKeyDownRef.current = true;
+    window.clearTimeout(handledEscapeKeyDownTimeoutRef.current);
+    handledEscapeKeyDownTimeoutRef.current = window.setTimeout(() => {
+      handledEscapeKeyDownRef.current = false;
+    }, 0);
+  }, []);
+
+  const handleEscapeKeyDownEvent = useCallback(
+    (event: KeyboardEvent) => {
+      markEscapeKeyDownHandled();
+      event.stopPropagation();
+      onEscapeKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return true;
+      }
+
+      if (open) {
+        event.preventDefault();
+        setOpen(false);
+        triggerRef?.current?.focus();
+      }
+
+      return true;
+    },
+    [markEscapeKeyDownHandled, onEscapeKeyDown, open, setOpen, triggerRef],
+  );
+
+  const handleEscapeKeyDown = (event: ReactKeyboardEvent) => {
+    if (event.key !== "Escape") {
+      return false;
+    }
+
+    const baseUIEvent = event as ReactKeyboardEvent & {
+      preventBaseUIHandler?: () => void;
+    };
+
+    baseUIEvent.preventBaseUIHandler?.();
+
+    if (event.defaultPrevented || event.nativeEvent.defaultPrevented) {
+      return true;
+    }
+
+    return handleEscapeKeyDownEvent(event.nativeEvent);
+  };
 
   const setHeightFromContent = useCallback(
     (element: Element) => {
@@ -414,7 +467,7 @@ const Content = <T extends TgphElement = "div">({
         setHeightFromContent(element);
       }
     });
-    // Attatch the observer once the initial animation completes
+    // Attach the observer once the initial animation completes
     // and the content ref is available
     if (internalContentRef.current && initialAnimationComplete) {
       observer.observe(internalContentRef.current);
@@ -434,32 +487,57 @@ const Content = <T extends TgphElement = "div">({
   // we add a timeout here to ensure that the DOM element has responded to
   // the state changes first
   useEffect(() => {
-    let timeout: NodeJS.Timeout;
-    if (context.open) {
-      timeout = setTimeout(() => {
-        setHeightFromContent(internalContentRef.current as unknown as Element);
-      }, 10);
+    if (!context.open) {
+      return undefined;
     }
 
-    return () => timeout && clearTimeout(timeout);
+    const timeout = window.setTimeout(() => {
+      setHeightFromContent(internalContentRef.current as unknown as Element);
+    }, 10);
+
+    return () => window.clearTimeout(timeout);
   }, [context.open, setHeightFromContent]);
 
+  useEffect(() => {
+    return () => {
+      window.clearTimeout(handledEscapeKeyDownTimeoutRef.current);
+    };
+  }, []);
+
+  const contentContext = {
+    ...context,
+    onEscapeKeyDown,
+  };
+
   return (
-    <DismissableLayer
-      onEscapeKeyDown={(event) => {
-        if (context.open) {
-          // Don't allow the event to bubble up outside of the menu
-          event.stopPropagation();
-          event.preventDefault();
-          context.setOpen(false);
-        }
-      }}
-    >
+    <ComboboxContext.Provider value={contentContext}>
       <TelegraphMenu.Content
         className="tgph"
         mt="1"
+        onEscapeKeyDown={(event: KeyboardEvent) => {
+          if (handledEscapeKeyDownRef.current) {
+            handledEscapeKeyDownRef.current = false;
+            return;
+          }
+
+          onEscapeKeyDown?.(event);
+
+          if (event.defaultPrevented) {
+            // Consumer escape handlers can keep the popup open.
+            return;
+          }
+
+          if (context.open) {
+            // Don't allow the event to bubble up outside of the menu
+            event.stopPropagation();
+            event.preventDefault();
+            context.setOpen(false);
+          }
+        }}
         onCloseAutoFocus={(event: Event) => {
           if (!hasInteractedOutside.current) {
+            // Menu close autofocus would otherwise move focus away from the
+            // combobox trigger after keyboard selection or Escape close.
             context.triggerRef?.current?.focus();
           }
 
@@ -489,10 +567,14 @@ const Content = <T extends TgphElement = "div">({
         tgphRef={composedRef}
         data-tgph-combobox-content
         data-tgph-combobox-content-open={context.open}
-        // Cancel out accessibility attirbutes related to aria menu
+        // Cancel out accessibility attributes related to aria menu
         role={undefined}
         aria-orientation={undefined}
         onKeyDown={(event: ReactKeyboardEvent) => {
+          if (handleEscapeKeyDown(event)) {
+            return;
+          }
+
           // Don't allow the event to bubble up outside of the menu
           event.stopPropagation();
 
@@ -506,6 +588,8 @@ const Content = <T extends TgphElement = "div">({
             document.activeElement === options?.[0] &&
             LAST_KEYS.includes(event.key)
           ) {
+            // Moving backward from the first option should return focus to search,
+            // matching the previous keyboard loop inside the combobox popup.
             context.searchRef?.current?.focus();
           }
         }}
@@ -514,7 +598,7 @@ const Content = <T extends TgphElement = "div">({
           {children}
         </Stack>
       </TelegraphMenu.Content>
-    </DismissableLayer>
+    </ComboboxContext.Provider>
   );
 };
 
@@ -530,7 +614,7 @@ const Options = <T extends TgphElement = "div">({
   const optionsRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs<unknown>(tgphRef, optionsRef);
 
-  // Scroll to the selected option (or defaultScrollToValue) when the combobox opens
+  // Scroll to the selected option or defaultScrollToValue when the combobox opens.
   useEffect(() => {
     if (context.open && optionsRef.current) {
       // Small delay to ensure the DOM has rendered
@@ -541,7 +625,8 @@ const Options = <T extends TgphElement = "div">({
             ? getValueFromOption(context.value[0], context.legacyBehavior)
             : null;
 
-        // Use selected value if available, otherwise fall back to defaultScrollToValue
+        // Prefer the current selection, then fall back to the explicit initial
+        // scroll target for long lists.
         const valueToScrollTo = selectedValue ?? context.defaultScrollToValue;
 
         if (valueToScrollTo) {
@@ -596,8 +681,9 @@ const Options = <T extends TgphElement = "div">({
   );
 };
 
-export type OptionProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof TelegraphMenu.Button<T>
+export type OptionProps<T extends TgphElement = "button"> = Omit<
+  TgphComponentProps<typeof TelegraphMenu.Button<T>>,
+  "label"
 > & {
   value: DefinedOption["value"];
   label?: DefinedOption["label"];
@@ -611,11 +697,18 @@ const Option = <T extends TgphElement>({
   onSelect,
   children,
   closeOnClick,
+  tgphRef,
   ...props
 }: OptionProps<T>) => {
   const context = useContext(ComboboxContext);
+  const { onEscapeKeyDown, setOpen, triggerRef } = context;
   const [isFocused, setIsFocused] = useState(false);
   const contextValue = context.value;
+  const optionRef = useRef<HTMLElement>(null);
+  const composedRef = useComposedRefs<HTMLElement>(
+    tgphRef as Ref<HTMLElement>,
+    optionRef,
+  );
 
   const isVisible =
     !context.searchQuery ||
@@ -631,25 +724,76 @@ const Option = <T extends TgphElement>({
       )
     : getValueFromOption(contextValue, context.legacyBehavior) === value;
 
-  const handleSelection = (event: Event | ReactKeyboardEvent) => {
-    // Don't allow the event to bubble up outside of the menu
-    event.stopPropagation();
+  useEffect(() => {
+    const option = optionRef.current;
+    if (!option) {
+      return undefined;
+    }
 
-    // Don't do anything if the key isn't a selection key
+    const handleOptionKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      event.stopPropagation();
+      onEscapeKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      event.preventDefault();
+      setOpen(false);
+      triggerRef?.current?.focus();
+    };
+
+    option.addEventListener("keydown", handleOptionKeyDown);
+
+    return () => {
+      option.removeEventListener("keydown", handleOptionKeyDown);
+    };
+  }, [onEscapeKeyDown, setOpen, triggerRef]);
+
+  const handleSelection = (event: Event | ReactKeyboardEvent) => {
     const keyboardEvent = event as ReactKeyboardEvent;
-    if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) return;
+    if (keyboardEvent.key === "Escape") {
+      event.stopPropagation();
+      context.onEscapeKeyDown?.(keyboardEvent.nativeEvent);
+
+      if (
+        event.defaultPrevented ||
+        keyboardEvent.nativeEvent.defaultPrevented
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      context.setOpen(false);
+      context.triggerRef?.current?.focus();
+      return;
+    }
+
+    if (keyboardEvent.key && !SELECT_KEYS.includes(keyboardEvent.key)) {
+      // Let non-selection keys bubble to the content layer so Escape dismissal
+      // and popup-level navigation shims still run from focused options.
+      return;
+    }
+
+    // Don't allow selection events to bubble up outside of the menu.
+    event.stopPropagation();
 
     // Don't bubble up the event
     event.preventDefault();
 
     if (context.closeOnSelect === true) {
+      // Close before emitting value changes so controlled callers see the old
+      // menu-backed ordering of open/value updates.
       context.setOpen(false);
     }
 
     if (onSelect) {
-      // Need to convert to non keyboard type event
-      // since onSelect is expecting a mouse event
-      // and we've handled the keyboard event already
+      // Menu onSelect receives an Event; keyboard selection is already handled
+      // here, so bridge the event shape for the public override callback.
       const onSelectEvent = event as unknown as Event;
       return onSelect(onSelectEvent);
     }
@@ -660,6 +804,7 @@ const Option = <T extends TgphElement>({
 
       // TODO: Remove this once { value, label } option is deprecated
       if (context.legacyBehavior === true) {
+        // Legacy single select still emits the option object shape.
         onValueChange?.({ value, label });
       } else {
         onValueChange?.(value);
@@ -676,13 +821,16 @@ const Option = <T extends TgphElement>({
         : [
             ...contextValue,
             // TODO: Remove this once { value, label } option is deprecated
+            // Preserve the legacy array item shape when that mode is enabled.
             context.legacyBehavior === true ? { value, label } : value,
           ];
 
       onValueChange?.(newValue);
     }
 
-    context.triggerRef?.current?.focus();
+    if (context.closeOnSelect === true) {
+      context.triggerRef?.current?.focus();
+    }
   };
 
   if (isVisible) {
@@ -705,6 +853,11 @@ const Option = <T extends TgphElement>({
         data-tgph-combobox-option-focused={isFocused}
         data-tgph-combobox-option-value={value}
         data-tgph-combobox-option-label={label}
+        tgphRef={
+          composedRef as TgphComponentProps<
+            typeof TelegraphMenu.Button<T>
+          >["tgphRef"]
+        }
         {...props}
       >
         {label || children || value}
@@ -735,11 +888,13 @@ const Search = ({
   useEffect(() => {
     const handleSearchKeyDown = (event: KeyboardEvent) => {
       if (FIRST_KEYS.includes(event.key)) {
+        // Arrowing down from the search input should transfer focus into the
+        // options list without scrolling the popup.
         context.contentRef?.current?.focus({ preventScroll: true });
       }
 
       if (event.key === "Escape") {
-        context.setOpen(false);
+        return;
       }
 
       event.stopPropagation();
@@ -757,11 +912,11 @@ const Search = ({
 
   return (
     <Box borderBottom="px" px="1" pb="1">
-      <VisuallyHidden.Root>
+      <VisuallyHidden>
         <Text as="label" htmlFor={id}>
           {label}
         </Text>
-      </VisuallyHidden.Root>
+      </VisuallyHidden>
       <TelegraphInput
         id={id}
         variant="ghost"
@@ -867,6 +1022,8 @@ const Create = <T extends TgphElement, LB extends boolean>({
   const variableAlreadyExists = useCallback(
     (searchQuery: string | undefined) => {
       if (!values || values?.length === 0) return false;
+      // Compare through getValueFromOption so create works for both string
+      // values and legacy { value, label } options.
       return values.some(
         (v) => getValueFromOption(v, legacyBehavior) === searchQuery,
       );
@@ -891,6 +1048,8 @@ const Create = <T extends TgphElement, LB extends boolean>({
 
             const create = onCreate as CreateProps<T, LB>["onCreate"];
 
+            // The conditional prop type keeps public APIs precise, but runtime
+            // creation narrows through the legacyBehavior branch above.
             create(value);
 
             context.setSearchQuery?.("");

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -107,7 +107,9 @@ All Stack props are also supported for additional styling.
 and CSS variables remain available outside the local subtree. The package also
 continues to expose Radix-compatible Popper CSS custom properties, such as
 `--radix-popper-anchor-width` and `--radix-popper-available-height`, mapped to
-Base UI's positioning variables for downstream style compatibility.
+Base UI's positioning variables for downstream style compatibility. The portal
+positioner owns the popover z-index layer so menu-backed popups keep rendering
+above modal overlays and other lower layering surfaces.
 
 ### `<Menu.Button>`
 

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -484,10 +484,21 @@ describe("Menu", () => {
     expect(content).toHaveAttribute("data-state", "open");
     expect(content).toHaveAttribute("role", "menu");
     expect(content).toHaveStyle({
+      outline: "none",
+    });
+    expect(content).toHaveStyle({
       transformOrigin: "var(--transform-origin)",
     });
     expect(content).toHaveStyle({
       "--radix-popper-transform-origin": "var(--transform-origin)",
+    });
+    expect(content.parentElement).toHaveStyle({
+      zIndex: "var(--tgph-zIndex-popover)",
+    });
+    expect(
+      screen.getByRole("menuitem", { name: "Manage workflow" }),
+    ).toHaveStyle({
+      outline: "none",
     });
     expect(container).not.toContainElement(content);
   });

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -583,6 +583,7 @@ const Content = <T extends TgphElement = "div">({
               py={py}
               shadow={shadow}
               style={{
+                outline: "none",
                 overflowY: "auto",
                 transformOrigin: "var(--transform-origin)",
                 ...RADIX_POPPER_COMPATIBILITY_VARS,
@@ -653,6 +654,9 @@ const Button = <T extends TgphElement = "button">({
   const nativeKeyboardSelectionPendingRef = useRef(false);
   const preventNextKeyboardCloseRef = useRef(false);
   const reactKeyboardSelectionHandledRef = useRef(false);
+  const fallbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
   const composedTgphRef = useComposedRefs<HTMLElement>(
     tgphRef,
     itemRef,
@@ -665,16 +669,17 @@ const Button = <T extends TgphElement = "button">({
       return;
     }
 
-    let fallbackTimeout: ReturnType<typeof setTimeout> | undefined;
     const resetNativeKeyboardState = () => {
       nativeKeyboardClickHandledRef.current = false;
       nativeKeyboardSelectionPendingRef.current = false;
       reactKeyboardSelectionHandledRef.current = false;
     };
     const clearFallbackTimeout = () => {
-      if (fallbackTimeout !== undefined) {
-        item.ownerDocument.defaultView?.clearTimeout(fallbackTimeout);
-        fallbackTimeout = undefined;
+      if (fallbackTimeoutRef.current !== undefined) {
+        item.ownerDocument.defaultView?.clearTimeout(
+          fallbackTimeoutRef.current,
+        );
+        fallbackTimeoutRef.current = undefined;
       }
     };
     const handleNativeKeyDown = (event: KeyboardEvent) => {
@@ -695,28 +700,31 @@ const Button = <T extends TgphElement = "button">({
       }
 
       clearFallbackTimeout();
-      fallbackTimeout = item.ownerDocument.defaultView?.setTimeout(() => {
-        // Defer one tick so React keydown and Base UI selection can mark their
-        // refs before the native fallback fires a duplicate selection.
-        if (
-          reactKeyboardSelectionHandledRef.current ||
-          nativeKeyboardClickHandledRef.current
-        ) {
+      fallbackTimeoutRef.current = item.ownerDocument.defaultView?.setTimeout(
+        () => {
+          // Defer one tick so React keydown and Base UI selection can mark their
+          // refs before the native fallback fires a duplicate selection.
+          if (
+            reactKeyboardSelectionHandledRef.current ||
+            nativeKeyboardClickHandledRef.current
+          ) {
+            resetNativeKeyboardState();
+            return;
+          }
+
+          if (onSelect) {
+            onSelect(event);
+            ignoreNextKeyboardClickRef.current = true;
+            preventNextKeyboardCloseRef.current = event.defaultPrevented;
+          }
+
+          // Trigger the normal click path for parity with native button keyboard
+          // activation after the legacy onSelect callback has had a chance to cancel.
+          item.click();
           resetNativeKeyboardState();
-          return;
-        }
-
-        if (onSelect) {
-          onSelect(event);
-          ignoreNextKeyboardClickRef.current = true;
-          preventNextKeyboardCloseRef.current = event.defaultPrevented;
-        }
-
-        // Trigger the normal click path for parity with native button keyboard
-        // activation after the legacy onSelect callback has had a chance to cancel.
-        item.click();
-        resetNativeKeyboardState();
-      }, 0);
+        },
+        0,
+      );
     };
 
     item.addEventListener("keydown", handleNativeKeyDown);
@@ -799,6 +807,7 @@ const Button = <T extends TgphElement = "button">({
           disabled={disabled}
           mx={mx}
           style={{
+            outline: "none",
             flexShrink: 0,
             ...menuItemProps.style,
           }}
@@ -909,6 +918,7 @@ const SubTrigger = <T extends TgphElement = "button">({
           disabled={disabled}
           mx={mx}
           style={{
+            outline: "none",
             flexShrink: 0,
             ...menuItemProps.style,
           }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1793,31 +1793,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/core@npm:^1.0.0":
-  version: 1.6.0
-  resolution: "@floating-ui/core@npm:1.6.0"
-  dependencies:
-    "@floating-ui/utils": "npm:^0.2.1"
-  checksum: 10c0/667a68036f7dd5ed19442c7792a6002ca02d1799221c4396691bbe0b6008b48f6ccad581225e81fa266bb91232f6c66838a5f825f554217e1ec886178b93381b
-  languageName: node
-  linkType: hard
-
 "@floating-ui/core@npm:^1.7.5":
   version: 1.7.5
   resolution: "@floating-ui/core@npm:1.7.5"
   dependencies:
     "@floating-ui/utils": "npm:^0.2.11"
   checksum: 10c0/f9c52205e198b231d63a387b09c659aab08c46a1899e0b0bbe147b8b4f048b546f15ba17cb5d2a471da9534f1883d979425e13e5c4ceee67be63e4b0abd4db5d
-  languageName: node
-  linkType: hard
-
-"@floating-ui/dom@npm:^1.6.1":
-  version: 1.6.3
-  resolution: "@floating-ui/dom@npm:1.6.3"
-  dependencies:
-    "@floating-ui/core": "npm:^1.0.0"
-    "@floating-ui/utils": "npm:^0.2.0"
-  checksum: 10c0/d6cac10877918ce5a8d1a24b21738d2eb130a0191043d7c0dd43bccac507844d3b4dc5d4107d3891d82f6007945ca8fb4207a1252506e91c37e211f0f73cf77e
   languageName: node
   linkType: hard
 
@@ -1831,18 +1812,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/react-dom@npm:^2.0.0":
-  version: 2.0.8
-  resolution: "@floating-ui/react-dom@npm:2.0.8"
-  dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-  peerDependencies:
-    react: ">=16.8.0"
-    react-dom: ">=16.8.0"
-  checksum: 10c0/4d87451e2dcc54b4753a0d81181036e47821cfd0d4c23f7e9c31590c7c91fb15fb0a5a458969a5ddabd61601eca5875ebd4e40bff37cee31f373b8f1ccc64518
-  languageName: node
-  linkType: hard
-
 "@floating-ui/react-dom@npm:^2.1.8":
   version: 2.1.8
   resolution: "@floating-ui/react-dom@npm:2.1.8"
@@ -1852,13 +1821,6 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 10c0/26260ca4bb23b57c73b824062505abf977a008ce6e0463bdacca74f7e49853c4cd1d2bbf1a77c6caa17fa37dfffda2c6c4cd07a8737ebd7474aaff7818401d75
-  languageName: node
-  linkType: hard
-
-"@floating-ui/utils@npm:^0.2.0, @floating-ui/utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "@floating-ui/utils@npm:0.2.1"
-  checksum: 10c0/ee77756712cf5b000c6bacf11992ffb364f3ea2d0d51cc45197a7e646a17aeb86ea4b192c0b42f3fbb29487aee918a565e84f710b8c3645827767f406a6b4cc9
   languageName: node
   linkType: hard
 
@@ -3074,512 +3036,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/primitive@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/primitive@npm:1.1.3"
-  checksum: 10c0/88860165ee7066fa2c179f32ffcd3ee6d527d9dcdc0e8be85e9cb0e2c84834be8e3c1a976c74ba44b193f709544e12f54455d892b28e32f0708d89deda6b9f1d
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-arrow@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-arrow@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c3b46766238b3ee2a394d8806a5141432361bf1425110c9f0dcf480bda4ebd304453a53f294b5399c6ee3ccfcae6fd544921fd01ddc379cf5942acdd7168664b
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-collection@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-collection@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-slot": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/fa321a7300095508491f75414f02b243f0c3f179dc0728cfd115e2ea9f6f48f1516532b59f526d9ac81bbab63cd98a052074b4703ec0b9428fac945ebabec5fd
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-compose-refs@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@radix-ui/react-compose-refs@npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/d36a9c589eb75d634b9b139c80f916aadaf8a68a7c1c4b8c6c6b88755af1a92f2e343457042089f04cc3f23073619d08bb65419ced1402e9d4e299576d970771
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-context@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@radix-ui/react-context@npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/cece731f8cc25d494c6589cc681e5c01a93867d895c75889973afa1a255f163c286e390baa7bc028858eaabe9f6b57270d0ca6377356f652c5557c1c7a41ccce
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-direction@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-direction@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/7a89d9291f846a3105e45f4df98d6b7a08f8d7b30acdcd253005dc9db107ee83cbbebc9e47a9af1e400bcd47697f1511ceab23a399b0da854488fc7220482ac9
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-dismissable-layer@npm:1.1.11, @radix-ui/react-dismissable-layer@npm:^1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c825572a64073c4d3853702029979f6658770ffd6a98eabc4984e1dee1b226b4078a2a4dc7003f96475b438985e9b21a58e75f51db74dd06848dcae1f2d395dc
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-guards@npm:1.1.3":
-  version: 1.1.3
-  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/0bab65eb8d7e4f72f685d63de7fbba2450e3cb15ad6a20a16b42195e9d335c576356f5a47cb58d1ffc115393e46d7b14b12c5d4b10029b0ec090861255866985
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-focus-scope@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-focus-scope@npm:1.1.7"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/8a6071331bdeeb79b223463de75caf759b8ad19339cab838e537b8dbb2db236891a1f4df252445c854d375d43d9d315dfcce0a6b01553a2984ec372bb8f1300e
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-id@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-id@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/7d12e76818763d592c331277ef62b197e2e64945307e650bd058f0090e5ae48bbd07691b23b7e9e977901ef4eadcb3e2d5eaeb17a13859083384be83fc1292c7
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-menu@npm:^2.1.16":
-  version: 2.1.16
-  resolution: "@radix-ui/react-menu@npm:2.1.16"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-collection": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
-    "@radix-ui/react-focus-guards": "npm:1.1.3"
-    "@radix-ui/react-focus-scope": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.8"
-    "@radix-ui/react-portal": "npm:1.1.9"
-    "@radix-ui/react-presence": "npm:1.1.5"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-roving-focus": "npm:1.1.11"
-    "@radix-ui/react-slot": "npm:1.2.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    aria-hidden: "npm:^1.2.4"
-    react-remove-scroll: "npm:^2.6.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/27516b2b987fa9181c4da8645000af8f60691866a349d7a46b9505fa7d2e9d92b9e364db4f7305d08e9e57d0e1afc8df8354f8ee3c12aa05c0100c16b0e76c27
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-popper@npm:1.2.8":
-  version: 1.2.8
-  resolution: "@radix-ui/react-popper@npm:1.2.8"
-  dependencies:
-    "@floating-ui/react-dom": "npm:^2.0.0"
-    "@radix-ui/react-arrow": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-    "@radix-ui/react-use-rect": "npm:1.1.1"
-    "@radix-ui/react-use-size": "npm:1.1.1"
-    "@radix-ui/rect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/48e3f13eac3b8c13aca8ded37d74db17e1bb294da8d69f142ab6b8719a06c3f90051668bed64520bf9f3abdd77b382ce7ce209d056bb56137cecc949b69b421c
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-portal@npm:1.1.9":
-  version: 1.1.9
-  resolution: "@radix-ui/react-portal@npm:1.1.9"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/45b432497c722720c72c493a29ef6085bc84b50eafe79d48b45c553121b63e94f9cdb77a3a74b9c49126f8feb3feee009fe400d48b7759d3552396356b192cd7
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-portal@npm:^1.1.10":
-  version: 1.1.10
-  resolution: "@radix-ui/react-portal@npm:1.1.10"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.4"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/c8f77e2c9413f654f5232045888898eaac88d8d0515714c8ecdc25eea0dc20667639a1ead1528bfbb591ac9ae599de006879859ccb4c2b5c088b49f1af3a9c1a
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-presence@npm:1.1.5":
-  version: 1.1.5
-  resolution: "@radix-ui/react-presence@npm:1.1.5"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/d0e61d314250eeaef5369983cb790701d667f51734bafd98cf759072755562018052c594e6cdc5389789f4543cb0a4d98f03ff4e8f37338d6b5bf51a1700c1d1
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-primitive@npm:2.1.3":
-  version: 2.1.3
-  resolution: "@radix-ui/react-primitive@npm:2.1.3"
-  dependencies:
-    "@radix-ui/react-slot": "npm:1.2.3"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/fdff9b84913bb4172ef6d3af7442fca5f9bba5f2709cba08950071f819d7057aec3a4a2d9ef44cf9cbfb8014d02573c6884a04cff175895823aaef809ebdb034
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-primitive@npm:2.1.4":
-  version: 2.1.4
-  resolution: "@radix-ui/react-primitive@npm:2.1.4"
-  dependencies:
-    "@radix-ui/react-slot": "npm:1.2.4"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/90d687b222a25975371ed1f9f08648d75237214b8dec4cbaf09ec9ac951339b17421278f1aff2fb7c5672ba8bd03774a94904efdba73805dd5cc947ce5be8c4a
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-roving-focus@npm:1.1.11":
-  version: 1.1.11
-  resolution: "@radix-ui/react-roving-focus@npm:1.1.11"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.3"
-    "@radix-ui/react-collection": "npm:1.1.7"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-direction": "npm:1.1.1"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-primitive": "npm:2.1.3"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/2cd43339c36e89a3bf1db8aab34b939113dfbde56bf3a33df2d74757c78c9489b847b1962f1e2441c67e41817d120cb6177943e0f655f47bc1ff8e44fd55b1a2
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-slot@npm:1.2.3":
-  version: 1.2.3
-  resolution: "@radix-ui/react-slot@npm:1.2.3"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/5913aa0d760f505905779515e4b1f0f71a422350f077cc8d26d1aafe53c97f177fec0e6d7fbbb50d8b5e498aa9df9f707ca75ae3801540c283b26b0136138eef
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-slot@npm:1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-slot@npm:1.2.4"
-  dependencies:
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/8b719bb934f1ae5ac0e37214783085c17c2f1080217caf514c1c6cc3d9ca56c7e19d25470b26da79aa6e605ab36589edaade149b76f5fc0666f1063e2fc0a0dc
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-callback-ref@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-callback-ref@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/5f6aff8592dea6a7e46589808912aba3fb3b626cf6edd2b14f01638b61dbbe49eeb9f67cd5601f4c15b2fb547b9a7e825f7c4961acd4dd70176c969ae405f8d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-controllable-state@npm:1.2.2, @radix-ui/react-use-controllable-state@npm:^1.2.2":
-  version: 1.2.2
-  resolution: "@radix-ui/react-use-controllable-state@npm:1.2.2"
-  dependencies:
-    "@radix-ui/react-use-effect-event": "npm:0.0.2"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f55c4b06e895293aed4b44c9ef26fb24432539f5346fcd6519c7745800535b571058685314e83486a45bf61dc83887e24826490d3068acc317fb0a9010516e63
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-effect-event@npm:0.0.2":
-  version: 0.0.2
-  resolution: "@radix-ui/react-use-effect-event@npm:0.0.2"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/e84ff72a3e76c5ae9c94941028bb4b6472f17d4104481b9eab773deab3da640ecea035e54da9d6f4df8d84c18ef6913baf92b7511bee06930dc58bd0c0add417
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-escape-keydown@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-escape-keydown@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/bff53be99e940fef1d3c4df7d560e1d9133182e5a98336255d3063327d1d3dd4ec54a95dc5afe15cca4fb6c184f0a956c70de2815578c318cf995a7f9beabaa1
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-layout-effect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-layout-effect@npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/9f98fdaba008dfc58050de60a77670b885792df473cf82c1cef8daee919a5dd5a77d270209f5f0b0abfaac78cb1627396e3ff56c81b735be550409426fe8b040
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-rect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-rect@npm:1.1.1"
-  dependencies:
-    "@radix-ui/rect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/271711404c05c589c8dbdaa748749e7daf44bcc6bffc9ecd910821c3ebca0ee245616cf5b39653ce690f53f875c3836fd3f36f51ab1c628273b6db599eee4864
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-use-size@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/react-use-size@npm:1.1.1"
-  dependencies:
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/851d09a816f44282e0e9e2147b1b571410174cc048703a50c4fa54d672de994fd1dfff1da9d480ecfd12c77ae8f48d74f01adaf668f074156b8cd0043c6c21d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-visually-hidden@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.4"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.4"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/cca313cd3268f483612da1ab91c4cca55a54d24963dd543154f2d043bfdca21a96ab0582152ae473de44769474867d5433dbadae799a42932e6204fd2d5fa889
-  languageName: node
-  linkType: hard
-
-"@radix-ui/rect@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@radix-ui/rect@npm:1.1.1"
-  checksum: 10c0/0dac4f0f15691199abe6a0e067821ddd9d0349c0c05f39834e4eafc8403caf724106884035ae91bbc826e10367e6a5672e7bec4d4243860fa7649de246b1f60b
-  languageName: node
-  linkType: hard
-
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.15"
@@ -4118,11 +3574,6 @@ __metadata:
   dependencies:
     "@knocklabs/eslint-config": "npm:^0.0.5"
     "@knocklabs/typescript-config": "npm:^0.0.2"
-    "@radix-ui/react-dismissable-layer": "npm:^1.1.11"
-    "@radix-ui/react-menu": "npm:^2.1.16"
-    "@radix-ui/react-portal": "npm:^1.1.10"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:^1.2.4"
     "@telegraph/button": "workspace:^"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
@@ -6235,15 +5686,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-hidden@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "aria-hidden@npm:1.2.4"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  checksum: 10c0/8abcab2e1432efc4db415e97cb3959649ddf52c8fc815d7384f43f3d3abf56f1c12852575d00df9a8927f421d7e0712652dd5f8db244ea57634344e29ecfc74a
-  languageName: node
-  linkType: hard
-
 "aria-query@npm:5.3.0, aria-query@npm:^5.0.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
@@ -7376,13 +6818,6 @@ __metadata:
   version: 4.0.1
   resolution: "detect-newline@npm:4.0.1"
   checksum: 10c0/1cc1082e88ad477f30703ae9f23bd3e33816ea2db6a35333057e087d72d466f5a777809b71f560118ecff935d2c712f5b59e1008a8b56a900909d8fd4621c603
-  languageName: node
-  linkType: hard
-
-"detect-node-es@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "detect-node-es@npm:1.1.0"
-  checksum: 10c0/e562f00de23f10c27d7119e1af0e7388407eb4b06596a25f6d79a360094a109ff285de317f02b090faae093d314cf6e73ac3214f8a5bb3a0def5bece94557fbe
   languageName: node
   linkType: hard
 
@@ -8939,13 +8374,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
-  languageName: node
-  linkType: hard
-
-"get-nonce@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "get-nonce@npm:1.0.1"
-  checksum: 10c0/2d7df55279060bf0568549e1ffc9b84bc32a32b7541675ca092dce56317cdd1a59a98dcc4072c9f6a980779440139a3221d7486f52c488e69dc0fd27b1efb162
   languageName: node
   linkType: hard
 
@@ -12102,57 +11530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-remove-scroll-bar@npm:^2.3.7":
-  version: 2.3.8
-  resolution: "react-remove-scroll-bar@npm:2.3.8"
-  dependencies:
-    react-style-singleton: "npm:^2.2.2"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/9a0675c66cbb52c325bdbfaed80987a829c4504cefd8ff2dd3b6b3afc9a1500b8ec57b212e92c1fb654396d07bbe18830a8146fe77677d2a29ce40b5e1f78654
-  languageName: node
-  linkType: hard
-
-"react-remove-scroll@npm:^2.6.3":
-  version: 2.6.3
-  resolution: "react-remove-scroll@npm:2.6.3"
-  dependencies:
-    react-remove-scroll-bar: "npm:^2.3.7"
-    react-style-singleton: "npm:^2.2.3"
-    tslib: "npm:^2.1.0"
-    use-callback-ref: "npm:^1.3.3"
-    use-sidecar: "npm:^1.1.3"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/068e9704ff26816fffc4c8903e2c6c8df7291ee08615d7c1ab0cf8751f7080e2c5a5d78ef5d908b11b9cfc189f176d312e44cb02ea291ca0466d8283b479b438
-  languageName: node
-  linkType: hard
-
-"react-style-singleton@npm:^2.2.2, react-style-singleton@npm:^2.2.3":
-  version: 2.2.3
-  resolution: "react-style-singleton@npm:2.2.3"
-  dependencies:
-    get-nonce: "npm:^1.0.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/841938ff16d16a6b76895f4cb2e1fea957e5fe3b30febbf03a54892dae1c9153f2383e231dea0b3ba41192ad2f2849448fa859caccd288943bce32639e971bee
-  languageName: node
-  linkType: hard
-
 "react@npm:^19.2.6":
   version: 19.2.6
   resolution: "react@npm:19.2.6"
@@ -13776,7 +13153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.0.0, tslib@npm:^2.0.1, tslib@npm:^2.1.0, tslib@npm:^2.4.0":
+"tslib@npm:^2.0.1, tslib@npm:^2.4.0":
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 10c0/e03a8a4271152c8b26604ed45535954c0a45296e32445b4b87f8a5abdb2421f40b59b4ca437c4346af0f28179780d604094eb64546bee2019d903d01c6c19bdb
@@ -14266,37 +13643,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10c0/4ef57b45aa820d7ac6496e9208559986c665e49447cb072744c13b66925a362d96dd5a46c4530a6b8e203e5db5fe849369444440cb22ecfc26c679359e5dfa3c
-  languageName: node
-  linkType: hard
-
-"use-callback-ref@npm:^1.3.3":
-  version: 1.3.3
-  resolution: "use-callback-ref@npm:1.3.3"
-  dependencies:
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/f887488c6e6075cdad4962979da1714b217bcb1ee009a9e57ce9a844bcfc4c3a99e93983dfc2e5af9e0913824d24e730090ff255e902c516dcb58d2d3837e01c
-  languageName: node
-  linkType: hard
-
-"use-sidecar@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "use-sidecar@npm:1.1.3"
-  dependencies:
-    detect-node-es: "npm:^1.1.0"
-    tslib: "npm:^2.0.0"
-  peerDependencies:
-    "@types/react": "*"
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-  checksum: 10c0/161599bf921cfaa41c85d2b01c871975ee99260f3e874c2d41c05890d41170297bdcf314bc5185e7a700de2034ac5b888e3efc8e9f35724f4918f53538d717c9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #846.
- Linear: [KNO-13674](https://linear.app/knock/issue/KNO-13674).

## What changed

- Removes direct Radix runtime dependencies from `@telegraph/combobox`.
- Reworks Combobox content through the migrated Telegraph Menu popup layer.
- Moves key constants and option accessible-label logic into `Combobox.helpers.ts`.
- Preserves accessible-label fallback for React-node labels and empty string labels after the helper extraction.
- Preserves controlled open state, preventable Escape dismissal, `closeOnSelect={false}` focus behavior, legacy values, portal rendering, and popup sizing compatibility.

## Why

- Moves Combobox onto Base UI-backed primitives without forcing a breaking API rewrite.
- Reuses the migrated Menu popup layer so dismissal, focus, portal, and positioning behavior stay aligned across the stack.
- Keeps accessibility fallbacks explicit while option labels can be strings, numbers, React nodes, or empty strings.

## Verification

- `yarn test packages/combobox/src/Combobox/Combobox.test.tsx packages/menu/src/Menu/Menu.test.tsx`
- `yarn workspace @telegraph/combobox build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
