### PR TITLE
test(select): verify Select after Combobox migration

### DIFF
--- a/.changeset/sour-selects-dance.md
+++ b/.changeset/sour-selects-dance.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/select": patch
+---
+
+Verify Select against the migrated Combobox implementation, including single-select, multi-select, prop pass-through, portalled accessibility scans, keyboard selection, Escape dismissal, and focus return.

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -69,22 +69,35 @@ export const CountrySelector = () => {
 - Advanced filtering
 - Multi-select with complex UI
 
+## Implementation Notes
+
+Select is a lightweight wrapper around `@telegraph/combobox`. It inherits the
+migrated Combobox popup, portal, focus, and dismissal behavior, which is backed
+by Base UI through Telegraph primitives.
+
+The public Select API remains unchanged. Single-select usage closes after
+selection, while multi-select usage stays open; this behavior is inferred from
+whether `value` or `defaultValue` is an array. `triggerProps`, `contentProps`,
+and `optionsProps` continue to pass through to the underlying Combobox parts.
+
+Select does not depend on Radix directly.
+
 ## API Reference
 
 ### `<Select.Root>`
 
 The main select container component.
 
-| Prop            | Type                                  | Default       | Description                             |
-| --------------- | ------------------------------------- | ------------- | --------------------------------------- |
-| `value`         | `string \| string[]`                  | `undefined`   | Selected value(s)                       |
-| `onValueChange` | `(value: string \| string[]) => void` | `undefined`   | Called when selection changes           |
-| `size`          | `"0" \| "1" \| "2" \| "3"`           | `"1"`         | Size of the trigger button              |
-| `placeholder`   | `string`                              | `undefined`   | Placeholder text when no value selected |
-| `disabled`      | `boolean`                             | `false`       | Whether the select is disabled          |
-| `triggerProps`  | `ComboboxTriggerProps`                | `undefined`   | Props passed to the trigger button      |
-| `contentProps`  | `ComboboxContentProps`                | `undefined`   | Props passed to the dropdown content    |
-| `optionsProps`  | `ComboboxOptionsProps`                | `undefined`   | Props passed to the options container   |
+| Prop            | Type                                  | Default     | Description                             |
+| --------------- | ------------------------------------- | ----------- | --------------------------------------- |
+| `value`         | `string \| string[]`                  | `undefined` | Selected value(s)                       |
+| `onValueChange` | `(value: string \| string[]) => void` | `undefined` | Called when selection changes           |
+| `size`          | `"0" \| "1" \| "2" \| "3"`            | `"1"`       | Size of the trigger button              |
+| `placeholder`   | `string`                              | `undefined` | Placeholder text when no value selected |
+| `disabled`      | `boolean`                             | `false`     | Whether the select is disabled          |
+| `triggerProps`  | `ComboboxTriggerProps`                | `undefined` | Props passed to the trigger button      |
+| `contentProps`  | `ComboboxContentProps`                | `undefined` | Props passed to the dropdown content    |
+| `optionsProps`  | `ComboboxOptionsProps`                | `undefined` | Props passed to the options container   |
 
 ### `<Select.Option>`
 
@@ -383,8 +396,8 @@ export const ConditionalSelect = ({ userRole, permissions }) => {
 ### Loading State
 
 ```tsx
-import { Select } from "@telegraph/select";
 import { Box } from "@telegraph/layout";
+import { Select } from "@telegraph/select";
 
 export const SelectWithLoading = ({ loading, options, ...props }) => {
   if (loading) {
@@ -677,6 +690,7 @@ export const CountryRegionSelector = () => {
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/select)
 - [Combobox Component](../combobox/README.md) - Full-featured dropdown with search
+- [Base UI Menu](https://base-ui.com/react/components/menu/)
 
 ## Contributing
 

--- a/packages/select/src/Select/Select.test.tsx
+++ b/packages/select/src/Select/Select.test.tsx
@@ -1,0 +1,283 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+
+import { Select } from "./Select";
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const queryPortalElement = (selector: string) =>
+  document.querySelector(selector);
+const queryPortalElements = (selector: string) =>
+  document.querySelectorAll(selector);
+
+const getOptionByText = (text: string) => {
+  return Array.from(queryPortalElements("[data-tgph-combobox-option]")).find(
+    (option) => option.textContent === text,
+  ) as HTMLElement | undefined;
+};
+
+const options = [
+  { value: "email", label: "Email" },
+  { value: "sms", label: "SMS" },
+  { value: "push", label: "Push" },
+];
+
+const renderSelectOptions = () => {
+  return options.map((option) => (
+    <Select.Option key={option.value} value={option.value}>
+      {option.label}
+    </Select.Option>
+  ));
+};
+
+const ControlledSingleSelect = ({
+  onValueChange,
+}: {
+  onValueChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useState("email");
+
+  const handleValueChange = (nextValue: string) => {
+    setValue(nextValue);
+    onValueChange?.(nextValue);
+  };
+
+  return (
+    <Select.Root value={value} onValueChange={handleValueChange}>
+      {renderSelectOptions()}
+    </Select.Root>
+  );
+};
+
+const ControlledMultiSelect = ({
+  onValueChange,
+}: {
+  onValueChange?: (value: Array<string>) => void;
+}) => {
+  const [value, setValue] = useState<Array<string>>(["email"]);
+
+  const handleValueChange = (nextValue: Array<string>) => {
+    setValue(nextValue);
+    onValueChange?.(nextValue);
+  };
+
+  return (
+    <Select.Root value={value} onValueChange={handleValueChange}>
+      {renderSelectOptions()}
+    </Select.Root>
+  );
+};
+
+describe("Select", () => {
+  it("is accessible", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select.Root defaultValue="email">{renderSelectOptions()}</Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expectToHaveNoViolations(await axe(container));
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expectToHaveNoViolations(
+      await axe(document.body, {
+        rules: {
+          region: { enabled: false },
+        },
+      }),
+    );
+  });
+
+  it("supports keyboard selection, Escape dismissal, and focus return", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root onValueChange={onValueChange}>
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector(
+      "[data-tgph-combobox-trigger]",
+    ) as HTMLElement;
+
+    trigger.focus();
+    await user.keyboard("[ArrowDown]");
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expect(document.activeElement).toHaveTextContent("Email");
+
+    await user.keyboard("[Enter]");
+
+    await waitFor(() => expect(trigger).toHaveTextContent("Email"));
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onValueChange).toHaveBeenLastCalledWith("email");
+
+    trigger.focus();
+    await user.keyboard("[ArrowDown]");
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    expect(document.activeElement).toHaveTextContent("Email");
+
+    fireEvent.keyDown(document.activeElement!, { key: "Escape" });
+
+    await waitFor(() =>
+      expect(trigger.getAttribute("aria-expanded")).toBe("false"),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
+  it("selects a controlled single value and closes after selection", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ControlledSingleSelect onValueChange={onValueChange} />,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveTextContent("Email");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("SMS")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("SMS"));
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(onValueChange).toHaveBeenLastCalledWith("sms");
+  });
+
+  it("keeps controlled multi-select open after selection", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <ControlledMultiSelect onValueChange={onValueChange} />,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveTextContent("Email");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("SMS")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("EmailSMS"));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onValueChange).toHaveBeenLastCalledWith(["email", "sms"]);
+  });
+
+  it("derives multi-select behavior from an uncontrolled array defaultValue", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root defaultValue={["email"]} onValueChange={onValueChange}>
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    await user.click(getOptionByText("Push")!);
+
+    await waitFor(() => expect(trigger).toHaveTextContent("EmailPush"));
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(onValueChange).toHaveBeenLastCalledWith(["email", "push"]);
+  });
+
+  it("passes trigger, content, and options props through to Combobox", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Select.Root
+        defaultValue="email"
+        triggerProps={{ "data-select-trigger": true }}
+        contentProps={{ "data-select-content": true }}
+        optionsProps={{ "data-select-options": true, maxHeight: "64" }}
+      >
+        {renderSelectOptions()}
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    expect(trigger).toHaveAttribute("data-select-trigger", "true");
+
+    await user.click(trigger!);
+    await waitFor(() =>
+      expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+    );
+
+    const content = queryPortalElement("[data-tgph-combobox-content]");
+    const optionList = queryPortalElement('[role="listbox"]');
+
+    expect(content).toHaveAttribute("data-select-content", "true");
+    expect(optionList).toHaveAttribute("data-select-options", "true");
+    expect(optionList).toHaveStyle({
+      "--max-height": "var(--tgph-spacing-64)",
+    });
+  });
+
+  it("uses option children as the Combobox option label", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root defaultValue="email" onValueChange={onValueChange}>
+        <Select.Option value="email">Email</Select.Option>
+        <Select.Option value="sms">SMS label from children</Select.Option>
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await user.click(getOptionByText("SMS label from children")!);
+
+    await waitFor(() =>
+      expect(trigger).toHaveTextContent("SMS label from children"),
+    );
+    expect(onValueChange).toHaveBeenLastCalledWith("sms");
+  });
+
+  it("does not select disabled options", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    const { container } = render(
+      <Select.Root value="email" onValueChange={onValueChange}>
+        <Select.Option value="email">Email</Select.Option>
+        <Select.Option value="sms" disabled>
+          SMS
+        </Select.Option>
+      </Select.Root>,
+    );
+    const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+
+    await user.click(trigger!);
+    await user.click(getOptionByText("SMS")!);
+
+    expect(trigger).toHaveTextContent("Email");
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #847.
- Linear: [KNO-13675](https://linear.app/knock/issue/KNO-13675).

## What changed

- Adds Select integration tests around the migrated Combobox.
- Covers accessibility, controlled single-select close behavior, multi-select open behavior, option labels, disabled options, and prop passthrough.
- Documents that Select remains a lightweight wrapper over Combobox.
- Adds a patch changeset for `@telegraph/select`.

## Why

- Verifies the published Select wrapper remains compatible after Combobox moves onto Base UI-backed primitives.
- Keeps this PR verification-only so Select runtime behavior stays inherited from Combobox.

## Verification

- `yarn test packages/select/src/Select/Select.test.tsx packages/combobox/src/Combobox/Combobox.test.tsx`
- `yarn workspace @telegraph/select build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
