### PR TITLE
fix(segmented-control): restore radio-group semantics for single select

### DIFF
--- a/.changeset/segmented-control-radio-semantics.md
+++ b/.changeset/segmented-control-radio-semantics.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/segmented-control": patch
+---
+
+Restore radio-group accessibility semantics for single-select `SegmentedControl`. After the Base UI migration it rendered every option as a toggle button (`role="group"` + `aria-pressed`), which misrepresents a single-select control as independent multi-select toggles. Single-select now exposes `role="radiogroup"` + `role="radio"` + `aria-checked`, while `type="multiple"` keeps the correct toggle-button semantics. Also stops emitting the redundant `aria-disabled="false"` on enabled options.

--- a/packages/segmented-control/README.md
+++ b/packages/segmented-control/README.md
@@ -437,9 +437,12 @@ export const SegmentedControlWithTooltips = () => {
 
 ### ARIA Attributes
 
-- `role="group"` - Applied to the root container
-- `role="button"` - Applied to each option
-- `aria-pressed` - Indicates the selected state
+Single-select (the default) is a radio group; multi-select (`type="multiple"`) is
+a set of independent toggle buttons.
+
+- `role="radiogroup"` (single) / `role="group"` (multiple) - Applied to the root container
+- `role="radio"` (single) / `role="button"` (multiple) - Applied to each option
+- `aria-checked` (single) / `aria-pressed` (multiple) - Indicates the selected state
 - `aria-label` - Provides accessible names for options
 
 ### Best Practices

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
@@ -39,14 +39,45 @@ describe("SegmentedControl", () => {
   it("renders the default option with Telegraph state attributes", () => {
     render(<SegmentedControlFixture />);
 
-    const activeOption = screen.getByRole("button", { name: "Left" });
+    const activeOption = screen.getByRole("radio", { name: "Left" });
 
     expect(activeOption).toHaveAttribute("data-tgph-segmented-control-option");
     expect(activeOption).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
-    expect(activeOption).toHaveAttribute("aria-pressed", "true");
+    expect(activeOption).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("exposes radio-group semantics for single select", () => {
+    render(<SegmentedControlFixture />);
+
+    // Single-select is a radio group, not a set of independent toggles, so the
+    // container and options should read as radiogroup/radio to assistive tech.
+    const group = screen.getByRole("radiogroup");
+    const activeOption = screen.getByRole("radio", { name: "Left" });
+    const inactiveOption = screen.getByRole("radio", { name: "Center" });
+
+    expect(group).toContainElement(activeOption);
+    expect(activeOption).toHaveAttribute("aria-checked", "true");
+    expect(inactiveOption).toHaveAttribute("aria-checked", "false");
+    // Base UI's `aria-pressed` toggle semantics must not leak into single select.
+    expect(activeOption).not.toHaveAttribute("aria-pressed");
+    expect(inactiveOption).not.toHaveAttribute("aria-pressed");
+  });
+
+  it("does not emit aria-disabled on enabled options", () => {
+    render(<SegmentedControlFixture />);
+
+    // Base UI marks enabled composite items with aria-disabled="false"; the
+    // wrapper drops that redundant value so only disabled options expose it.
+    expect(screen.getByRole("radio", { name: "Left" })).not.toHaveAttribute(
+      "aria-disabled",
+    );
+    expect(screen.getByRole("radio", { name: "Right" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
   });
 
   it("supports controlled single values and legacy string callbacks", async () => {
@@ -74,14 +105,14 @@ describe("SegmentedControl", () => {
 
     render(<ControlledSegmentedControl />);
 
-    await user.click(screen.getByRole("button", { name: "Center" }));
+    await user.click(screen.getByRole("radio", { name: "Center" }));
 
     expect(onValueChange).toHaveBeenCalledWith("center");
-    expect(screen.getByRole("button", { name: "Center" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Center" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
-    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "inactive",
     );
@@ -98,10 +129,10 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Left" }));
+    await user.click(screen.getByRole("radio", { name: "Left" }));
 
     expect(onValueChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
@@ -118,10 +149,10 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Left" }));
+    await user.click(screen.getByRole("radio", { name: "Left" }));
 
     expect(onValueChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
@@ -150,14 +181,14 @@ describe("SegmentedControl", () => {
 
     render(<ControlledSegmentedControl />);
 
-    await user.click(screen.getByRole("button", { name: "None" }));
+    await user.click(screen.getByRole("radio", { name: "None" }));
 
     expect(onValueChange).toHaveBeenCalledWith("");
-    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "None" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
-    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "inactive",
     );
@@ -189,20 +220,20 @@ describe("SegmentedControl", () => {
 
     render(<ControlledSegmentedControl />);
 
-    await user.click(screen.getByRole("button", { name: "Sentinel" }));
+    await user.click(screen.getByRole("radio", { name: "Sentinel" }));
 
     expect(onValueChange).toHaveBeenCalledWith(emptyStringSentinel);
-    expect(screen.getByRole("button", { name: "None" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "None" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "inactive",
     );
-    expect(screen.getByRole("button", { name: "Sentinel" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Sentinel" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
   });
 
-  it("supports controlled multiple values and legacy array callbacks", async () => {
+  it("exposes toggle-button semantics for multiple select", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();
 
@@ -227,6 +258,16 @@ describe("SegmentedControl", () => {
     };
 
     render(<ControlledSegmentedControl />);
+
+    // Multi-select stays as independent toggle buttons: role="group" with
+    // aria-pressed, and no radio semantics.
+    expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+    expect(screen.queryByRole("radio")).not.toBeInTheDocument();
+    expect(screen.getByRole("group")).toBeInTheDocument();
+
+    const leftOption = screen.getByRole("button", { name: "Left" });
+    expect(leftOption).toHaveAttribute("aria-pressed", "true");
+    expect(leftOption).not.toHaveAttribute("aria-checked");
 
     await user.click(screen.getByRole("button", { name: "Center" }));
 
@@ -254,10 +295,10 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    await user.click(screen.getByRole("button", { name: "Right" }));
+    await user.click(screen.getByRole("radio", { name: "Right" }));
 
     expect(onValueChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: "Left" })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: "Left" })).toHaveAttribute(
       "data-tgph-segmented-control-option-status",
       "active",
     );
@@ -278,8 +319,8 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    const leftOption = screen.getByRole("button", { name: "Left" });
-    const centerOption = screen.getByRole("button", { name: "Center" });
+    const leftOption = screen.getByRole("radio", { name: "Left" });
+    const centerOption = screen.getByRole("radio", { name: "Center" });
 
     expect(leftOption).toBeDisabled();
     expect(leftOption).toHaveAttribute("data-tgph-button-state", "disabled");
@@ -296,8 +337,8 @@ describe("SegmentedControl", () => {
 
     render(<SegmentedControlFixture />);
 
-    const leftOption = screen.getByRole("button", { name: "Left" });
-    const centerOption = screen.getByRole("button", { name: "Center" });
+    const leftOption = screen.getByRole("radio", { name: "Left" });
+    const centerOption = screen.getByRole("radio", { name: "Center" });
 
     leftOption.focus();
     await user.keyboard("{ArrowRight}");
@@ -316,8 +357,8 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    const leftOption = screen.getByRole("button", { name: "Left" });
-    const rightOption = screen.getByRole("button", { name: "Right" });
+    const leftOption = screen.getByRole("radio", { name: "Left" });
+    const rightOption = screen.getByRole("radio", { name: "Right" });
 
     rightOption.focus();
     await user.keyboard("{ArrowRight}");
@@ -335,7 +376,7 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    const leftOption = screen.getByRole("button", { name: "Left" });
+    const leftOption = screen.getByRole("radio", { name: "Left" });
 
     leftOption.focus();
     await user.keyboard("{ArrowLeft}");
@@ -353,7 +394,7 @@ describe("SegmentedControl", () => {
       </SegmentedControl.Root>,
     );
 
-    const leftOption = screen.getByRole("button", { name: "Left" });
+    const leftOption = screen.getByRole("radio", { name: "Left" });
 
     leftOption.focus();
     await user.keyboard("{ArrowRight}");
@@ -378,8 +419,6 @@ describe("SegmentedControl", () => {
     );
 
     expect(rootRef.current).toBe(screen.getByTestId("segmented-control-root"));
-    expect(optionRef.current).toBe(
-      screen.getByRole("button", { name: "Left" }),
-    );
+    expect(optionRef.current).toBe(screen.getByRole("radio", { name: "Left" }));
   });
 });

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -73,12 +73,14 @@ const SegmentedControlContextState = createContext<{
   showScrollButtons?: boolean;
   activeOptionRef?: HTMLButtonElement | null;
   setActiveOptionRef?: Dispatch<SetStateAction<HTMLButtonElement | null>>;
+  isMultiple?: boolean;
 }>({
   disabled: false,
   size: "1",
   showScrollButtons: false,
   activeOptionRef: null,
   setActiveOptionRef: () => {},
+  isMultiple: false,
 });
 
 export type RootProps<
@@ -336,6 +338,7 @@ const Root = <
           showScrollButtons,
           activeOptionRef,
           setActiveOptionRef,
+          isMultiple,
         }}
       >
         <SegmentedControlDirectionProvider dir={dir}>
@@ -360,6 +363,10 @@ const Root = <
                 overflow={showScrollButtons ? "hidden" : "visible"}
                 position="relative"
                 dir={dir}
+                // Base UI's Toggle Group renders `role="group"`, which is right for
+                // multi-select. Single-select is a radio group, so override the
+                // container's role so assistive tech announces single selection.
+                {...(isMultiple ? undefined : { role: "radiogroup" })}
                 tgphRef={composedContainerRef}
                 onKeyDown={handleKeyDown}
                 {...props}
@@ -467,7 +474,7 @@ const OptionButton = ({
   tgphRef,
   ...props
 }: OptionButtonProps) => {
-  const { setActiveOptionRef, ...context } = useContext(
+  const { setActiveOptionRef, isMultiple, ...context } = useContext(
     SegmentedControlContextState,
   );
   const derivedSize = context.size ?? size;
@@ -496,6 +503,20 @@ const OptionButton = ({
       data-tgph-segmented-control-option-status={status}
       tgphRef={composedButtonRef}
       {...props}
+      // Base UI's Toggle marks each option with `aria-pressed`, which reads as an
+      // independent toggle. For single-select, present each option as a radio
+      // (`role="radio"` + `aria-checked`) so assistive tech announces single
+      // selection; multi-select keeps Base UI's toggle semantics as-is.
+      {...(isMultiple
+        ? undefined
+        : {
+            role: "radio" as const,
+            "aria-checked": status === "active",
+            "aria-pressed": undefined,
+          })}
+      // Base UI emits `aria-disabled="false"` on enabled composite items; drop the
+      // redundant value so only genuinely disabled options expose the state.
+      aria-disabled={derivedDisabled || undefined}
     />
   );
 };


### PR DESCRIPTION
## What changed

- **`SegmentedControl`** — single-select now presents as a radio group (`role="radiogroup"` + `role="radio"` + `aria-checked`) instead of `aria-pressed` toggle buttons. `type="multiple"` keeps toggle semantics. Also stops emitting `aria-disabled="false"` on enabled options.

## Why

After the Base UI migration, single-select was built on Toggle Group, so every option rendered as an `aria-pressed` toggle inside `role="group"` — which reads as independent multi-select to assistive tech and breaks consumers (and ~39 control tests) that rely on `role="radio"`. Overlaying the radio ARIA on the existing Toggle Group leaves the roving-focus, value-sentinel, and scroll behavior untouched; swapping to Base UI's RadioGroup would mean duplicating RadioCards' keyboard-parity shim.

## Notes

Arrow keys still only move focus; selection stays on Space/Enter/click. Making selection follow focus is a follow-up that needs the RadioGroup swap.

Resolves [KNO-14061](https://linear.app/knock/issue/KNO-14061/telegraph-segmentedcontrol-lost-radio-semantics-after-base)
