### PR TITLE
fix(tooltip): support published Tooltip consumers

### DIFF
--- a/.changeset/sharp-tooltips-sip.md
+++ b/.changeset/sharp-tooltips-sip.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/data-list": patch
+"@telegraph/tag": patch
+"@telegraph/tooltip": minor
+"@telegraph/truncate": patch
+---
+
+Verify published Tooltip consumers against the Base UI-backed implementation and preserve their trigger refs, optional tooltip labels, and Radix-compatible trigger state attributes. TooltipIfTruncated now documents and tests that an explicit `label` takes precedence over child text when both are provided.

--- a/packages/data-list/README.md
+++ b/packages/data-list/README.md
@@ -41,11 +41,11 @@ export const UserProfile = () => (
 
 Container component that wraps data list items.
 
-| Prop          | Type                   | Default    | Description                           |
-| ------------- | ---------------------- | ---------- | ------------------------------------- |
-| `direction`   | `"column" \| "row"`    | `"column"` | Layout direction of list items        |
-| `gap`         | `keyof tokens.spacing` | `"4"`      | Gap between list items                |
-| All Stack props | -                    | -          | Inherits all Stack component properties |
+| Prop            | Type                   | Default    | Description                             |
+| --------------- | ---------------------- | ---------- | --------------------------------------- |
+| `direction`     | `"column" \| "row"`    | `"column"` | Layout direction of list items          |
+| `gap`           | `keyof tokens.spacing` | `"4"`      | Gap between list items                  |
+| All Stack props | -                      | -          | Inherits all Stack component properties |
 
 ### `<DataList.Item>`
 
@@ -72,13 +72,17 @@ Row container for composing custom label-value layouts.
 
 Label component for displaying field names.
 
-| Prop        | Type                   | Default  | Description                     |
-| ----------- | ---------------------- | -------- | ------------------------------- |
-| `maxW`      | `keyof tokens.spacing` | `"36"`   | Maximum width of label          |
-| `maxH`      | `keyof tokens.spacing` | `"6"`    | Maximum height of label         |
-| `w`         | `keyof tokens.spacing` | `"full"` | Width of label                  |
-| `icon`      | `IconProps`            | -        | Optional icon to display        |
-| `textProps` | `TextProps`            | -        | Props to pass to Text component |
+| Prop           | Type                                          | Default     | Description                                          |
+| -------------- | --------------------------------------------- | ----------- | ---------------------------------------------------- |
+| `maxW`         | `keyof tokens.spacing`                        | `"36"`      | Maximum width of label                               |
+| `maxH`         | `keyof tokens.spacing`                        | `"6"`       | Maximum height of label                              |
+| `w`            | `keyof tokens.spacing`                        | `"full"`    | Width of label                                       |
+| `icon`         | `IconProps`                                   | -           | Optional icon to display                             |
+| `description`  | `React.ReactNode`                             | `undefined` | Tooltip content shown for label descriptions         |
+| `tooltipProps` | `Partial<TgphComponentProps<typeof Tooltip>>` | `undefined` | Props passed to the Base UI-backed Telegraph Tooltip |
+| `textProps`    | `TextProps`                                   | -           | Props to pass to Text component                      |
+
+`DataList.Label` uses the Base UI-backed `@telegraph/tooltip` package when `description` is provided. `tooltipProps` pass through to Tooltip, except `enabled` and `label`, which are controlled by DataList so labels without descriptions do not render tooltips.
 
 ### `<DataList.Value>`
 

--- a/packages/data-list/src/DataList/DataList.test.tsx
+++ b/packages/data-list/src/DataList/DataList.test.tsx
@@ -1,0 +1,58 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DataList } from "./DataList";
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DataList", () => {
+  it("shows label descriptions through the migrated Tooltip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DataList.Label
+        description="The unique identifier for this user"
+        tooltipProps={{ delayDuration: 0, skipAnimation: true }}
+      >
+        User ID
+      </DataList.Label>,
+    );
+
+    await user.hover(screen.getByText("User ID"));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "The unique identifier for this user",
+    );
+  });
+
+  it("keeps the label tooltip disabled without a description", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <DataList.Label tooltipProps={{ delayDuration: 0, skipAnimation: true }}>
+        User ID
+      </DataList.Label>,
+    );
+
+    await user.hover(screen.getByText("User ID"));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/tag/README.md
+++ b/packages/tag/README.md
@@ -71,16 +71,16 @@ export const TagExamples = () => (
 
 The main tag component with built-in interactive features.
 
-| Prop         | Type                | Default          | Description                         |
-| ------------ | ------------------- | ---------------- | ----------------------------------- |
-| `size`       | `"0" \| "1" \| "2"` | `"1"`            | Size of the tag                     |
-| `color`      | `TagColor`          | `"default"`      | Color scheme of the tag             |
-| `variant`    | `"soft" \| "solid"` | `"soft"`         | Visual style variant                |
-| `icon`       | `IconProps`         | `undefined`      | Icon to display at the start        |
-| `onRemove`   | `() => void`        | `undefined`      | Makes tag removable with X button   |
-| `onCopy`     | `(event: React.MouseEvent<HTMLButtonElement>) => void` | `undefined` | Adds copy button functionality |
-| `textToCopy` | `string`            | `undefined`      | Text to copy to clipboard |
-| `textProps`  | `TextProps`         | `{ maxW: "40" }` | Props passed to the text component  |
+| Prop         | Type                                                   | Default          | Description                        |
+| ------------ | ------------------------------------------------------ | ---------------- | ---------------------------------- |
+| `size`       | `"0" \| "1" \| "2"`                                    | `"1"`            | Size of the tag                    |
+| `color`      | `TagColor`                                             | `"default"`      | Color scheme of the tag            |
+| `variant`    | `"soft" \| "solid"`                                    | `"soft"`         | Visual style variant               |
+| `icon`       | `IconProps`                                            | `undefined`      | Icon to display at the start       |
+| `onRemove`   | `() => void`                                           | `undefined`      | Makes tag removable with X button  |
+| `onCopy`     | `(event: React.MouseEvent<HTMLButtonElement>) => void` | `undefined`      | Adds copy button functionality     |
+| `textToCopy` | `string`                                               | `undefined`      | Text to copy to clipboard          |
+| `textProps`  | `TextProps`                                            | `{ maxW: "40" }` | Props passed to the text component |
 
 #### TagColor Type
 
@@ -499,7 +499,7 @@ export const AnimatedTags = ({ tags, onRemove }) => (
 ### ARIA Attributes
 
 - Icons include proper `alt` attributes or `aria-hidden="true"`
-- Copy button includes tooltip with descriptive text
+- Copy button includes descriptive text through the Base UI-backed `@telegraph/tooltip` package
 - Remove button includes clear action description
 - Motion respects `prefers-reduced-motion` preference
 
@@ -539,19 +539,19 @@ Icon component with contextual styling.
 
 Remove button component.
 
-| Prop      | Type         | Default                     | Description               |
-| --------- | ------------ | --------------------------- | ------------------------- |
-| `onClick` | `(event: React.MouseEvent<HTMLButtonElement>) => void` | - | Click handler for removal |
-| `icon`    | `IconProps`  | `{ icon: X, alt: "close" }` | Button icon configuration |
+| Prop      | Type                                                   | Default                     | Description               |
+| --------- | ------------------------------------------------------ | --------------------------- | ------------------------- |
+| `onClick` | `(event: React.MouseEvent<HTMLButtonElement>) => void` | -                           | Click handler for removal |
+| `icon`    | `IconProps`                                            | `{ icon: X, alt: "close" }` | Button icon configuration |
 
 ### `<Tag.CopyButton>`
 
 Copy functionality button with animation.
 
-| Prop         | Type         | Default | Description               |
-| ------------ | ------------ | ------- | ------------------------- |
-| `onClick`    | `(event: React.MouseEvent<HTMLButtonElement>) => void` | - | Additional click handler |
-| `textToCopy` | `string`     | -       | Text to copy to clipboard |
+| Prop         | Type                                                   | Default | Description               |
+| ------------ | ------------------------------------------------------ | ------- | ------------------------- |
+| `onClick`    | `(event: React.MouseEvent<HTMLButtonElement>) => void` | -       | Additional click handler  |
+| `textToCopy` | `string`                                               | -       | Text to copy to clipboard |
 
 ## Examples
 

--- a/packages/tag/src/Tag/Tag.test.tsx
+++ b/packages/tag/src/Tag/Tag.test.tsx
@@ -1,5 +1,6 @@
-import { render } from "@testing-library/react";
-import { describe, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
 import { axe, expectToHaveNoViolations } from "vitest.axe";
 
 import { Tag } from "./Tag";
@@ -21,6 +22,20 @@ describe("Tag", () => {
     );
     const results = await axe(container);
     expectToHaveNoViolations(results);
+  });
+
+  it("shows the copy affordance tooltip through the migrated Tooltip", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Tag size="2" color="default" onCopy={() => {}}>
+        Copyable
+      </Tag>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Copy text" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Copy text");
   });
 
   describe("type inheritance", () => {

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -16,7 +16,14 @@ import { clsx } from "clsx";
 import { Check, Copy, X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
-import React from "react";
+import {
+  type ComponentProps,
+  type MouseEvent,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 
 import { COLOR, SIZE, SPACING, VARIANT, cssVars } from "./Tag.constants";
 
@@ -31,7 +38,7 @@ export type RootProps<T extends TgphElement = "span"> =
     Omit<TgphComponentProps<typeof Stack>, "as" | "tgphRef"> &
     RootBaseProps;
 
-const TagContext = React.createContext<Required<RootBaseProps>>({
+const TagContext = createContext<Required<RootBaseProps>>({
   size: "1",
   color: "default",
   variant: "soft",
@@ -90,7 +97,7 @@ const Text = <T extends TgphElement = "span">({
   style,
   ...props
 }: TextProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   return (
     <TelegraphText
       as={as}
@@ -121,11 +128,11 @@ export type CopyButtonProps = TgphComponentProps<
 };
 
 const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
 
-  const [copied, setCopied] = React.useState(false);
+  const [copied, setCopied] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (copied) {
       const timeout = setTimeout(() => setCopied(false), 2000);
       return () => clearTimeout(timeout);
@@ -136,8 +143,8 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
     <LazyMotion features={domAnimation}>
       <Tooltip label="Copy text">
         <TelegraphButton.Root
-          onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
-            // Still run onClick incase the consumer wants to do something else
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            // Still run onClick in case the consumer wants to do something else
             onClick?.(event);
             setCopied(true);
             if (textToCopy) {
@@ -162,8 +169,9 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
             animate={{ y: copied ? 0 : "150%", opacity: copied ? 1 : 1 }}
             transition={{ duration: 0.15, type: "spring", bounce: 0 }}
             icon={Check}
-            alt="Copied text"
-            aria-hidden={!copied}
+            {...(copied
+              ? { alt: "Copied text" }
+              : { "aria-hidden": true as const })}
           />
           <TelegraphButton.Icon
             as={motion.span}
@@ -172,8 +180,9 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
             transition={{ duration: 0.15, type: "spring", bounce: 0 }}
             icon={Copy}
             position="absolute"
-            alt="Copy text"
-            aria-hidden={copied}
+            {...(copied
+              ? { "aria-hidden": true as const }
+              : { alt: "Copy text" })}
           />
         </TelegraphButton.Root>
       </Tooltip>
@@ -182,7 +191,7 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
 };
 
 const Button = <T extends TgphElement>({ ...props }: ButtonProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   return (
     <TelegraphButton
       size={context.size}
@@ -207,7 +216,7 @@ const Icon = <T extends TgphElement = "span">({
   "aria-hidden": ariaHidden,
   ...props
 }: IconProps<T>) => {
-  const context = React.useContext(TagContext);
+  const context = useContext(TagContext);
   const a11yProps = !alt ? { "aria-hidden": ariaHidden } : { alt };
   return (
     <TelegraphIcon
@@ -223,12 +232,12 @@ const Icon = <T extends TgphElement = "span">({
 
 export type DefaultProps<T extends TgphElement = "span"> = PolymorphicProps<T> &
   TgphComponentProps<typeof Root<T>> & {
-    icon?: React.ComponentProps<typeof TelegraphIcon>;
-    textProps?: React.ComponentProps<typeof Text>;
+    icon?: ComponentProps<typeof TelegraphIcon>;
+    textProps?: ComponentProps<typeof Text>;
     onRemove?: () => void;
   } & ( // Optionally allow textToCopy only when onCopy is defined
     | {
-        onCopy: (event: React.MouseEvent<HTMLButtonElement>) => void;
+        onCopy: (event: MouseEvent<HTMLButtonElement>) => void;
         textToCopy?: string;
       }
     | {

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -82,7 +82,7 @@ The main tooltip component that wraps content and provides contextual informatio
 | `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
 | `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
 | `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                          |
-| `triggerRef`              | `RefObject<HTMLButtonElement>`           | `undefined` | Ref forwarded to the rendered trigger element                |
+| `triggerRef`              | `RefObject<HTMLElement \| null>`         | `undefined` | Ref forwarded to the rendered trigger element                |
 | `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
 | `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
 | `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -1,3 +1,4 @@
+import { Button } from "@telegraph/button";
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -283,6 +284,21 @@ describe("Tooltip", () => {
       transformOrigin: "var(--transform-origin)",
     });
     expect(container).not.toContainElement(content);
+  });
+
+  it("renders string labels around Telegraph triggers without dropping typography props", async () => {
+    render(
+      <Tooltip defaultOpen label="Telegraph trigger context" skipAnimation>
+        <Button>Hover target</Button>
+      </Tooltip>,
+    );
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Telegraph trigger context",
+    );
+    expect(
+      screen.getByRole("button", { name: "Hover target" }),
+    ).toHaveAttribute("data-state", "open");
   });
 
   it("preserves existing trigger descriptions when linking the tooltip", async () => {

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -13,6 +13,7 @@ import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
 import {
   Children,
+  type ComponentPropsWithRef,
   type ComponentPropsWithoutRef,
   type ReactNode,
   type RefObject,
@@ -31,6 +32,9 @@ type BaseTooltipProviderProps = ComponentPropsWithoutRef<
   typeof BaseTooltip.Provider
 >;
 type BaseTooltipTriggerProps = ComponentPropsWithoutRef<
+  typeof BaseTooltip.Trigger
+>;
+type BaseTooltipTriggerPropsWithRef = ComponentPropsWithRef<
   typeof BaseTooltip.Trigger
 >;
 type BaseTooltipPortalProps = ComponentPropsWithoutRef<
@@ -72,17 +76,23 @@ type LegacyTooltipRootProps = Omit<
   open?: BaseTooltipRootProps["open"];
 };
 
-type LegacyTooltipPositionerProps = Omit<
-  BaseTooltipPositionerProps,
-  "children" | "className" | "render" | "style"
+type LegacyTooltipPositionerProps = Partial<
+  Omit<
+    BaseTooltipPositionerProps,
+    "align" | "children" | "className" | "render" | "side" | "style"
+  >
 > & {
+  align?: BaseTooltipPositionerProps["align"];
   avoidCollisions?: boolean;
   hideWhenDetached?: boolean;
+  side?: BaseTooltipPositionerProps["side"];
 };
 
-type LegacyTooltipPopupProps = Omit<
-  BaseTooltipPopupProps,
-  "children" | "className" | "render" | "style"
+type LegacyTooltipPopupProps = Partial<
+  Omit<
+    BaseTooltipPopupProps,
+    "align" | "children" | "className" | "render" | "side" | "style"
+  >
 > & {
   "aria-label"?: BaseTooltipPopupProps["aria-label"];
   forceMount?: BaseTooltipPortalProps["keepMounted"];
@@ -94,7 +104,7 @@ type LegacyTooltipPopupProps = Omit<
 
 export type TooltipBaseProps<T extends TgphElement = "div"> = {
   children?: ReactNode;
-  label: ReactNode;
+  label?: ReactNode;
   labelProps?: TgphComponentProps<typeof Stack<T>>;
   enabled?: boolean;
   asChild?: boolean;
@@ -103,7 +113,7 @@ export type TooltipBaseProps<T extends TgphElement = "div"> = {
   disableFocusOpen?: boolean;
   skipAnimation?: boolean;
   style?: TgphComponentProps<typeof Stack<T>>["style"];
-  triggerRef?: RefObject<HTMLButtonElement>;
+  triggerRef?: RefObject<HTMLElement | null>;
 };
 
 export type TooltipProps<T extends TgphElement = "div"> =
@@ -212,6 +222,8 @@ const Tooltip = <T extends TgphElement = "div">({
     [existingAriaDescribedBy, resolvedOpen ? tooltipId : undefined]
       .filter(Boolean)
       .join(" ") || undefined;
+  const resolvedTriggerRef =
+    triggerRef as BaseTooltipTriggerPropsWithRef["ref"];
 
   const handleOpenChange = useCallback<
     NonNullable<BaseTooltipRootProps["onOpenChange"]>
@@ -278,7 +290,7 @@ const Tooltip = <T extends TgphElement = "div">({
               data-state={triggerDataState}
               delay={derivedDelayDuration}
               onFocus={handleFocus}
-              ref={triggerRef}
+              ref={resolvedTriggerRef}
               render={createTgphBaseUIRender(
                 cloneElement(children, {
                   "aria-describedby": triggerAriaDescribedBy,
@@ -292,7 +304,7 @@ const Tooltip = <T extends TgphElement = "div">({
               data-state={triggerDataState}
               delay={derivedDelayDuration}
               onFocus={handleFocus}
-              ref={triggerRef}
+              ref={resolvedTriggerRef}
             >
               {children}
             </BaseTooltip.Trigger>

--- a/packages/truncate/README.md
+++ b/packages/truncate/README.md
@@ -72,13 +72,13 @@ A text component that automatically truncates content with an ellipsis and shows
 
 A component that conditionally shows a tooltip only when its content is truncated.
 
-| Prop              | Type                                 | Default     | Description                                                                   |
-| ----------------- | ------------------------------------ | ----------- | ----------------------------------------------------------------------------- |
-| `label`           | `string \| ReactNode`                | `undefined` | The text to show in the tooltip. If not provided, will use the content's text |
-| `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                               |
-| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                     |
+| Prop              | Type                                 | Default     | Description                                                                                |
+| ----------------- | ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
+| `label`           | `string \| ReactNode`                | `undefined` | The text to show in the tooltip. When provided, it takes precedence over the child content |
+| `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                                            |
+| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                                  |
 
-`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It continues to pass tooltip props through unchanged and only enables the tooltip when `useTruncate` detects overflow.
+`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It measures the wrapped child with `useTruncate`, passes that same element ref to Tooltip as the trigger, and only enables the tooltip when overflow is detected. Tooltip props continue to pass through unchanged, including focus and hover behavior such as `disableFocusOpen`.
 
 ### `useTruncate`
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -64,6 +64,88 @@ describe("TooltipIfTruncated", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Long value");
   });
 
+  it("uses the explicit label when provided", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated
+        delayDuration={0}
+        label="Explicit tooltip label"
+        skipAnimation
+      >
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Visible value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Visible value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Explicit tooltip label",
+    );
+  });
+
+  it("uses React element child content as the tooltip label", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          <span>Element value</span>
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Element value" }));
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Element value",
+    );
+  });
+
+  it("opens from focus when truncated", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Focus value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "Focus value" })).toHaveFocus();
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Focus value");
+  });
+
+  it("can suppress focus-triggered open while preserving hover", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TooltipIfTruncated delayDuration={0} disableFocusOpen skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Hover only
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Hover only" });
+
+    await user.tab();
+
+    expect(trigger).toHaveFocus();
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    await user.hover(trigger);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Hover only");
+  });
+
   it("keeps the tooltip disabled when the child is not truncated", async () => {
     const user = userEvent.setup();
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -5,7 +5,7 @@ import {
 } from "@telegraph/helpers";
 import { Tooltip } from "@telegraph/tooltip";
 import { Text } from "@telegraph/typography";
-import { type ReactNode, type RefObject, isValidElement, useRef } from "react";
+import { type ReactNode, isValidElement, useRef } from "react";
 
 import { useTruncate } from "../useTruncate";
 
@@ -19,19 +19,16 @@ const TooltipIfTruncated = ({
   children,
   ...props
 }: TooltipIfTruncatedProps) => {
-  const truncateRef = useRef<HTMLButtonElement>(null);
-  const { truncated } = useTruncate(
-    { tgphRef: truncateRef as RefObject<HTMLElement> },
-    [children],
-  );
+  const truncateRef = useRef<HTMLElement>(null);
+  const { truncated } = useTruncate({ tgphRef: truncateRef }, [children]);
 
   const textToDisplayInTooltip = (() => {
+    if (label !== undefined) return label;
     if (typeof children === "string") return children;
     if (isValidElement(children)) {
       const childProps = children.props as Record<string, unknown>;
       return childProps.children;
     }
-    return label;
   })();
 
   return (
@@ -42,7 +39,7 @@ const TooltipIfTruncated = ({
         </Text>
       }
       enabled={truncated}
-      triggerRef={truncateRef as RefObject<HTMLButtonElement>}
+      triggerRef={truncateRef}
       {...props}
     >
       <RefToTgphRef>{children}</RefToTgphRef>


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #848.
- Linear: [KNO-13676](https://linear.app/knock/issue/KNO-13676).

## What changed

- Widens Tooltip trigger refs so published consumers can use non-button trigger elements safely.
- Updates `TooltipIfTruncated` to share the measured element ref with Tooltip.
- Fixes Tag copy button accessible naming around the copy/check icon state.
- Adds published-consumer tests and README updates for Tooltip, Truncate, Tag, and DataList.

## Why

- Verifies and fixes published Tooltip consumers after Tooltip moves onto Base UI.
- Keeps tooltip accessibility and ref behavior stable for real downstream package usage.

## Verification

- `yarn test packages/tooltip/src/Tooltip/Tooltip.test.tsx packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx packages/tag/src/Tag/Tag.test.tsx packages/data-list/src/DataList/DataList.test.tsx`
- `yarn workspace @telegraph/tooltip build`
- Stack-wide: `yarn install --immutable`, `yarn manypkg:check`, `yarn test`, `yarn build:packages`, `yarn lint`, `yarn build:storybook`, `git diff --check`
