### PR TITLE
fix(layout): share --direction custom property between Box and Stack

### DIFF
--- a/.changeset/fix-box-stack-direction-var.md
+++ b/.changeset/fix-box-stack-direction-var.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/layout": patch
+---
+
+Fix `Box` and `Stack` using different CSS custom properties for `flex-direction`, which silently dropped the `direction`/`flexDirection` prop when composing Box-based components with `as={Stack}`.
+
+`Box` mapped `direction`/`flexDirection` to `--flex-direction` while the `.tgph-stack` CSS reads `--direction`. On an element with both classes (e.g. `<Box as={Stack} direction="column">` or `<Tabs.Panel as={Stack} direction="column">`), the `.tgph-stack` rule won the cascade and resolved `flex-direction` from the never-set `--direction`, so the layout fell back to `row`. `Box` now writes `--direction` — the same custom property `Stack` uses — and the `.tgph-box` rule defaults and reads it, so both class rules resolve `flex-direction` identically and the interactive pseudo-state fallbacks regenerate as `--hover--direction` etc. The old `--flex-direction` custom property was already dead on any element with the stack class and is no longer emitted.

--- a/packages/layout/src/Box/Box.constants.ts
+++ b/packages/layout/src/Box/Box.constants.ts
@@ -362,7 +362,9 @@ const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
     value: "VARIABLE",
   },
   flexDirection: {
-    cssVar: "--flex-direction",
+    // Shares --direction with Stack so `Box as={Stack} direction=...` (and any
+    // Box-based component composed with Stack) resolves to one custom property.
+    cssVar: "--direction",
     value: "VARIABLE",
   },
 } as const;

--- a/packages/layout/src/Box/Box.styles.css
+++ b/packages/layout/src/Box/Box.styles.css
@@ -21,7 +21,7 @@
   --bottom: auto;
   --overflow: visible visible;
   --align-self: auto;
-  --flex-direction: row;
+  --direction: row;
 
   background-color: var(--background-color);
   border-width: var(--border-width);
@@ -45,7 +45,7 @@
   bottom: var(--bottom);
   overflow: var(--overflow);
   align-self: var(--align-self);
