### PR TITLE
fix(base-ui): stack Tabs vertically and composite Modal enter animation

### DIFF
--- a/.changeset/fix-tabs-vertical-modal-scale.md
+++ b/.changeset/fix-tabs-vertical-modal-scale.md
@@ -1,0 +1,9 @@
+---
+"@telegraph/tabs": patch
+"@telegraph/modal": patch
+---
+
+Fix two visual regressions from the Base UI migration:
+
+- **Tabs**: the root now renders a vertical `Stack` (`direction="column"`) by default so the tab list sits above the tab panel. Previously it rendered a bare `Box`, forcing consumers to pass `as={Stack} direction="column"` — which silently fell back to a horizontal `row` layout because `Box` emits `--flex-direction` while the `Stack` CSS reads `--direction`. Consumers can still override `direction` for side-by-side layouts.
+- **Modal**: the content now slides in with a GPU-composited `translateY` transform instead of animating the `top` layout property. Animating `top` forced layout + paint on the main thread every frame, so on a busy page (e.g. a large list rendering as the modal opens) the spring dropped frames and the modal snapped into place. The resting position is now static and only the transform animates. Also settle the stack-depth scale at exactly `1` for a lone modal (it previously rested at `1.02`, ~2% too large).

--- a/packages/modal/src/Modal/Modal.helpers.test.ts
+++ b/packages/modal/src/Modal/Modal.helpers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { getStackedModalScale } from "./Modal.helpers";
+
+describe("getStackedModalScale", () => {
+  it("rests at scale 1 for an unregistered layer (no stacking provider)", () => {
+    // Before a layer registers — or with no ModalStackingProvider — the stack
+    // reports zero layers and a fallback layer index of 0. The active modal
+    // must still settle at exactly 1 rather than overshooting to 1.02.
+    expect(getStackedModalScale(0, 0)).toBe(1);
+  });
+
+  it("rests at scale 1 for a single registered modal", () => {
+    expect(getStackedModalScale(1, 0)).toBe(1);
+  });
+
+  it("keeps the top layer at scale 1 while stacked layers shrink by depth", () => {
+    // Two layers: top (index 1) stays full size, the one beneath shrinks.
+    expect(getStackedModalScale(2, 1)).toBe(1);
+    expect(getStackedModalScale(2, 0)).toBeCloseTo(0.98);
+
+    // Three layers: shrink accumulates the further a layer sits from the top.
+    expect(getStackedModalScale(3, 2)).toBe(1);
+    expect(getStackedModalScale(3, 1)).toBeCloseTo(0.98);
+    expect(getStackedModalScale(3, 0)).toBeCloseTo(0.96);
+  });
+});

--- a/packages/modal/src/Modal/Modal.helpers.ts
+++ b/packages/modal/src/Modal/Modal.helpers.ts
@@ -6,6 +6,24 @@ export type BaseUIPreventableEvent = (Event | SyntheticEvent) & {
   stopPropagation?: () => void;
 };
 
