### PR TITLE
fix(menu): keep focus on a typeable trigger input when the popup opens

### DIFF
--- a/.changeset/menu-open-autofocus-focus-bounce.md
+++ b/.changeset/menu-open-autofocus-focus-bounce.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/menu": patch
+---
+
+Fix a focus race from the Base UI migration where an input composed inside `Menu.Trigger` could not be typed into: the menu popup stole focus on open, so keystrokes fed the menu typeahead instead of the input (breaking PropertySelectorField everywhere it appears, plus the block editor slash-command and variable suggestion menus).
+
+`MenuContent`'s `onOpenAutoFocus` shim emulated Radix's prevented-autofocus contract by re-asserting the intended focus in a `setTimeout(0)`. Base UI's `MenuPopup` hardcodes its initial focus and queues it on the next animation frame, so the `setTimeout(0)` restore fired first and then lost the race — the popup won every time. The shim now bounces focus back synchronously from a one-shot `focusin` listener on the popup: when Base UI's queued initial focus lands, the listener re-focuses the intended target during that same `.focus()` call, with no dependence on timer ordering. The bounce disarms after the first restore, on the first `pointerdown`/`keydown` inside the popup, and on close, so ArrowDown navigation and item clicks still move focus into the menu.

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ debug-storybook.log
 # moon
 .moon/cache
 .moon/docker
+
+# Vitest browser mode artifacts
+.vitest-attachments
+**/__screenshots__

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -27,6 +27,8 @@
     "dev": "vite build --watch --emptyOutDir false",
     "build": "yarn clean && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test:browser": "vitest run --config ./vitest.browser.config.mts",
+    "test:browser:headed": "vitest run --config ./vitest.browser.config.mts --browser.headless=false",
     "format": "prettier \"src/**/*.{js,ts,tsx}\" --write",
     "format:check": "prettier \"src/**/*.{js,ts,tsx}\" --check",
     "preview": "vite preview"
@@ -48,11 +50,15 @@
     "@telegraph/prettier-config": "workspace:^",
     "@telegraph/vite-config": "workspace:^",
     "@types/react": "^19.2.17",
+    "@vitest/browser": "4.1.5",
+    "@vitest/browser-playwright": "4.1.5",
     "eslint": "^10.4.0",
