### PR TITLE
fix: override rounded corners in combobox option tag

### DIFF
--- a/.changeset/shiny-canyons-care.md
+++ b/.changeset/shiny-canyons-care.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": patch
+---
+
+Overrides incorrectly rounded border on remove option button in Combobox option tag

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -350,6 +350,8 @@ const TriggerTagButton = <T extends TgphElement>({
     <Tag.Button
       icon={{ icon: X, alt: `Remove ${triggerTagContext.value}` }}
       height="full"
+      borderTopRightRadius="1"
+      borderBottomRightRadius="1"
       onClick={(event: React.MouseEvent) => {
         if (!context.onValueChange) return;
         const onValueChange =

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -350,8 +350,7 @@ const TriggerTagButton = <T extends TgphElement>({
     <Tag.Button
       icon={{ icon: X, alt: `Remove ${triggerTagContext.value}` }}
       height="full"
-      borderTopRightRadius="1"
-      borderBottomRightRadius="1"
+      borderRightRadius="1"
       onClick={(event: React.MouseEvent) => {
         if (!context.onValueChange) return;
         const onValueChange =


### PR DESCRIPTION
### WHAT CHANGED
pass down correct border values to Tag component from Combobox so that we fix: (screenshots)

### BEFORE:
<img width="465" height="348" alt="image" src="https://github.com/user-attachments/assets/836340ed-3f3c-4050-9b53-02793178743e" />


### NOW:
<img width="532" height="316" alt="image" src="https://github.com/user-attachments/assets/90f15a9b-2ad5-4701-acb8-7223355ab138" />

