### PR TITLE
test(migration): add stack-wide Base UI verification gates

### DIFF
--- a/.changeset/quiet-checkpoints-verify.md
+++ b/.changeset/quiet-checkpoints-verify.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/segmented-control": patch
+"@telegraph/tabs": patch
+---
+
+docs: update Base UI migration README references

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ yarn format
 yarn lint
 ```
 
+For Base UI migration checkpoint work, also run:
+
+```bash
+yarn check:base-ui-migration
+```
+
 ### Releasing
 
 We use [changesets](https://github.com/changesets/changesets) to manage releases. Each time a PR is opened, make sure to include a changeset. A changeset bot will add a comment to your PR prompting you to do so with a template, click that and commit it to your PR.

--- a/docs/base-ui-migration-stack-checkpoint.md
+++ b/docs/base-ui-migration-stack-checkpoint.md
@@ -1,0 +1,112 @@
+# Base UI Migration Stack Checkpoint
+
+Last updated: 2026-06-12
+
+## Purpose
+
+This document records the stack-wide checkpoint for KNO-13677 before the final Radix cleanup layer. It complements the PR description with a durable local record of what was checked, what remains, and which evidence should be re-used in the after action report.
+
+## Checkpoint Scope
+
+- React 18 compatibility across migrated packages.
+- Remaining Radix runtime imports, dependencies, compatibility variables, and historical/documentation references.
+- README coverage for packages touched by the migration stack.
+- Local package, test, lint, and Storybook validation.
+- Visual and functional Storybook checks in the Codex in-app Browser only, compared against the published baseline at `https://telegraph-storybook.vercel.app/`.
+
+## Repeatable Command
+
+Run:
+
+```sh
+yarn check:base-ui-migration
+```
+
+The command verifies:
+
+- all published packages that import React declare the expected React 18/19 peer range;
+- migrated Base UI packages declare the expected React DOM 18/19 peer range;
+- migrated package source avoids known React 19-only APIs;
+- published packages outside the intentionally unpublished `@telegraph/filter` package do not retain runtime `@radix-ui/*` imports or dependencies;
+- migrated package READMEs document Base UI implementation notes and do not keep stale Radix primitive references;
+- published Tooltip consumers still have package READMEs available for verification.
+
+## Current Radix Classification
+
+Runtime Radix imports/dependencies should be zero outside `@telegraph/filter`.
+
+Expected non-runtime references before final cleanup:
+
+- `packages/menu/src/Menu/Menu.tsx` maps Base UI positioning variables to Radix-compatible `--radix-popper-*` CSS custom properties for downstream style compatibility.
+- `packages/combobox/src/Combobox/Combobox.tsx` consumes those Radix-compatible popper variables to preserve the previous public styling contract.
+- `packages/menu/src/Menu/Menu.test.tsx` verifies the compatibility custom property mapping.
+- `packages/compose-refs` source and README retain attribution/docs for the original Radix compose-refs implementation.
+- `packages/helpers` docs retain external-library interop examples that mention Radix; these are documentation examples, not Telegraph runtime dependencies.
+- package changelogs retain historical dependency update entries.
+- `@telegraph/filter` remains out of scope because it is not published.
+
+## Storybook Coverage Plan
+
+Use one local Storybook server only. Build affected packages before browser checks, start Storybook with `yarn dev:storybook`, and stop it after evidence is captured.
+
+Compare local `http://localhost:3005/iframe.html?...` stories against published baseline `https://telegraph-storybook.vercel.app/iframe.html?...` for:
+
+- Appearance and Input Slot-backed stories.
+- Tabs default, controlled, force-mounted, disabled, and overflow/menu states.
+- RadioCards default, controlled, disabled, and keyboard states.
+- Popover default, placements, controlled, nested, and close behavior.
+- Tooltip default/open/placement states and downstream consumers in Truncate, Tag, and DataList.
+- Menu default, grouped, checkbox/radio, nested submenu, disabled, and portal positioning states.
+- SegmentedControl single, multiple, disabled, vertical, and overflow states.
+- Toggle default, checked, disabled, icon, and form states.
+- Modal default, controlled, nested stacking, focus return, and dismiss states.
+- Combobox single, multi, clearable, search, empty, create, legacy, and controlled-open states.
+- Select single, multi, clearable, disabled, and keyboard states.
+
+## Evidence Ledger
+
+Completed locally for KNO-13677:
+
+- `yarn check:base-ui-migration`: passed. Reported zero runtime `@radix-ui` imports outside `@telegraph/filter`, zero `@radix-ui` package dependencies outside `@telegraph/filter`, zero stale migrated README Radix references, zero missing Base UI README notes, and zero Tooltip consumer README failures.
+- `yarn check:react18`: passed through the same checkpoint script. This verifies React peer ranges, React DOM peer ranges for migrated packages, and absence of known React 19-only source API usage outside the unpublished Filter package.
+- Runtime Radix import scan: `rg -n "from [\"']@radix-ui|require\\([\"']@radix-ui|import\\([\"']@radix-ui" packages --glob 'src/**/*.{ts,tsx,js,jsx}'` returned no matches.
+- Radix package dependency scan: `rg -n '"@radix-ui/' packages/*/package.json package.json` returned no matches.
+- Broad non-changelog Radix scan: remaining matches are Radix-compatible popper CSS custom properties in Menu/Combobox, helper attribution/docs, Tokens' Radix Colors reference, and helper README external-library examples.
+- README audit: Tabs and SegmentedControl references were updated from Radix primitive links to Base UI primitive links. Toggle README now explicitly documents that it no longer depends on Radix.
+- `yarn manypkg:check`: passed.
+- `git diff --check`: passed.
+- Prettier check for changed files: passed.
+- React/TypeScript best-practices audit for changed code: passed. This PR adds a JavaScript checkpoint script and docs only; the script uses const arrow helpers, avoids default React namespace usage, avoids TypeScript interfaces/enums, and does not touch TS/TSX component source.
+- `yarn test`: passed. 31 test files, 413 tests.
+- `yarn build:packages`: exited 0. It still prints inherited declaration-generator diagnostics in unrelated existing packages (`nextjs`, `style-engine`, `link`, `tabs`, and unpublished `filter`), but all 31 package build tasks completed successfully.
+- `yarn lint`: passed. 30 package lint tasks successful.
+- `yarn build:storybook`: passed. Empty CSS warnings for Combobox, Tag, and Tooltip are expected because those packages currently emit empty package CSS.
+- Storybook dev no-open smoke test: `storybook dev -p 3005 --no-open --exact-port --ci --smoke-test --no-version-updates --disable-telemetry --loglevel warn` passed when allowed to bind the local port.
+- Storybook visual and DOM parity evidence: captured in `/private/tmp/telegraph-stack-checkpoint-kno-13677`.
+
+Browser evidence files:
+
+- `browser-state.json`: local and published state captures for the desktop visual matrix.
+- `browser-mobile-state.json`: local and published state captures for mobile-width dense stories.
+- `portal-checks.json`: local and published portal/open-state checks for Menu, Modal, Combobox, Select, and Popover.
+- `keyboard-checks.json`: local Escape-key checks for Menu, Modal, Combobox, Select, and Popover.
+- `local-*.png` and `published-*.png`: screenshot pairs captured with the Codex in-app Browser only.
+
+Visual coverage completed:
+
+- Desktop local/published screenshot pairs: Input leading icon, Tooltip default, Popover default open, TruncatedText custom tooltip story, Tag default, DataList default, Tabs second tab, RadioCards option 2, Menu default open, Menu submenu root open, SegmentedControl center selected, Toggle checked, Modal open, Combobox open, and Select open.
+- Mobile local/published screenshot pairs: SegmentedControl scrollable, Combobox multi-select wrap layout, and Modal open.
+- Manual visual inspection found the representative local/published pairs aligned for Menu, Combobox, Modal, mobile SegmentedControl, and mobile Combobox.
+
+Functional and accessibility smoke evidence:
+
+- Tabs: second tab selected and second panel visible.
+- RadioCards: second radio checked.
+- SegmentedControl: center option pressed.
+- Toggle: checkbox checked through the visible label.
+- Menu: `role="menu"` opens with expected menu items; Escape closes and returns focus to the trigger.
+- Modal: `role="dialog"` opens in a portaled `.tgph` surface; Escape closes and returns focus to the opener.
+- Combobox and Select: open state exposes `role="listbox"` with expected options; Escape closes the listbox.
+- Popover: open state exposes `role="dialog"`; Escape flips trigger `aria-expanded` to `false` and unmounts after the exit animation.
+
+CI and BugBot/watch status: pending until the PR is submitted.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "lint": "turbo lint --filter=\"./packages/**\" --filter=\"!@telegraph/prettier-config\"",
     "format": "turbo format",
     "format:check": "turbo format:check",