-  flex-direction: var(--flex-direction);
+  flex-direction: var(--direction);
 }
 
 /* Auto-generates interactive pseudo-class rules (hover, focus, active,

--- a/packages/layout/src/Box/Box.test.tsx
+++ b/packages/layout/src/Box/Box.test.tsx
@@ -2,6 +2,8 @@ import { render } from "@testing-library/react";
 import React from "react";
 import { describe, expect, expectTypeOf, it } from "vitest";
 
+import { Stack } from "../Stack";
+
 import { Box } from "./Box";
 import type { BoxProps } from "./Box";
 
@@ -240,12 +242,21 @@ describe("Box", () => {
   });
 
   describe("flex and size compatibility props", () => {
-    it("applies direction to the flex-direction css variable", () => {
+    it("applies direction to the --direction css variable shared with Stack", () => {
       const { container } = render(<Box direction="column" />);
       const box = container.querySelector(".tgph-box");
 
       expect(box).toHaveStyle({
-        "--flex-direction": "column",
+        "--direction": "column",
+      });
+    });
+
+    it("applies flexDirection to the --direction css variable shared with Stack", () => {
+      const { container } = render(<Box flexDirection="column" />);
+      const box = container.querySelector(".tgph-box");
+
+      expect(box).toHaveStyle({
+        "--direction": "column",
       });
     });
 
@@ -256,6 +267,18 @@ describe("Box", () => {
       expect(box).toHaveStyle({
         "--max-height": "400px",
       });
+    });
+  });
+
+  describe("composition with Stack via as prop", () => {
+    it("preserves direction when rendered as={Stack}", () => {
+      const { container } = render(<Box as={Stack} direction="column" />);
+      const element = container.querySelector(".tgph-stack");
+
+      // Box consumes `direction` before Stack ever sees the prop, so it must
+      // write the same --direction custom property the .tgph-stack CSS reads.
+      expect(element).toHaveClass("tgph-box");
+      expect(element).toHaveStyle({ "--direction": "column" });
     });
   });
 });

--- a/packages/layout/src/Stack/Stack.test.tsx
+++ b/packages/layout/src/Stack/Stack.test.tsx
@@ -1,9 +1,38 @@
-import { describe, expectTypeOf, it } from "vitest";
+import { render } from "@testing-library/react";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { cssVars as boxCssVars } from "../Box/Box.constants";
 
 import { Stack } from "./Stack";
 import type { StackProps } from "./Stack";
+import { cssVars as stackCssVars } from "./Stack.constants";
 
 describe("Stack", () => {
+  describe("direction css variable", () => {
+    it("maps direction to --direction", () => {
+      const { container } = render(<Stack direction="column" />);
+      const stack = container.querySelector(".tgph-stack");
+
+      expect(stack).toHaveStyle({ "--direction": "column" });
+    });
+
+    it("maps the flexDirection alias to --direction", () => {
+      const { container } = render(<Stack flexDirection="column" />);
+      const stack = container.querySelector(".tgph-stack");
+
+      expect(stack).toHaveStyle({ "--direction": "column" });
+    });
+
+    it("agrees with Box on the direction custom property", () => {
+      // Box and Stack must write the same custom property, or `as={Stack}`
+      // composition silently drops the direction prop again (KNO-14080).
+      expect(boxCssVars.direction.cssVar).toBe(stackCssVars.direction.cssVar);
+      expect(boxCssVars.flexDirection.cssVar).toBe(
+        stackCssVars.flexDirection.cssVar,
+      );
+    });
+  });
+
   describe("type inheritance", () => {
     it("accepts valid polymorphic props", () => {
       expectTypeOf<StackProps<"a">["href"]>().toEqualTypeOf<

--- a/packages/tabs/src/Tabs/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs/Tabs.test.tsx
@@ -1,3 +1,4 @@
+import { Stack } from "@telegraph/layout";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, useState } from "react";
@@ -69,6 +70,26 @@ describe("Tabs", () => {
     expect(screen.getByTestId("tabs-root")).toHaveStyle({
       "--direction": "row",
     });
+  });
+
+  it("preserves panel direction when composed with as={Stack}", () => {
+    render(
+      <Tabs defaultValue="tab1">
+        <Tabs.List>
+          <Tabs.Tab value="tab1">First Tab</Tabs.Tab>
+        </Tabs.List>
+
+        <Tabs.Panel value="tab1" as={Stack} direction="column">
+          First panel
+        </Tabs.Panel>
+      </Tabs>,
+    );
+
+    // Regression (KNO-14080): the Box-based panel consumed `direction` into a
+    // custom property the Stack CSS never read, so panels rendered as rows.
+    const panel = screen.getByRole("tabpanel");
+    expect(panel).toHaveClass("tgph-stack");
+    expect(panel).toHaveStyle({ "--direction": "column" });
   });
 
   it("supports controlled values and change callbacks", async () => {


### PR DESCRIPTION
## What changed

- **`@telegraph/layout`**: `Box` now maps `direction`/`flexDirection` to `--direction` — the same custom property `Stack` uses — and `.tgph-box` defaults and reads it; interactive pseudo-state fallbacks regenerate as `--hover--direction` etc.
- **`layout` tests**: regression coverage for `<Box as={Stack} direction="column">`, the `flexDirection` alias on both components, and a parity test asserting Box and Stack agree on the custom property.
- **`tabs` tests**: `<Tabs.Panel as={Stack} direction="column">` keeps its column layout.
- Patch changeset for `@telegraph/layout`.

## Why

`Box` wrote `--flex-direction` while the `.tgph-stack` rule reads `--direction`. On an element with both classes — any Box-based component composed with `as={Stack}` — the stack rule wins the cascade and resolves `flex-direction` from the never-set `--direction`, so `direction="column"` silently rendered a row. This is the root cause behind the tab layouts breaking in control (worked around with inline styles in knocklabs/control#10137); #864 fixed the Tabs root by making it a real `Stack`, but `TabPanel` and every other Box-based component were still affected.

## Notes

Ships as a patch — the old `--flex-direction` var was already dead on any element with the stack class, and nothing references it anymore.

Resolves [KNO-14080](https://linear.app/knock/issue/KNO-14080/telegraph-layout-boxstack-flex-direction-var-mismatch-drops-direction)