+    "playwright": "^1.61.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "typescript": "^6.0.2",
-    "vite": "^8.1.1"
+    "vite": "^8.1.1",
+    "vitest-browser-react": "^2.2.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/menu/src/Menu/Menu.browser.test.tsx
+++ b/packages/menu/src/Menu/Menu.browser.test.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { page, userEvent } from "vitest/browser";
+
+import { Menu } from "./Menu";
+import { TypeableTriggerExample } from "./Menu.fixtures";
+
+// Reproduces KNO-14086 end-to-end: a typeable input composed inside
+// Menu.Trigger that prevents the legacy openAutoFocus. Base UI defers its
+// initial popup focus to a real animation frame, so this only reproduces in a
+// headed browser with real vsync — every headless environment (jsdom,
+// happy-dom, headless Chromium) fires that focus eagerly and hides the race.
+// The old setTimeout(0) restore lost the race here (focus landed in the popup);
+// the focusin bounce wins.
+const TypeableTriggerMenu = () => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Menu.Root open={open} onOpenChange={setOpen}>
+      <Menu.Trigger nativeButton={false}>
+        <div>
+          <input aria-label="Filter" onChange={() => setOpen(true)} />
+        </div>
+      </Menu.Trigger>
+      <Menu.Content onOpenAutoFocus={(event) => event.preventDefault()}>
+        <Menu.Button>Item one</Menu.Button>
+        <Menu.Button>Item two</Menu.Button>
+      </Menu.Content>
+    </Menu.Root>
+  );
+};
+
+const waitFrames = (count: number) =>
+  new Promise<void>((resolve) => {
+    let remaining = count;
+    const step = () => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        resolve();
+        return;
+      }
+      requestAnimationFrame(step);
+    };
+    requestAnimationFrame(step);
+  });
+
+describe("Menu typeable trigger (real browser)", () => {
+  it("keeps focus on the trigger input across Base UI's initial focus", async () => {
+    render(<TypeableTriggerMenu />);
+    const inputLocator = page.getByRole("textbox", { name: "Filter" });
+    await expect.element(inputLocator).toBeInTheDocument();
+    const input = inputLocator.element() as HTMLInputElement;
+
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    // Typing opens the menu; Base UI queues its initial focus for a later frame.
+    await userEvent.keyboard("i");
+    // Wait past the frame where Base UI's FloatingFocusManager runs its initial
+    // focus — the bounce runs inside that same focus event.
+    await waitFrames(4);
+
+    // The fix keeps focus on the input. The old setTimeout(0) restore fired
+    // before Base UI's frame and lost the race, so focus landed in the popup.
+    expect(document.activeElement).toBe(input);
+
+    // Continued typing must feed the input, not the menu's typeahead.
+    await userEvent.keyboard("tem");
+    await waitFrames(2);
+    expect(document.activeElement).toBe(input);
+    expect(input.value).toBe("item");
+  });
+});
+
+// Drives the exact composition the Storybook `TypeableTrigger` story ships, the
+// way a user would (real click + typing), so a broken demo can't slip through.
+describe("Menu typeable trigger story (real browser)", () => {
+  it("opens on click and keeps focus in the input while typing to filter", async () => {
+    render(<TypeableTriggerExample />);
+    const inputLocator = page.getByRole("textbox", {
+      name: "Filter properties",
+    });
+    await expect.element(inputLocator).toBeInTheDocument();
+    const input = inputLocator.element() as HTMLInputElement;
+
+    await userEvent.click(input);
+    await waitFrames(4);
+    expect(document.activeElement, "focus after click").toBe(input);
+    expect(
+      document.querySelector('[role="menu"]'),
+      "menu open after click",
+    ).toBeTruthy();
+
+    // Type one char at a time so the controlled input keeps up; keystrokes must
+    // land in the input (not the menu typeahead) and focus must stay.
+    for (const char of "workflow") {
+      await userEvent.keyboard(char);
+      await waitFrames(1);
+    }
+    expect(document.activeElement, "focus while typing").toBe(input);
+    expect(input.value).toBe("workflow");
+    // Filtered down to the two workflow.* options.
+    expect(document.querySelectorAll('[role="menuitem"]').length).toBe(2);
+  });
+});

