### PR TITLE
fix(popover): set z-index on Base UI positioner so popovers layer above app content

### DIFF
--- a/.changeset/menu-skip-animation-parity.md
+++ b/.changeset/menu-skip-animation-parity.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+`Menu.Content` now accepts a `skipAnimation` prop for API parity with `Popover.Content`. Menu's popup is not motion-animated, so the prop is a no-op, but accepting it stops the prop from leaking onto the DOM node (and triggering React's "unknown prop" warning) when consumers pass it for symmetry with Popover.

--- a/.changeset/popover-positioner-zindex.md
+++ b/.changeset/popover-positioner-zindex.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/popover": patch
+---
+
+Set the popover z-index on the Base UI positioner instead of only the popup. Base UI portals content to `<body>` and applies a `transform` to the positioner, making it the stacking-context root at `z-index: auto`; a z-index on the popup child alone was trapped inside that context, so popovers could render underneath app content with its own positive z-index. This matches how Menu and Tooltip already set their positioner z-index.

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -80,6 +80,13 @@ describe("Menu", () => {
       void validProps;
     });
 
+    it("accepts skipAnimation for Popover API parity", () => {
+      const validProps: MenuContentProps = {
+        skipAnimation: true,
+      };
+      void validProps;
+    });
+
     it("rejects unknown props on type level", () => {
       // @ts-expect-error unknown prop rejected on MenuContentProps
       const invalidProp: MenuContentProps = { invalidProp: "invalid" };
@@ -501,6 +508,25 @@ describe("Menu", () => {
       outline: "none",
     });
     expect(container).not.toContainElement(content);
+  });
+
+  it("consumes skipAnimation instead of leaking it to the DOM", async () => {
+    render(
+      <Menu.Root defaultOpen>
+        <Menu.Trigger>
+          <TestButton>Workflow actions</TestButton>
+        </Menu.Trigger>
+        <Menu.Content data-testid="menu-content" skipAnimation>
+          <Menu.Button>Manage workflow</Menu.Button>
+        </Menu.Content>
+      </Menu.Root>,
+    );
+
+    const content = await screen.findByTestId("menu-content");
+
+    // Menu accepts skipAnimation for Popover parity but must not forward it to
+    // the DOM node, which would trigger React's unknown-prop warning.
+    expect(content).not.toHaveAttribute("skipanimation");
   });
 
   it("forwards trigger and content refs through tgphRef", async () => {

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -387,6 +387,7 @@ export type ContentProps<T extends TgphElement = "div"> = Partial<
     onInteractOutside?: LegacyDismissEventHandler;
     onOpenAutoFocus?: LegacyDismissEventHandler;
     onPointerDownOutside?: LegacyDismissHandlers["onPointerDownOutside"];
+    skipAnimation?: boolean;
   };
 
 const Content = <T extends TgphElement = "div">({
@@ -422,6 +423,11 @@ const Content = <T extends TgphElement = "div">({
   shadow = "2",
   side = "bottom",
   sideOffset = 4,
+  // Accepted for API parity with Popover.Content. Menu's popup is not
+  // motion-animated, so there is no open/close animation to skip; consume the
+  // prop here so it does not leak onto the DOM node and trigger React's
+  // "unknown prop" warning.
+  skipAnimation: _skipAnimation,
   sticky,
   style,
   tgphRef,

--- a/packages/popover/src/Popover/Popover.test.tsx
+++ b/packages/popover/src/Popover/Popover.test.tsx
@@ -490,6 +490,11 @@ describe("Popover", () => {
     expect(content).toHaveStyle({
       transformOrigin: "var(--transform-origin)",
     });
+    // The z-index must sit on the Base UI positioner (the popup's parent and
+    // stacking-context root) so popovers layer above positioned app content.
+    expect(content.parentElement).toHaveStyle({
+      zIndex: "var(--tgph-zIndex-popover)",
+    });
     expect(container).not.toContainElement(content);
   });
 

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -336,6 +336,11 @@ const Content = <T extends TgphElement = "div">({
           getBaseUIPositionerVisibilityStyle({
             anchorHidden: state.anchorHidden,
             hideWhenDetached,
+            // Base UI's transformed positioner is the stacking-context root, so
+            // the z-index must live here; a z-index on the popup child alone is
+            // trapped at the positioner's `auto` level and paints under app
+            // content that has its own positive z-index.
+            zIndex: "var(--tgph-zIndex-popover)",
           })
         }
       >


### PR DESCRIPTION
## What changed

- **`Popover.Content`** — set the z-index on the Base UI positioner (`var(--tgph-zIndex-popover)`), not just the popup, matching what `Menu` and `Tooltip` already do.
- **`Menu.Content`** — accept a `skipAnimation` prop for `Popover.Content` parity so passing it no longer leaks onto the DOM node. Bundled here as the same post-migration API-alignment theme.

## Why

Base UI portals the popover to `<body>` and puts a `transform` on the positioner, making it the stacking-context root at `z-index: auto`. The z-index only lived on the popup *child*, so it was trapped in that context and popovers rendered under app content with its own positive z-index. Once this ships, control can drop its temporary `#__next { isolation: isolate }` workaround.

`Menu.Content` never consumed `skipAnimation` (only `Popover` does), so the dashboard passing it for symmetry triggered React's unknown-prop warning. Menu's popup isn't animated, so it's a no-op — it just stops the leak.

Resolves [KNO-14059](https://linear.app/knock/issue/KNO-14059/telegraph-set-z-index-on-base-ui-positioner-so-popovers-layer-above)
