### PR TITLE
chore(KNO-13807): harden Yarn install scripts, disable by default with allow-list

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,9 @@
 nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.9.1.cjs
+
+# Harden install scripts against supply-chain attacks (KNO-13807).
+# Build/postinstall scripts are the primary execution vector for npm supply
+# chain attacks, so they are disabled by default. The packages that genuinely
+# need to compile or download a binary at install time are allow-listed via
+# `dependenciesMeta.<pkg>.built: true` in package.json.
+enableScripts: false

--- a/package.json
+++ b/package.json
@@ -45,6 +45,17 @@
   "resolutions": {
     "parse5": "^7.2.1"
   },
+  "dependenciesMeta": {
+    "esbuild": {
+      "built": true
+    },
+    "sharp": {
+      "built": true
+    },
+    "unrs-resolver": {
+      "built": true
+    }
+  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix --report-unused-disable-directives --max-warnings 0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2284,6 +2284,13 @@ __metadata:
     vite-tsconfig-paths: "npm:^6.1.1"
     vitest: "npm:4.1.5"
     vitest-axe: "npm:0.1.0"
+  dependenciesMeta:
+    esbuild:
+      built: true
+    sharp:
+      built: true
+    unrs-resolver:
+      built: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What

Hardens Yarn install scripts in the Telegraph monorepo: build/postinstall scripts are now **disabled by default**, with a small allow-list for the packages that genuinely need to compile or download a binary at install time.

Linear: [KNO-13807](https://linear.app/knock/issue/KNO-13807/harden-yarn-install-scripts-in-telegraph-disable-by-default-allow-list)

## Why

Install and postinstall scripts are the primary execution vector for the recent wave of npm supply-chain attacks — Shai-Hulud and the `nx`, `chalk`, and `debug` compromises all ran their payloads through a postinstall script. Until now the root `.yarnrc.yml` had no script hardening, so any installed package could run arbitrary code at install time, in CI and on contributor machines. As a published design system, a compromised build step here would also flow out to every downstream consumer (the Knock dashboard, the JS SDK, etc.).

## Changes

**`.yarnrc.yml`** — disable build scripts globally:
```yaml
enableScripts: false
```

**`package.json`** — allow-list the packages that actually need build scripts:
```jsonc
"dependenciesMeta": {
  "esbuild": { "built": true },
  "sharp": { "built": true },
  "unrs-resolver": { "built": true }
}
```

`yarn.lock` is updated to record the `dependenciesMeta` on the root workspace entry (required for `yarn install --immutable` to stay green in CI).

## Notes on the implementation

The ticket proposed putting `dependenciesMeta` in `.yarnrc.yml`. **It belongs in `package.json`** — Yarn 4.9.1 reads `dependenciesMeta` from the manifest, not from `.yarnrc.yml`, and silently ignores it if placed in the rc file. The allow-list is in `package.json` here.

The allow-list was **re-derived from a fresh install**, not copied from the ticket. A clean `yarn install` (empty `node_modules`, no build state) reports exactly these third-party packages running build scripts:

- `esbuild` (postinstall) — powers the package builds
- `sharp` (install) — native image library
- `unrs-resolver` (postinstall) — native resolver binary

The root workspace `@knocklabs/telegraph@workspace:.` also runs scripts (`postinstall: manypkg check`, `prepare: husky`), but `enableScripts: false` does **not** gate the top-level workspace's own lifecycle scripts — those keep running and don't need allow-listing. Verified empirically.

I also confirmed the allow-list mechanism actually works rather than being a no-op: temporarily dropping `esbuild` from `dependenciesMeta` and reinstalling produced `YN0004: esbuild lists build scripts, but all build scripts have been disabled`, while `sharp` and `unrs-resolver` still built. So `enableScripts: false` is genuinely active and `built: true` is what selectively re-enables a package.

## Verification

All run locally against a fresh install with the hardened config:

- ✅ `yarn install` — clean, no errors; only the 3 allow-listed packages + root workspace build
- ✅ `yarn install --immutable` — passes (this is what CI runs); lockfile is stable
- ✅ `yarn build:packages` — 31/31 packages build (esbuild path)
- ✅ `yarn test` — 306 tests pass across 22 files
- ✅ `yarn format:check` and `yarn lint` — pass

## Follow-ups

Same hardening is proposed for `control` ([KNO-13800](https://linear.app/knock/issue/KNO-13800/harden-yarn-install-scripts-disable-by-default-allow-list-the-6)) and the JS SDK repo. Note for those: put the allow-list in `package.json`, and re-derive it per-repo from a fresh install.