+// Each modal stacked beneath the active one shrinks by this factor per level of
+// depth so lower layers read as sitting further back.
+export const MODAL_STACK_SCALE_STEP = 0.02;
+
+/**
+ * Resting scale for a modal content surface within the modal stack.
+ *
+ * The active (top) modal rests at scale 1; each layer beneath it shrinks by
+ * {@link MODAL_STACK_SCALE_STEP} per level of depth. Depth is measured from the
+ * top layer, so an unregistered layer — no `ModalStackingProvider`, or the first
+ * paint before the layer registers, where `layersLength` is 0 — still settles at
+ * exactly 1 rather than overshooting to 1.02.
+ */
+export const getStackedModalScale = (layersLength: number, layer: number) => {
+  const depthFromTop = Math.max(0, layersLength - 1 - layer);
+  return 1 - depthFromTop * MODAL_STACK_SCALE_STEP;
+};
+
 export const callAutoFocusHandler = (
   handler: ((event: Event) => void) | undefined,
   eventName: string,

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -36,11 +36,19 @@ import {
 import {
   type BaseUIPreventableEvent,
   callAutoFocusHandler,
+  getStackedModalScale,
 } from "./Modal.helpers";
 import { useModalStacking } from "./ModalStacking";
 
 const BASE_UI_OUTSIDE_PRESS_DISMISS_REASON = "outside-press";
 const ROOT_OUTSIDE_DISMISS_SUPPRESSION_DELAY_MS = 100;
+// The modal slides in from this many pixels above its resting position. Driven
+// via translateY — a GPU-composited transform — rather than the `top` layout
+// property, so the enter animation stays smooth even when the main thread is
+// busy (e.g. a large list rendering as the modal opens). `top` would force a
+// layout + paint every frame and snap under load. Matches the previous slide
+// distance of one spacing-4 step (1rem).
+const MODAL_ENTER_TRANSLATE_Y = -16;
 
 type BaseDialogRootProps = ComponentProps<typeof BaseDialog.Root>;
 type BaseDialogPopupProps = ComponentPropsWithoutRef<typeof BaseDialog.Popup>;
@@ -211,7 +219,6 @@ const RootComponent = ({
   const layerIndex = stacking.layers.indexOf(layerId);
   const layer = layerIndex === -1 ? 0 : layerIndex;
   const layersLength = stacking.layers?.length || 0;
-  const isStacked = layer !== 0;
   const isTopLayer =
     layersLength === 0 ||
     layerId === stacking.layers[stacking.layers.length - 1];
@@ -443,20 +450,18 @@ const RootComponent = ({
                 <RefToTgphRef>
                   <Stack
                     as={motion.div}
-                    initial={{
-                      top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layersLength - 1})`,
-                    }}
-                    animate={{
-                      top: isStacked
-                        ? `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer} )`
-                        : "var(--tgph-spacing-16)",
-                    }}
-                    exit={{ top: 0 }}
+                    initial={{ y: MODAL_ENTER_TRANSLATE_Y }}
+                    animate={{ y: 0 }}
+                    exit={{ y: MODAL_ENTER_TRANSLATE_Y }}
                     transition={{ type: "spring", duration: 0.3, bounce: 0 }}
                     w="full"
                     justify="center"
                     style={{
                       position: "fixed",
+                      // Resting position is static: each stacked layer sits one
+                      // spacing-4 step lower. The slide-in is handled by the
+                      // translateY animation above, so `top` never animates.
+                      top: `calc(var(--tgph-spacing-16) + var(--tgph-spacing-4) * ${layer})`,
                       left: 0,
                       maxHeight: "calc(100vh - var(--tgph-spacing-32))",
                       maxWidth: "calc(100vw - var(--tgph-spacing-8))",
@@ -468,7 +473,7 @@ const RootComponent = ({
                       as={motion.div}
                       direction="column"
                       animate={{
-                        scale: 1.02 - Math.abs(layersLength - layer) * 0.02,
+                        scale: getStackedModalScale(layersLength, layer),
                       }}
                       transition={{
                         duration: 0.2,

--- a/packages/tabs/src/Tabs/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs/Tabs.test.tsx
@@ -35,6 +35,42 @@ describe("Tabs", () => {
     expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
   });
 
+  it("stacks the tab list above the panel by rendering a vertical Stack", () => {
+    render(
+      <Tabs defaultValue="tab1" data-testid="tabs-root">
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    // The root must lay its children out as a column. Previously it rendered a
+    // bare Box, so consumers had to pass `as={Stack} direction="column"` — which
+    // silently fell back to `row` because Box emits `--flex-direction` while the
+    // Stack CSS reads `--direction`.
+    const root = screen.getByTestId("tabs-root");
+    expect(root).toHaveClass("tgph-stack");
+    expect(root).toHaveStyle({ "--direction": "column" });
+  });
+
+  it("lets consumers override the stacking direction", () => {
+    render(
+      <Tabs defaultValue="tab1" direction="row" data-testid="tabs-root">
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1">First panel</Tabs.Panel>
+      </Tabs>,
+    );
+
+    expect(screen.getByTestId("tabs-root")).toHaveStyle({
+      "--direction": "row",
+    });
+  });
+
   it("supports controlled values and change callbacks", async () => {
     const user = userEvent.setup();
     const onValueChange = vi.fn();

--- a/packages/tabs/src/Tabs/Tabs.tsx
+++ b/packages/tabs/src/Tabs/Tabs.tsx
@@ -3,7 +3,7 @@ import {
   type TgphComponentProps,
   createTgphBaseUIRender,
 } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Stack } from "@telegraph/layout";
 import { type ComponentProps } from "react";
 
 type BaseTabsRootProps = ComponentProps<typeof BaseTabs.Root>;
@@ -13,7 +13,7 @@ type TabsValueChangeHandler<Value extends TabsValue> = {
 }["bivarianceHack"];
 
 export type TabsProps<Value extends TabsValue = string> = TgphComponentProps<
-  typeof Box
+  typeof Stack
 > & {
   defaultValue?: Value;
   orientation?: BaseTabsRootProps["orientation"];
@@ -52,9 +52,11 @@ const Tabs = <Value extends TabsValue = string>({
       onValueChange={handleValueChange}
       orientation={orientation}
       render={createTgphBaseUIRender(
-        <Box data-tgph-tabs="" {...props}>
+        // Stack the tab list above the panel by default; `direction` is
+        // overridable for side-by-side tab layouts.
+        <Stack direction="column" data-tgph-tabs="" {...props}>
           {children}
-        </Box>,
+        </Stack>,
       )}
     />
   );


### PR DESCRIPTION
Fixes two visual regressions from the Base UI migration ([#837](https://github.com/knocklabs/telegraph/pull/837)), both spotted on infra-dev while verifying control's dep bump.

## What changed

**`@telegraph/tabs` — tab list rendered beside the panel instead of above it.**
The root now renders a vertical `Stack` (`direction="column"`) instead of a bare `Box`. Consumers previously had to pass `as={Stack} direction="column"` to get the standard layout — but that combination is broken: `Box` maps `direction` to `--flex-direction` while the `Stack` CSS class reads `--direction`, so the var was ignored and the list fell back to a full-height `row`. The root now owns its layout; `direction` is still overridable for side-by-side tab layouts.

**`@telegraph/modal` — enter animation snapped into place on busy pages.**
The slide-in now animates a GPU-composited `transform: translateY(...)` instead of the `top` layout property, with the resting position set statically. `top` is not composited, so every animation frame forced layout + paint on the main thread; on a busy page (e.g. the create-workflow modal opening over a ~285-row list) the spring dropped frames and snapped. An idle Storybook page never stressed it, which is why it only reproduced in control. Also settled the stack-depth scale at exactly `1` for a lone modal (it rested at `1.02`, ~2% too large).

## Why it only showed in control

The scale math regressed because the migration changed the unresolved-layer fallback from `-1` to `0`, and the snap came from `top` being non-composited — both only surface under a real, busy render. Extracted the scale into a pure `getStackedModalScale` helper with unit tests, and added Tabs tests asserting the vertical layout.

## Verification

- Build, lint, and all tabs + modal unit tests green.
- Verified live in Storybook: Tabs root computes `flex-direction: column`; Modal enter animates `transform: translateY(-16px → 0)` with `top` static at `64px`, and the content settles at `scale(1)` (no residual `1.02`).

Resolves [KNO-14078](https://linear.app/knock/issue/KNO-14078)