--- a/packages/menu/src/Menu/Menu.fixtures.tsx
+++ b/packages/menu/src/Menu/Menu.fixtures.tsx
@@ -1,0 +1,95 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import { Stack } from "@telegraph/layout";
+import { useState } from "react";
+
+import { Menu } from "./Menu";
+
+const PROPERTIES = [
+  "workflow.name",
+  "workflow.status",
+  "recipient.email",
+  "recipient.id",
+  "actor.name",
+];
+
+/**
+ * A typeable input composed inside `Menu.Trigger`, as PropertySelectorField and
+ * the block editor suggestion menus do. Shared between the Storybook story and
+ * the headed browser test so both exercise the exact same composition.
+ *
+ * The input stays a real text field: `nativeButton={false}` + a wrapping `div`
+ * put Base UI's button semantics on the div, not the input, and passing
+ * `onClick` to the trigger suppresses Base UI's own open-on-press so it doesn't
+ * fight the input's focus/typing. Opening is driven by focus/typing; the popup
+ * prevents the legacy `openAutoFocus` so keystrokes keep feeding the input.
+ */
+export const TypeableTriggerExample = (
+  args: Partial<TgphComponentProps<typeof Menu.Root>> = {},
+) => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+  const matches = PROPERTIES.filter((property) =>
+    property.toLowerCase().includes(value.trim().toLowerCase()),
+  );
+
+  return (
+    <Stack m="20" style={{ width: 260 }}>
+      <Menu.Root {...args} open={open} onOpenChange={setOpen}>
+        <Menu.Trigger nativeButton={false} onClick={() => {}}>
+          <div>
+            <input
+              aria-label="Filter properties"
+              placeholder="Filter properties…"
+              value={value}
+              onChange={(event) => {
+                setValue(event.target.value);
+                setOpen(true);
+              }}
+              onFocus={() => setOpen(true)}
+              onKeyDown={(event) => {
+                // Keep typing in the input rather than Base UI's menu typeahead;
+                // let only navigation/selection keys reach the open menu.
+                if (
+                  !["ArrowDown", "ArrowUp", "Enter", "Escape"].includes(
+                    event.key,
+                  )
+                ) {
+                  event.stopPropagation();
+                }
+              }}
+              style={{
+                width: "100%",
+                boxSizing: "border-box",
+                padding: "6px 10px",
+                borderRadius: 6,
+                border: "1px solid var(--tgph-gray-6)",
+                font: "inherit",
+              }}
+            />
+          </div>
+        </Menu.Trigger>
+        <Menu.Content
+          {...args}
+          onOpenAutoFocus={(event) => event.preventDefault()}
+          style={{ width: 260 }}
+        >
+          {matches.length > 0 ? (
+            matches.map((property) => (
+              <Menu.Button
+                key={property}
+                onSelect={() => {
+                  setValue(property);
+                  setOpen(false);
+                }}
+              >
+                {property}
+              </Menu.Button>
+            ))
+          ) : (
+            <Menu.Button disabled={true}>No matches</Menu.Button>
+          )}
+        </Menu.Content>
+      </Menu.Root>
+    </Stack>
+  );
+};

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 
 import { Menu as TelegraphMenu } from "./Menu";
+import { TypeableTriggerExample } from "./Menu.fixtures";
 
 const meta: Meta = {
   tags: ["autodocs"],
@@ -143,4 +144,11 @@ export const WithSubmenu: Story = {
       </Stack>
     );
   },
