### PR TITLE
docs(migration): finalize Radix cleanup

### DIFF
--- a/.changeset/neat-fireflies-clean.md
+++ b/.changeset/neat-fireflies-clean.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/helpers": patch
+---
+
+docs: update helper examples for Base UI migration

--- a/docs/base-ui-migration-final-cleanup.md
+++ b/docs/base-ui-migration-final-cleanup.md
@@ -1,0 +1,71 @@
+# Base UI Migration Final Cleanup
+
+Last updated: 2026-06-12
+
+## Purpose
+
+This document records the final Radix cleanup audit for KNO-13678. It should be used with the PR description and the KNO-13677 checkpoint doc when preparing the project after-action report.
+
+## Direct Dependency And Runtime Import Result
+
+- Runtime source import scan for `@radix-ui/*` across package source returned no matches.
+- Direct package manifest and lockfile scan for `@radix-ui/*` returned no matches.
+- `@telegraph/filter` remains ignored for published migration scope because it is not published.
+
+## Remaining Radix Reference Classification
+
+The remaining `radix` matches are intentionally retained or historical:
+
+- `packages/menu/src/Menu/Menu.tsx`, `packages/menu/src/Menu/Menu.test.tsx`, `packages/menu/README.md`, and `packages/combobox/src/Combobox/Combobox.tsx` retain `--radix-popper-*` CSS custom property names as an explicit compatibility contract for downstream styles.
+- `packages/radio/src/RadioCards/RadioCards.tsx`, `packages/radio/src/RadioCards/RadioCards.test.tsx`, and `packages/tabs/src/Tabs/Tabs.test.tsx` retain Radix-compatible API/state wording because the migration intentionally keeps those public contracts while using Base UI internally.
+- `packages/combobox/README.md`, `packages/select/README.md`, `packages/toggle/README.md`, and `packages/tooltip/README.md` retain short compatibility/no-longer-depends notes that document the migration outcome for consumers.
+- `packages/compose-refs/src/compose-refs.ts` and `packages/compose-refs/README.md` retain source attribution for the original compose-refs implementation.
+- `packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx` retains one source attribution link for the original Slot merge behavior. The source comments and published README examples were updated away from Radix-specific integration guidance.
+- `packages/tokens/README.md` retains a Radix Colors reference as design-token/color-system context, not component implementation guidance.
+- Package changelogs retain historical dependency update entries.
+- Migration docs, including this file and the KNO-13677 checkpoint, retain Radix mentions only to document audit commands, migration evidence, and accepted compatibility exceptions.
+
+## Final Documentation Changes
+
+- `packages/helpers/README.md` now uses Base UI examples for the active render-bridge guidance instead of old `@radix-ui/react-popover` and `@radix-ui/react-dialog` examples.
+- `packages/helpers/README.md` now describes `RefToTgphRef` as a generic external-library bridge and keeps `createTgphBaseUIRender` as the preferred Base UI integration path.
+
+## Final Verification Evidence
+
+Completed locally for KNO-13678:
+
+- `rg "@radix-ui|radix"` was run case-insensitively across packages, docs, root metadata, and `yarn.lock`, excluding changelogs/dist/node_modules. All active matches align with the classification above.
+- Runtime source import scan for `@radix-ui/*`: no matches.
+- Direct manifest and lockfile scan for `@radix-ui/*`: no matches.
+- `yarn install --immutable`: passed with existing peer warning noise for root `postcss`/`vite`.
+- `yarn check:base-ui-migration`: passed.
+- `yarn check:react18`: passed.
+- Prettier check for changed files: passed.
+- `git diff --check`: passed.
+- React/TypeScript best-practices audit for changed code: passed. The only changed TSX lines are source comments in `RefToTgphRef`; no implementation code patterns were added.
+- `yarn test`: passed. 31 test files, 413 tests.
+- `yarn build:packages`: exited 0. It still prints inherited declaration-generator diagnostics in existing packages (`nextjs`, `style-engine`, `link`, `tabs`, and unpublished `filter`), but all 31 package build tasks completed successfully.
+- `yarn lint`: passed. 30 package lint tasks successful.
+- `yarn build:storybook`: passed. Empty CSS warnings for Combobox, Tag, and Tooltip are expected because those packages currently emit empty package CSS.
+
+## Final Storybook Smoke Evidence
+
+Browser evidence was captured with the Codex in-app Browser only and a single local static Storybook preview server on port 3005. The local server was stopped after verification and port 3005 was confirmed clear.
+
+Evidence files:
+
+- `/private/tmp/telegraph-final-cleanup-kno-13678/storybook-dom-smoke-results.json`
+- `/private/tmp/telegraph-final-cleanup-kno-13678/storybook-targeted-dom-results.json`
+- `/private/tmp/telegraph-final-cleanup-kno-13678/tooltip-hover-results.json`
+
+Local and published baseline checks completed:
+
+- Popover default story rendered one open `role="dialog"` locally and in the published baseline.
+- Menu default trigger opened one `role="menu"` with four `role="menuitem"` elements locally and in the published baseline.
+- Modal trigger opened one `role="dialog"` locally and in the published baseline.
+- Combobox single-select trigger opened one `role="listbox"` with five `role="option"` elements locally and in the published baseline.
+- Select single-select trigger opened one `role="listbox"` with two `role="option"` elements locally and in the published baseline.
+- SegmentedControl Center option became selected locally and in the published baseline. Local uses `aria-pressed="true"`; the published baseline uses `data-state="on"` with `role="radio"`.
+- Tooltip local `Open` story rendered one `role="tooltip"`. Published baseline hover on the default story rendered one `role="tooltip"`.
+
+The in-app Browser screenshot API repeatedly timed out on `Page.captureScreenshot`, including with clipped viewport captures and after reconnecting the Browser session. No Chrome or alternate browser was used. Because KNO-13678 only changes docs/comments, final visual confidence relies on the KNO-13677 screenshot matrix plus this final DOM/ARIA smoke pass.

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -232,39 +232,38 @@ const CustomButton = ({
 
 ### `RefToTgphRef`
 
-Component for handling ref forwarding between external libraries (like Radix) and Telegraph components.
+Component for handling ref forwarding between external libraries and Telegraph
+components.
 
 ```tsx
-import * as Popover from "@radix-ui/react-popover";
 import { Button } from "@telegraph/button";
 import { RefToTgphRef } from "@telegraph/helpers";
 
-// Radix expects a `ref` prop, but Telegraph uses `tgphRef`
-<Popover.Trigger asChild>
-  <RefToTgphRef>
-    <Button>Open Popover</Button>
-  </RefToTgphRef>
-</Popover.Trigger>;
+// Use when an external primitive passes a React `ref` to a single child,
+// but the Telegraph child expects `tgphRef`.
+<RefToTgphRef>
+  <Button>Open</Button>
+</RefToTgphRef>;
 ```
 
 #### Use Cases
 
-**With Radix UI Primitives:**
+**With Base UI render props:**
 
 ```tsx
-import * as Dialog from "@radix-ui/react-dialog";
+import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
-import { RefToTgphRef } from "@telegraph/helpers";
+import { createTgphBaseUIRender } from "@telegraph/helpers";
 
-const DialogExample = () => (
-  <Dialog.Root>
-    <Dialog.Trigger asChild>
-      <RefToTgphRef>
-        <Button>Open Dialog</Button>
-      </RefToTgphRef>
-    </Dialog.Trigger>
-    <Dialog.Content>{/* Dialog content */}</Dialog.Content>
-  </Dialog.Root>
+const PopoverExample = () => (
+  <Popover.Root>
+    <Popover.Trigger render={createTgphBaseUIRender(<Button>Open</Button>)} />
+    <Popover.Portal>
+      <Popover.Positioner>
+        <Popover.Popup>{/* Popover content */}</Popover.Popup>
+      </Popover.Positioner>
+    </Popover.Portal>
+  </Popover.Root>
 );
 ```
 
@@ -583,32 +582,6 @@ const Card = ({ variant, children, ...props }: CardProps) => {
 ### Integration with External Libraries
 
 ```tsx
-import * as RadixPopover from "@radix-ui/react-popover";
-import { Button } from "@telegraph/button";
-import { PolymorphicProps, RefToTgphRef } from "@telegraph/helpers";
-
-type PopoverProps = PolymorphicProps<"div"> & {
-  trigger: React.ReactNode;
-  content: React.ReactNode;
-};
-
-const Popover = ({ trigger, content, ...props }: PopoverProps) => (
-  <RadixPopover.Root>
-    <RadixPopover.Trigger asChild>
-      <RefToTgphRef>{trigger}</RefToTgphRef>
-    </RadixPopover.Trigger>
-    <RadixPopover.Content {...props}>{content}</RadixPopover.Content>
-  </RadixPopover.Root>
-);
-
-// Usage:
-<Popover
-  trigger={<Button>Open Menu</Button>}
-  content={<div>Popover content</div>}
-/>;
-```
-
-```tsx
 import { Popover } from "@base-ui/react/popover";
 import { Button } from "@telegraph/button";
 import { PolymorphicProps, createTgphBaseUIRender } from "@telegraph/helpers";
@@ -710,7 +683,7 @@ type ConditionalProps<T extends TgphElement> = PolymorphicProps<T> &
 ### Component Development
 
 1. **Use `createTgphBaseUIRender` with Base UI `render` props**: Preserves Base UI props while forwarding refs to Telegraph `tgphRef`
-2. **Use `TgphSlot` for single-child prop composition**: Replaces Radix Slot-style prop merging while preserving native refs and `tgphRef`
+2. **Use `TgphSlot` for single-child prop composition**: Preserves native refs and `tgphRef`
 3. **Use `RefToTgphRef` with external libraries**: Ensures ref compatibility
 4. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
 5. **Type polymorphic components properly**: Use appropriate helper types

--- a/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
+++ b/packages/helpers/src/components/RefToTgphRef/RefToTgphRef.tsx
@@ -3,33 +3,34 @@
  *
  * PURPOSE:
  * ========
- * This component bridges the gap between third-party libraries (like Radix UI) and
- * Telegraph components. Third-party libraries expect components to accept a standard
+ * This component bridges the gap between third-party libraries and Telegraph
+ * components. Third-party libraries expect components to accept a standard
  * React `ref` prop, but Telegraph components use a custom `tgphRef` prop instead.
  *
- * Without this adapter, using Telegraph components with libraries like Radix would fail
- * because Radix would try to pass a `ref` that Telegraph components wouldn't receive.
+ * Without this adapter, using Telegraph components with libraries that clone a
+ * child and pass a standard `ref` would fail because Telegraph components
+ * wouldn't receive that ref.
  *
  * EXAMPLE USAGE:
  * ==============
  * ```tsx
- * <RadixTooltip.Trigger asChild>
+ * <HeadlessTrigger>
  *   <RefToTgphRef>
  *     <Button>Hover me</Button>  // Button uses tgphRef internally
  *   </RefToTgphRef>
- * </RadixTooltip.Trigger>
+ * </HeadlessTrigger>
  * ```
  *
  * WHAT IT DOES:
  * =============
- * 1. Receives a `ref` from the parent (e.g., Radix)
+ * 1. Receives a `ref` from the parent primitive
  * 2. Forwards it as both `ref` AND `tgphRef` to Telegraph children
  * 3. Merges any additional props from the parent with child props
  * 4. Handles both forwardRef components and regular components appropriately
  *
  * THE INFINITE LOOP PROBLEM:
  * ==========================
- * Radix and other libraries often pass ref callbacks that are recreated on every render
+ * External libraries often pass ref callbacks that are recreated on every render
  * (new function references). When we pass these unstable refs to children via
  * React.cloneElement, it causes the child to re-render with "new" props even though
  * the ref functionality hasn't actually changed. This can trigger infinite render loops.
@@ -62,7 +63,7 @@ type Child = React.ReactElement & {
  * mergeProps
  *
  * Merges props from the slot (parent/wrapper) with props from the child component.
- * This follows the same approach as Radix's Slot component to ensure compatibility.
+ * This follows the original Slot-style prop merge behavior to ensure compatibility.
  *
  * MERGE STRATEGY:
  * - Event handlers (onX): Compose them so both parent and child handlers run
@@ -197,7 +198,7 @@ const RefToTgphRef = React.forwardRef<any, any>(
      * REF STABILIZATION ARCHITECTURE
      *
      * PROBLEM:
-     * Libraries like Radix create new ref callback functions on every render.
+     * External libraries can create new ref callback functions on every render.
      * If we pass these unstable refs directly to children via React.cloneElement,
      * React sees the props object as changed (new function reference), causing
      * unnecessary re-renders and potential infinite loops.
@@ -210,7 +211,7 @@ const RefToTgphRef = React.forwardRef<any, any>(
      *
      */
 
-    // Storage for the latest ref callback/object from parent (e.g., Radix)
+    // Storage for the latest ref callback/object from the parent primitive.
     // This gets updated on every render but doesn't cause re-renders since it's
     // a mutable ref, not state.
     const refStorage = React.useRef(ref);


### PR DESCRIPTION
## Stack context

- Final PR in the Telegraph Radix to Base UI migration stack.
- Parent PR: #850.
- Linear: [KNO-13678](https://linear.app/knock/issue/KNO-13678).

## What changed

- Removed stale Radix examples from the Helpers README and pointed active guidance at Base UI render props.
- Updated `RefToTgphRef` source comments to describe generic headless-library ref bridging instead of Radix-specific usage.
- Added a final cleanup audit doc that classifies every remaining `radix` match.
- Added a Helpers changeset for the README update.

## Why

- Closes the migration with no direct `@radix-ui/*` runtime imports, package dependencies, or lockfile entries in the published migration scope.
- Keeps intentional compatibility references documented instead of leaving future cleanup work ambiguous.
- Leaves the stack ready for project-level after-action reporting and final merge review.

## Verification

- `rg "@radix-ui|radix"` classification pass.
- Runtime `@radix-ui/*` source import scan returned no matches in scope.
- Direct manifest and lockfile `@radix-ui/*` scan returned no matches in scope.
- `yarn install --immutable`.
- `yarn check:base-ui-migration`.
- `yarn check:react18`.
- `git diff --check`.
- React and TypeScript best-practices audit.
- `yarn test`.
- `yarn build:packages`.
- `yarn lint`.
- `yarn build:storybook`.
- Codex in-app Browser Storybook DOM/ARIA smoke checks for Popover, Tooltip, Menu, Modal, Combobox, Select, and SegmentedControl against the published baseline.

## Notes

- Browser evidence is stored in `/private/tmp/telegraph-final-cleanup-kno-13678`.
- The in-app Browser screenshot API timed out during this final docs-only pass; KNO-13677 contains the full screenshot matrix, and this PR adds final DOM/ARIA smoke evidence.