+    "check:base-ui-migration": "node ./scripts/check-base-ui-migration.mjs",
+    "check:react18": "node ./scripts/check-base-ui-migration.mjs",
     "dev:storybook": "storybook dev --port 3005 --no-open --exact-port",
     "build:storybook": "storybook build",
     "release": "yarn release:publish && yarn changeset tag",

--- a/packages/segmented-control/README.md
+++ b/packages/segmented-control/README.md
@@ -601,7 +601,7 @@ export const ProjectSettingsForm = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/segmented-control)
-- [Radix UI Toggle Group](https://www.radix-ui.com/primitives/docs/components/toggle-group)
+- [Base UI Toggle Group](https://base-ui.com/react/components/toggle-group)
 
 ## Contributing
 

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -779,7 +779,7 @@ export const MediaLibrary = () => {
 ## References
 
 - [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/tabs)
-- [Radix UI Tabs](https://www.radix-ui.com/primitives/docs/components/tabs) - Base primitive
+- [Base UI Tabs](https://base-ui.com/react/components/tabs) - Base primitive
 
 ## Contributing
 

--- a/packages/toggle/README.md
+++ b/packages/toggle/README.md
@@ -66,9 +66,10 @@ The default Toggle component provides a simple API for common use cases.
 Additionally, all native HTML input attributes are supported (`aria-label`, `aria-describedby`, etc.)
 
 `Toggle` owns its controlled/uncontrolled state and visually hidden input
-styling locally. It still renders a native checkbox for form submission,
-validation, keyboard interaction, and screen reader semantics while the visible
-switch, label, and indicator remain Telegraph components.
+styling locally and no longer depends on Radix. It still renders a native
+checkbox for form submission, validation, keyboard interaction, and screen
+reader semantics while the visible switch, label, and indicator remain Telegraph
+components.
 
 ### Composition API
 

--- a/scripts/check-base-ui-migration.mjs
+++ b/scripts/check-base-ui-migration.mjs
@@ -1,0 +1,528 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const rootDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const packagesDir = path.join(rootDir, "packages");
+const expectedReactPeerRange = "^18.0.0 || ^19.0.0";
+
+const migratedRuntimePackages = new Set([
+  "combobox",
+  "menu",
+  "modal",
+  "popover",
+  "radio",
+  "segmented-control",
+  "select",
+  "tabs",
+  "toggle",
+  "tooltip",
+]);
+
+const publishedTooltipConsumerPackages = new Set([
+  "data-list",
+  "tag",
+  "truncate",
+]);
+
+const outOfScopePackages = new Set(["filter"]);
+
+const ignoredDirectoryNames = new Set([
+  ".turbo",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+]);
+
+const sourceExtensions = new Set([
+  ".ts",
+  ".tsx",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".cjs",
+]);
+const readmeFileName = "README.md";
+
+const react19OnlyApis = [
+  "addTransitionType",
+  "cache",
+  "cacheSignal",
+  "preconnect",
+  "preinit",
+  "preinitModule",
+  "preload",
+  "preloadModule",
+  "requestFormReset",
+  "resume",
+  "resumeAndPrerender",
+  "resumeToPipeableStream",
+  "use",
+  "useActionState",
+  "useEffectEvent",
+  "useFormState",
+  "useFormStatus",
+  "useOptimistic",
+];
+
+const pathExists = async (targetPath) => {
+  try {
+    await stat(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const readJson = async (filePath) => {
+  const contents = await readFile(filePath, "utf8");
+  return JSON.parse(contents);
+};
+
+const listFiles = async (dirPath) => {
+  if (!(await pathExists(dirPath))) {
+    return [];
+  }
+
+  const entries = await readdir(dirPath, { withFileTypes: true });
+  const nestedEntries = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dirPath, entry.name);
+
+      if (entry.isDirectory()) {
+        return ignoredDirectoryNames.has(entry.name)
+          ? []
+          : listFiles(entryPath);
+      }
+
+      return entry.isFile() ? [entryPath] : [];
+    }),
+  );
+
+  return nestedEntries.flat();
+};
+
+const getPackageRecords = async () => {
+  const entries = await readdir(packagesDir, { withFileTypes: true });
+  const packageDirs = entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(packagesDir, entry.name));
+
+  return Promise.all(
+    packageDirs.map(async (packageDir) => {
+      const packageJsonPath = path.join(packageDir, "package.json");
+      const packageJson = await readJson(packageJsonPath);
+      const packageName = path.basename(packageDir);
+      const packageFiles = await listFiles(packageDir);
+      const sourceFiles = packageFiles.filter((filePath) => {
+        return (
+          filePath.startsWith(path.join(packageDir, "src")) &&
+          sourceExtensions.has(path.extname(filePath))
+        );
+      });
+
+      return {
+        packageDir,
+        packageJson,
+        packageJsonPath,
+        packageName,
+        sourceFiles,
+      };
+    }),
+  );
+};
+
+const relativePath = (filePath) => path.relative(rootDir, filePath);
+
+const isPublishedPackage = ({ packageJson, packageName }) => {
+  return !packageJson.private && !outOfScopePackages.has(packageName);
+};
+
+const containsReactImport = (contents) => {
+  return (
+    /from\s+["']react["']/.test(contents) ||
+    /require\(["']react["']\)/.test(contents)
+  );
+};
+
+const containsReactDomImport = (contents) => {
+  return (
+    /from\s+["']react-dom(?:\/client)?["']/.test(contents) ||
+    /require\(["']react-dom(?:\/client)?["']\)/.test(contents)
+  );
+};
+
+const containsRuntimeRadixImport = (contents) => {
+  return (
+    /from\s+["']@radix-ui\//.test(contents) ||
+    /require\(["']@radix-ui\//.test(contents) ||
+    /import\(["']@radix-ui\//.test(contents)
+  );
+};
+
+const matchesExpectedReactPeerRange = (range) => {
+  return range === expectedReactPeerRange;
+};
+
+const getMatchingLines = (contents, matcher) => {
+  return contents.split(/\r?\n/).flatMap((line, index) => {
+    return matcher(line)
+      ? [
+          {
+            lineNumber: index + 1,
+            text: line.trim(),
+          },
+        ]
+      : [];
+  });
+};
+
+const escapeRegExp = (value) => {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+};
+
+const getLineMatchAtIndex = (contents, index) => {
+  const lineNumber = contents.slice(0, index).split(/\r?\n/).length;
+  const text = contents.split(/\r?\n/)[lineNumber - 1]?.trim() ?? "";
+
+  return {
+    lineNumber,
+    text,
+  };
+};
+
+const getRegexMatches = (contents, matcher, getMatchIndex) => {
+  return Array.from(contents.matchAll(matcher)).map((match) => {
+    return getLineMatchAtIndex(contents, getMatchIndex(match));
+  });
+};
+
+const findReact19ApiMatches = (filePath, contents) => {
+  return react19OnlyApis.flatMap((apiName) => {
+    const escapedApiName = escapeRegExp(apiName);
+    const reactImportMatcher = new RegExp(
+      `import\\s*\\{[^}]*\\b${escapedApiName}\\b[^}]*\\}\\s*from\\s*["']react["']`,
+      "g",
+    );
+    const reactDomImportMatcher = new RegExp(
+      `import\\s*\\{[^}]*\\b${escapedApiName}\\b[^}]*\\}\\s*from\\s*["']react-dom(?:/client)?["']`,
+      "g",
+    );
+    const reactNamespaceMatcher = new RegExp(`\\bReact\\.${escapedApiName}\\b`);
+    const reactDomNamespaceMatcher = new RegExp(
+      `\\bReactDOM\\.${escapedApiName}\\b`,
+    );
+    const apiNameMatcher = new RegExp(`\\b${escapedApiName}\\b`);
+    const getApiMatchIndex = (match) => {
+      const apiIndex = match[0].search(apiNameMatcher);
+
+      return (match.index ?? 0) + Math.max(apiIndex, 0);
+    };
+
+    return [
+      ...getRegexMatches(contents, reactImportMatcher, getApiMatchIndex),
+      ...getRegexMatches(contents, reactDomImportMatcher, getApiMatchIndex),
+      ...getMatchingLines(contents, (line) => {
+        return (
+          reactNamespaceMatcher.test(line) ||
+          reactDomNamespaceMatcher.test(line)
+        );
+      }),
+    ].map((match) => ({
+      ...match,
+      apiName,
+      filePath,
+    }));
+  });
+};
+
+const getPackageSourceUsage = async (record) => {
+  const sourceFileContents = await Promise.all(
+    record.sourceFiles.map(async (filePath) => ({
+      contents: await readFile(filePath, "utf8"),
+      filePath,
+    })),
+  );
+
+  return {
+    importsReact: sourceFileContents.some(({ contents }) =>
+      containsReactImport(contents),
+    ),
+    importsReactDom: sourceFileContents.some(({ contents }) =>
+      containsReactDomImport(contents),
+    ),
+    react19ApiMatches: sourceFileContents.flatMap(({ contents, filePath }) =>
+      findReact19ApiMatches(filePath, contents),
+    ),
+    runtimeRadixImportMatches: sourceFileContents.flatMap(
+      ({ contents, filePath }) =>
+        getMatchingLines(contents, containsRuntimeRadixImport).map((match) => ({
+          ...match,
+          filePath,
+        })),
+    ),
+  };
+};
+
+const getDependencyNames = (packageJson, dependencyKey) => {
+  return Object.keys(packageJson[dependencyKey] ?? {});
+};
+
+const getRadixDependencyMatches = (record) => {
+  return ["dependencies", "peerDependencies", "devDependencies"].flatMap(
+    (dependencyKey) => {
+      return getDependencyNames(record.packageJson, dependencyKey)
+        .filter((dependencyName) => dependencyName.startsWith("@radix-ui/"))
+        .map((dependencyName) => ({
+          dependencyKey,
+          dependencyName,
+          filePath: record.packageJsonPath,
+        }));
+    },
+  );
+};
+
+const getReadmeAudit = async (record) => {
+  const readmePath = path.join(record.packageDir, readmeFileName);
+
+  if (!(await pathExists(readmePath))) {
+    return {
+      baseUiMentions: false,
+      radixMatches: [],
+      readmeExists: false,
+      readmePath,
+    };
+  }
+
+  const contents = await readFile(readmePath, "utf8");
+
+  return {
+    baseUiMentions: /Base UI/i.test(contents),
+    radixMatches: getMatchingLines(contents, (line) => /radix/i.test(line)).map(
+      (match) => ({
+        ...match,
+        filePath: readmePath,
+      }),
+    ),
+    readmeExists: true,
+    readmePath,
+  };
+};
+
+const isAllowedReadmeRadixReference = (match) => {
+  return /Radix-compatible|--radix-|no longer depends on Radix|does not depend on Radix|Radix-style prop names/i.test(
+    match.text,
+  );
+};
+
+const packageUsesBaseUi = (record) => {
+  return Boolean(record.packageJson.dependencies?.["@base-ui/react"]);
+};
+
+const formatFileMatch = ({
+  apiName,
+  dependencyKey,
+  dependencyName,
+  filePath,
+  lineNumber,
+  text,
+}) => {
+  const location = lineNumber
+    ? `${relativePath(filePath)}:${lineNumber}`
+    : relativePath(filePath);
+  const detail = apiName
+    ? `React 19-only API ${apiName}`
+    : dependencyName
+      ? `${dependencyKey} ${dependencyName}`
+      : text;
+
+  return `${location} - ${detail}`;
+};
+
+const printSection = (title, lines) => {
+  console.log(`\n${title}`);
+  console.log("-".repeat(title.length));
+  lines.forEach((line) => console.log(line));
+};
+
+const main = async () => {
+  const packageRecords = await getPackageRecords();
+  const packageUsages = await Promise.all(
+    packageRecords.map(async (record) => ({
+      record,
+      readmeAudit: await getReadmeAudit(record),
+      sourceUsage: await getPackageSourceUsage(record),
+    })),
+  );
+
+  const publishedReactPeerFailures = packageUsages.flatMap(
+    ({ record, sourceUsage }) => {
+      if (!isPublishedPackage(record) || !sourceUsage.importsReact) {
+        return [];
+      }
+
+      return matchesExpectedReactPeerRange(
+        record.packageJson.peerDependencies?.react,
+      )
+        ? []
+        : [
+            `${record.packageJson.name} must declare peerDependencies.react as ${expectedReactPeerRange}`,
+          ];
+    },
+  );
+
+  const publishedReactDomPeerFailures = packageUsages.flatMap(
+    ({ record, sourceUsage }) => {
+      if (!isPublishedPackage(record) || !sourceUsage.importsReactDom) {
+        return [];
+      }
+
+      return matchesExpectedReactPeerRange(
+        record.packageJson.peerDependencies?.["react-dom"],
+      )
+        ? []
+        : [
+            `${record.packageJson.name} must declare peerDependencies.react-dom as ${expectedReactPeerRange}`,
+          ];
+    },
+  );
+
+  const migratedReactDomPeerFailures = packageUsages.flatMap(({ record }) => {
+    if (!migratedRuntimePackages.has(record.packageName)) {
+      return [];
+    }
+
+    return matchesExpectedReactPeerRange(
+      record.packageJson.peerDependencies?.["react-dom"],
+    )
+      ? []
+      : [
+          `${record.packageJson.name} must declare peerDependencies.react-dom as ${expectedReactPeerRange}`,
+        ];
+  });
+
+  const react19ApiMatches = packageUsages.flatMap(({ record, sourceUsage }) => {
+    return outOfScopePackages.has(record.packageName)
+      ? []
+      : sourceUsage.react19ApiMatches;
+  });
+
+  const runtimeRadixImportMatches = packageUsages.flatMap(
+    ({ record, sourceUsage }) => {
+      return outOfScopePackages.has(record.packageName)
+        ? []
+        : sourceUsage.runtimeRadixImportMatches;
+    },
+  );
+
+  const radixDependencyMatches = packageUsages.flatMap(({ record }) => {
+    return outOfScopePackages.has(record.packageName)
+      ? []
+      : getRadixDependencyMatches(record);
+  });
+
+  const staleMigratedReadmeRadixMatches = packageUsages.flatMap(
+    ({ record, readmeAudit }) => {
+      if (!migratedRuntimePackages.has(record.packageName)) {
+        return [];
+      }
+
+      return readmeAudit.radixMatches
+        .filter((match) => !isAllowedReadmeRadixReference(match))
+        .map((match) => ({
+          ...match,
+          packageName: record.packageName,
+        }));
+    },
+  );
+
+  const missingMigratedReadmeBaseUiMentions = packageUsages.flatMap(
+    ({ record, readmeAudit }) => {
+      if (!migratedRuntimePackages.has(record.packageName)) {
+        return [];
+      }
+
+      return readmeAudit.baseUiMentions || !packageUsesBaseUi(record)
+        ? []
+        : [
+            `${record.packageJson.name} README should mention Base UI implementation details`,
+          ];
+    },
+  );
+
+  const tooltipConsumerReadmeFailures = packageUsages.flatMap(
+    ({ record, readmeAudit }) => {
+      if (!publishedTooltipConsumerPackages.has(record.packageName)) {
+        return [];
+      }
+
+      return readmeAudit.readmeExists
+        ? []
+        : [
+            `${record.packageJson.name} must keep a README after tooltip-consumer verification`,
+          ];
+    },
+  );
+
+  const failures = [
+    ...publishedReactPeerFailures,
+    ...publishedReactDomPeerFailures,
+    ...migratedReactDomPeerFailures,
+    ...react19ApiMatches.map(formatFileMatch),
+    ...runtimeRadixImportMatches.map(formatFileMatch),
+    ...radixDependencyMatches.map(formatFileMatch),
+    ...staleMigratedReadmeRadixMatches.map(formatFileMatch),
+    ...missingMigratedReadmeBaseUiMentions,
+    ...tooltipConsumerReadmeFailures,
+  ];
+
+  const migratedPackageNames = [...migratedRuntimePackages]
+    .map((packageName) => `@telegraph/${packageName}`)
+    .sort();
+  const publishedConsumerNames = [...publishedTooltipConsumerPackages]
+    .map((packageName) => `@telegraph/${packageName}`)
+    .sort();
+
+  printSection("React 18 compatibility scope", [
+    `Expected peer range: ${expectedReactPeerRange}`,
+    `Migrated packages checked: ${migratedPackageNames.join(", ")}`,
+    `Published tooltip consumers checked: ${publishedConsumerNames.join(", ")}`,
+    "Checks: peer dependency range, React 19-only API usage, and package README migration notes.",
+  ]);
+
+  printSection("Radix runtime scan", [
+    `Runtime @radix-ui imports outside @telegraph/filter: ${runtimeRadixImportMatches.length}`,
+    `@radix-ui package dependencies outside @telegraph/filter: ${radixDependencyMatches.length}`,
+    "@telegraph/filter remains intentionally out of published-scope cleanup.",
+  ]);
+
+  printSection("README migration audit", [
+    `Stale migrated-package Radix README references: ${staleMigratedReadmeRadixMatches.length}`,
+    `Migrated-package READMEs missing Base UI notes: ${missingMigratedReadmeBaseUiMentions.length}`,
+    `Tooltip consumer README failures: ${tooltipConsumerReadmeFailures.length}`,
+  ]);
+
+  if (failures.length > 0) {
+    printSection(
+      "Failures",
+      failures.map((failure) => `- ${failure}`),
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  printSection("Result", ["Base UI migration checkpoint checks passed."]);
+};
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}
+
+export { findReact19ApiMatches };


### PR DESCRIPTION
## Stack context

- Part of the Telegraph Radix to Base UI migration stack.
- Parent PR: #849.
- Linear: [KNO-13677](https://linear.app/knock/issue/KNO-13677).

## What changed

- Added `yarn check:base-ui-migration` and `yarn check:react18` checkpoint commands backed by `scripts/check-base-ui-migration.mjs`.
- Added a stack checkpoint report for Radix cleanup classification, React 18 support, Storybook visual evidence, and CI/review state.
- Updated the root README and affected package READMEs so migration docs point at Base UI where relevant.
- Added a changeset for README updates.

## Why

- Gives the stack repeatable local gates for React peer support, Radix runtime import cleanup, package dependency cleanup, and migration documentation.
- Captures visual and functional parity evidence before the final cleanup PR.
- Makes the migration easier to review as a stack instead of as isolated component rewrites.

## Verification

- `yarn check:base-ui-migration`.
- `yarn check:react18`.
- `yarn manypkg:check`.
- `git diff --check`.
- `yarn test`.
- `yarn build:packages`.
- `yarn lint`.
- `yarn build:storybook`.
- Storybook dev no-open smoke test on port 3005.
- Codex in-app Browser local-vs-published Storybook screenshot and functional/keyboard matrix captured at `/private/tmp/telegraph-stack-checkpoint-kno-13677`.