+};
+
+// A typeable input composed inside the trigger (PropertySelectorField, block
+// editor suggestion menus). Click or type to open; keystrokes keep landing in
+// the input — not the menu's typeahead — and ArrowDown moves into the list.
+export const TypeableTrigger: Story = {
+  render: (args) => <TypeableTriggerExample {...args} />,
 };

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1,5 +1,12 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChevronRight } from "lucide-react";
 import {
@@ -9,7 +16,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
 
@@ -946,5 +953,145 @@ describe("Menu", () => {
     expect(submenu).toHaveAttribute("role", "menu");
     expect(submenu).toHaveAttribute("data-side", "right");
     expect(submenu).toHaveAttribute("data-align", "start");
+  });
+
+  describe("typeable trigger open autofocus", () => {
+    // Long enough to clear a couple of jsdom animation frames (~16ms each).
+    const PENDING_FRAME_DRAIN_MS = 32;
+
+    beforeEach(async () => {
+      // Base UI queues its initial focus on an animation frame. These tests
+      // share one jsdom document, so drain any frame a previous test left
+      // pending before this one sets up focus, or it steals focus mid-setup.
+      await act(async () => {
+        await new Promise((resolve) =>
+          setTimeout(resolve, PENDING_FRAME_DRAIN_MS),
+        );
+      });
+    });
+
+    // Reproduces the surfaces (PropertySelectorField, block editor suggestion
+    // menus) that compose a typeable input inside Menu.Trigger and prevent the
+    // legacy openAutoFocus so keystrokes keep feeding the input, not the menu.
+    const TypeableTriggerMenu = ({
+      onOpenAutoFocus,
+      preventOpenAutoFocus = true,
+    }: {
+      onOpenAutoFocus?: (event: Event) => void;
+      preventOpenAutoFocus?: boolean;
+    }) => {
+      const [open, setOpen] = useState(false);
+
+      return (
+        <Menu.Root open={open} onOpenChange={setOpen}>
+          <Menu.Trigger nativeButton={false}>
+            <div data-testid="trigger">
+              <input
+                data-testid="trigger-input"
+                onChange={() => setOpen(true)}
+              />
+            </div>
+          </Menu.Trigger>
+          <Menu.Content
+            data-testid="menu-content"
+            onOpenAutoFocus={(event) => {
+              if (preventOpenAutoFocus) {
+                event.preventDefault();
+              }
+              onOpenAutoFocus?.(event);
+            }}
+          >
+            <Menu.Button>Item one</Menu.Button>
+            <Menu.Button>Item two</Menu.Button>
+          </Menu.Content>
+        </Menu.Root>
+      );
+    };
+
+    // Focus the input and open on a keystroke, matching the real controlled
+    // flow. Base UI queues its initial focus for a later frame, so it stays
+    // pending here and the explicitly simulated steal in each test is the first
+    // focusin — which is exactly the move the bounce must intercept.
+    const openMenuFromInput = async () => {
+      const input = screen.getByTestId("trigger-input");
+      act(() => input.focus());
+      fireEvent.change(input, { target: { value: "a" } });
+      await screen.findByTestId("menu-content");
+      return input;
+    };
+
+    // The bounce re-focuses the restore target synchronously from inside the
+    // `focusin` fired during Base UI's `.focus()` call. jsdom re-asserts
+    // `activeElement` to the just-focused element *after* that call returns,
+    // clobbering the re-focus (the technique works in a real browser — see
+    // KNO-14086), so these assert the bounce *logic* by spying on the restore
+    // target's `focus()`. The old setTimeout(0) restore never re-focuses in
+    // response to a later focusin, so it fails every one of these.
+
+    it("restores focus to the trigger input when the popup grabs initial focus", async () => {
+      render(<TypeableTriggerMenu />);
+      const input = await openMenuFromInput();
+      const firstItem = screen.getByRole("menuitem", { name: "Item one" });
+
+      const restoreFocus = vi.spyOn(input, "focus");
+      // Simulate Base UI's queued initial focus landing inside the popup.
+      act(() => firstItem.focus());
+
+      expect(restoreFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("bounces focus only once so later navigation into the menu is allowed", async () => {
+      render(<TypeableTriggerMenu />);
+      const input = await openMenuFromInput();
+      const firstItem = screen.getByRole("menuitem", { name: "Item one" });
+      const secondItem = screen.getByRole("menuitem", { name: "Item two" });
+
+      const restoreFocus = vi.spyOn(input, "focus");
+      act(() => firstItem.focus());
+      // One-shot: a deliberate later move into the menu (ArrowDown navigation,
+      // clicking another item) is left alone.
+      act(() => secondItem.focus());
+
+      expect(restoreFocus).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops bouncing after a pointer interaction inside the menu", async () => {
+      render(<TypeableTriggerMenu />);
+      const input = await openMenuFromInput();
+      const firstItem = screen.getByRole("menuitem", { name: "Item one" });
+
+      const restoreFocus = vi.spyOn(input, "focus");
+      // A pointerdown inside the popup is a deliberate move into the menu
+      // (clicking an item), so the focus it produces must not be bounced.
+      fireEvent.pointerDown(firstItem);
+      act(() => firstItem.focus());
+
+      expect(restoreFocus).not.toHaveBeenCalled();
+    });
+
+    it("stops bouncing after a key interaction inside the menu", async () => {
+      render(<TypeableTriggerMenu />);
+      const input = await openMenuFromInput();
+      const firstItem = screen.getByRole("menuitem", { name: "Item one" });
+
+      const restoreFocus = vi.spyOn(input, "focus");
+      // ArrowDown navigation inside the popup is a deliberate move into the menu.
+      fireEvent.keyDown(firstItem, { key: "ArrowDown" });
+      act(() => firstItem.focus());
+
+      expect(restoreFocus).not.toHaveBeenCalled();
+    });
+
+    it("does not bounce focus when open autofocus is not prevented", async () => {
+      render(<TypeableTriggerMenu preventOpenAutoFocus={false} />);
+      const input = await openMenuFromInput();
+      const firstItem = screen.getByRole("menuitem", { name: "Item one" });
+
+      // With the default autofocus intact, the menu is meant to take focus.
+      const restoreFocus = vi.spyOn(input, "focus");
+      act(() => firstItem.focus());
+
+      expect(restoreFocus).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -302,9 +302,7 @@ const MenuPopupContent = ({
 }: MenuPopupContentProps) => {
   const localContentRef = useRef<HTMLElement>(null);
   const openAutoFocusHandledRef = useRef(false);
-  const openAutoFocusTimeoutRef = useRef<
-    ReturnType<typeof setTimeout> | undefined
-  >(undefined);
+  const openAutoFocusAbortRef = useRef<AbortController | undefined>(undefined);
   const composedContentRef = useComposedRefs<HTMLElement>(
     tgphRef,
     contentRef,
@@ -313,15 +311,18 @@ const MenuPopupContent = ({
 
   useLayoutEffect(() => {
     const content = localContentRef.current;
-    const ownerWindow = content?.ownerDocument.defaultView;
 
     if (!popupState.open) {
+      // Close is the teardown point for the bounce: abort here rather than from
+      // an effect cleanup. A cleanup that aborted on every re-run would fight
+      // the `openAutoFocusHandledRef` guard (which intentionally dispatches the
+      // synthetic event only once per open, including under StrictMode's
+      // setup→teardown→setup), leaving the bounce disarmed. On unmount the popup
+      // node detaches and is collected with its listeners, so there is nothing
+      // to leak.
       openAutoFocusHandledRef.current = false;
-
-      if (openAutoFocusTimeoutRef.current !== undefined) {
-        clearTimeout(openAutoFocusTimeoutRef.current);
-        openAutoFocusTimeoutRef.current = undefined;
-      }
+      openAutoFocusAbortRef.current?.abort();
+      openAutoFocusAbortRef.current = undefined;
 
       return;
     }
@@ -346,15 +347,55 @@ const MenuPopupContent = ({
       previouslyFocusedElement,
     });
 
-    openAutoFocusTimeoutRef.current = ownerWindow?.setTimeout(() => {
-      openAutoFocusTimeoutRef.current = undefined;
+    if (!restoreTarget) {
+      return;
+    }
 
-      if (restoreTarget && ownerDocument.contains(restoreTarget)) {
-        // Base UI has already run its focus pass; now restore the Radix-style
-        // prevented autofocus target without racing its internal handler.
-        restoreTarget.focus();
-      }
-    }, 0);
+    // Base UI's MenuPopup hardcodes initial focus into the popup and exposes no
+    // way to opt out (only Popover/Dialog surface `initialFocus`). Its focus
+    // manager queues that move to the next animation frame, so the previous
+    // setTimeout(0) restore fired first and then lost the race, letting the
+    // popup steal focus from a typeable trigger input. Instead, bounce focus
+    // back the instant Base UI's initial focus lands: focusing an element inside
+    // the popup dispatches `focusin` here synchronously during Base UI's own
+    // `.focus()` call, so re-asserting the intended target from that event wins
+    // with no dependence on timer ordering.
+    const abortController = new AbortController();
+    openAutoFocusAbortRef.current = abortController;
+    const { signal } = abortController;
+
+    content.addEventListener(
+      "focusin",
+      () => {
+        // Disarm before restoring: the focus manager attempts initial focus only
+        // once, and any later move into the menu (navigation, selection) must be
+        // allowed through. Restoring focus into the trigger's input does not trip
+        // the focus manager's focus-out close logic because the trigger is a
+        // related node.
+        abortController.abort();
+
+        if (ownerDocument.contains(restoreTarget)) {
+          restoreTarget.focus();
+        }
+      },
+      { signal },
+    );
+
+    const disarmOnIntentionalFocus = () => {
+      // A pointer or key interaction inside the popup is a deliberate move into
+      // the menu (clicking an item, ArrowDown navigation); stop guarding so the
+      // focus it produces is allowed to stay.
+      abortController.abort();
+    };
+
+    content.addEventListener("keydown", disarmOnIntentionalFocus, {
+      capture: true,
+      signal,
+    });
+    content.addEventListener("pointerdown", disarmOnIntentionalFocus, {
+      capture: true,
+      signal,
+    });
   }, [onOpenAutoFocus, popupState.open]);
 
   return (

--- a/packages/menu/vitest.browser.config.mts
+++ b/packages/menu/vitest.browser.config.mts
@@ -1,0 +1,31 @@
+import { playwright } from "@vitest/browser-playwright";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+// Real-browser tests for behavior jsdom can't reproduce (async focus/rAF races,
+// real layout/positioning). Kept separate from the jsdom project so `yarn test`
+// is unaffected; run with `yarn workspace @telegraph/menu test:browser`.
+//
+// Headless by default so local runs don't pop a window; the fix is deterministic
+// so these pass headless. To reproduce the KNO-14086 race itself, run headed
+// (`test:browser:headed`, i.e. `--browser.headless=false`): it only surfaces
+// with real vsync, because headless Chromium fires Base UI's rAF-queued initial
+// focus eagerly and hides the bug.
+export default defineConfig({
+  root: dirname(fileURLToPath(import.meta.url)),
+  // @ts-expect-error -- plugin type mismatch, same as vitest/config.mts
+  plugins: [tsconfigPaths()],
+  test: {
+    name: "menu-browser",
+    globals: true,
+    include: ["src/**/*.browser.test.{ts,tsx}"],
+    browser: {
+      enabled: true,
+      provider: playwright(),
+      headless: true,
+      instances: [{ browser: "chromium" }],
+    },
+  },
+});

--- a/packages/menu/vitest.config.mts
+++ b/packages/menu/vitest.config.mts
@@ -1,4 +1,4 @@
-import { defineProject, mergeConfig } from "vitest/config";
+import { configDefaults, defineProject, mergeConfig } from "vitest/config";
 
 import { sharedConfig } from "../../vitest/config.mts";
 
@@ -8,6 +8,8 @@ export default mergeConfig(
     test: {
       name: "menu",
       environment: "jsdom",
+      // Browser-mode tests (real Chromium) run via vitest.browser.config.mts.
+      exclude: [...configDefaults.exclude, "**/*.browser.test.{ts,tsx}"],
     },
   }),
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -645,6 +645,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@blazediff/core@npm:1.9.1":
+  version: 1.9.1
+  resolution: "@blazediff/core@npm:1.9.1"
+  checksum: 10c0/fd45cdd0544002341d74831a179ef693a81414abd348c1ff0c01086c0ea03f5e5ee284c4e16c2e6fb3670c265f90a3d85752b9360320efa9a835928e604dae77
+  languageName: node
+  linkType: hard
+
 "@bramus/specificity@npm:^2.4.2":
   version: 2.4.2
   resolution: "@bramus/specificity@npm:2.4.2"
@@ -2900,6 +2907,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.29
+  resolution: "@polka/url@npm:1.0.0-next.29"
+  checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-android-arm64@npm:1.0.0-rc.15":
   version: 1.0.0-rc.15
   resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.15"
@@ -3750,13 +3764,17 @@ __metadata:
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^19.2.17"
+    "@vitest/browser": "npm:4.1.5"
+    "@vitest/browser-playwright": "npm:4.1.5"
     eslint: "npm:^10.4.0"
     lucide-react: "npm:^1.14.0"
     motion: "npm:^12.38.0"
+    playwright: "npm:^1.61.1"
     react: "npm:^19.2.7"
     react-dom: "npm:^19.2.7"
     typescript: "npm:^6.0.2"
     vite: "npm:^8.1.1"
+    vitest-browser-react: "npm:^2.2.0"
   peerDependencies:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
@@ -5219,6 +5237,41 @@ __metadata:
     babel-plugin-react-compiler:
       optional: true
   checksum: 10c0/6c42f53a970cb6b0776ba5b4203bb01690ac564c56fca706d4037b50aec965ddc0f11530ab58ab2cd0fbe8c12e14cff6966b22d90391283b4a53294e3ddd478d
+  languageName: node
+  linkType: hard
+
+"@vitest/browser-playwright@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/browser-playwright@npm:4.1.5"
+  dependencies:
+    "@vitest/browser": "npm:4.1.5"
+    "@vitest/mocker": "npm:4.1.5"
+    tinyrainbow: "npm:^3.1.0"
+  peerDependencies:
+    playwright: "*"
+    vitest: 4.1.5
+  peerDependenciesMeta:
+    playwright:
+      optional: false
+  checksum: 10c0/47b0ecc13757e638f7765cb4b3172e817a25249b00bc4e9462f4228b6336c0b2f7bb692ae636373f55c8e9b35d18eaecb03abd5f15b0c42a8351da9a62f23d9f
+  languageName: node
+  linkType: hard
+
+"@vitest/browser@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/browser@npm:4.1.5"
+  dependencies:
+    "@blazediff/core": "npm:1.9.1"
+    "@vitest/mocker": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
+    magic-string: "npm:^0.30.21"
+    pngjs: "npm:^7.0.0"
+    sirv: "npm:^3.0.2"
+    tinyrainbow: "npm:^3.1.0"
+    ws: "npm:^8.19.0"
+  peerDependencies:
+    vitest: 4.1.5
+  checksum: 10c0/ea95d100853dd7a1ea9f1b036edfe441688bf5873742341ebf169ab2e32041ab6e21e5f2df918c3c4b9f110265457cdce0c0afa83407617e460a83979ae48e44
   languageName: node
   linkType: hard
 
@@ -8196,12 +8249,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -10317,6 +10389,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mrmime@npm:2.0.1"
+  checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
+  languageName: node
+  linkType: hard
+
 "ms@npm:2.1.2":
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
@@ -11132,10 +11211,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c28896ba82a602182e240ed4f9c467fb0dd9cb57d510f8aba9f25183fe1cde3a0105725a29baffa4157fe885bbb11e228032a2aad0424111584fde45303f07bd
+  languageName: node
+  linkType: hard
+
+"playwright@npm:^1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
+  languageName: node
+  linkType: hard
+
 "pluralize@npm:^8.0.0":
   version: 8.0.0
   resolution: "pluralize@npm:8.0.0"
   checksum: 10c0/2044cfc34b2e8c88b73379ea4a36fc577db04f651c2909041b054c981cd863dd5373ebd030123ab058d194ae615d3a97cfdac653991e499d10caf592e8b3dc33
+  languageName: node
+  linkType: hard
+
+"pngjs@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "pngjs@npm:7.0.0"
+  checksum: 10c0/0d4c7a0fd476a9c33df7d0a2a73e1d56537628a668841f6995c2bca070cf30819f9254a64363266bc14ef2fee47659dd3b4f2b18eec7ab65143015139f497b38
   languageName: node
   linkType: hard
 
@@ -12298,6 +12408,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "sirv@npm:3.0.2"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/5930e4397afdb14fbae13751c3be983af4bda5c9aadec832607dc2af15a7162f7d518c71b30e83ae3644b9a24cea041543cc969e5fe2b80af6ce8ea3174b2d04
+  languageName: node
+  linkType: hard
+
 "slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -12984,6 +13105,13 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
+  languageName: node
+  linkType: hard
+
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
   languageName: node
   linkType: hard
 
@@ -13779,6 +13907,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest-browser-react@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "vitest-browser-react@npm:2.2.0"
+  peerDependencies:
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+    vitest: ^4.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/d2e582e564cf7f65f19a5a9c36b0b136e84fc6dabd42566703d79e0b220094a5a88a9197a42b2c4779f38977d79c8f3306387cd7edd2ef8e57790b921a759975
+  languageName: node
+  linkType: hard
+
 "vitest@npm:4.1.5":
   version: 4.1.5
   resolution: "vitest@npm:4.1.5"
@@ -14084,7 +14230,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0":
+"ws@npm:^8.18.0, ws@npm:^8.19.0":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"
   peerDependencies:


### PR DESCRIPTION
## What changed

`MenuContent`'s prevented-`onOpenAutoFocus` path no longer restores focus in a `setTimeout(0)`. It now bounces focus back to the intended target synchronously from a one-shot `focusin` listener on the popup — the instant Base UI's initial focus lands. The bounce disarms after the first restore, on the first `pointerdown`/`keydown` inside the popup, and on close, so navigation and clicks into the menu still work.

## Why

Since the Base UI migration, an input composed inside `Menu.Trigger` couldn't be typed into: the popup stole focus on open, so keystrokes fed the menu typeahead instead of the input (breaks PropertySelectorField everywhere it appears, plus the block editor slash-command / variable / skill-suggestion menus). Base UI's `MenuPopup` hardcodes its initial focus and queues it on the next animation frame, so the old `setTimeout(0)` restore fired first and then lost the race — the popup won every time. Bouncing from `focusin` runs inside Base UI's own `.focus()` call, so it wins deterministically with no timer assumptions.

## Tests

- **jsdom unit tests** assert the bounce *logic* via a spy on the restore target's `focus()` — they fail against the old `setTimeout` code. jsdom can't assert the real outcome because it re-asserts `activeElement` after a `.focus()` returns, clobbering the synchronous re-focus.
- **Real-browser tests** (`Menu.browser.test.tsx`, Vitest Browser Mode + Playwright, opt-in via `yarn workspace @telegraph/menu test:browser`) drive the actual typeable-trigger flow — including the exact `TypeableTrigger` Storybook composition (shared via `Menu.fixtures.tsx`) — and assert focus stays on the input while typing filters the list. They run **headless by default** (the fix is deterministic, so no window pops up); `test:browser:headed` reproduces the race itself.
- There's a **`TypeableTrigger` story** back in Storybook to manually test the input, verified by the browser test above so it can't silently break.
- **The race only reproduces in a headed browser.** Base UI defers its initial popup focus to a real animation frame; every headless env — jsdom, happy-dom, *and headless Chromium* — fires it eagerly, so the buggy code passes headless. Run headed to watch the old `setTimeout` restore lose (focus jumps to the popup). A headed CI job (xvfb) and generalizing the harness are tracked in [KNO-14089](https://linear.app/knock/issue/KNO-14089).

## Notes

- Upstream fix (not blocking): [mui/base-ui#5189](https://github.com/mui/base-ui/pull/5189) adds an `initialFocus` prop to `Menu.Popup`. If the Base UI team accepts it, we can delete the bounce and map a prevented `openAutoFocus` to `initialFocus === false` — the same mapping Telegraph's `Popover` and `Modal` already use — bringing `Menu` in line with the other primitives.

Resolves [KNO-14086](https://linear.app/knock/issue/KNO-14086/telegraph-menu-openautofocus-restore-races-base-ui-initial-focus)
