### PR TITLE
fix(combobox): correct client-side search matching (KNO-14268)

### DIFF
--- a/.changeset/combobox-search-matching.md
+++ b/.changeset/combobox-search-matching.md
@@ -5,7 +5,7 @@
 Fix client-side search matching in `Combobox`
 
 - Match options by their rendered DOM text, so text produced inside a child component (a custom option row, for example) is searchable. Previously the filter only read text off the React element tree, where a child component's render output doesn't exist.
-- Match queries that span sibling text nodes — searching `"Kyle McDonald"` now matches `<Text>Kyle</Text><Text>McDonald</Text>`.
+- Match queries that span sibling text nodes — searching `"Jane Doe"` now matches `<Text>Jane</Text><Text>Doe</Text>`.
 - Match numeric children, which were previously skipped entirely.
 - Trim the search query, so a pasted value with surrounding whitespace still matches.
 - Stop treating a controlled `<Combobox.Search value={...} />` — or any controlled input inside `Combobox.Content`, including a search wrapped in a consumer component — as an option. Its `value` prop was collected as a phantom option that could shadow the real one and mislabel the trigger.

--- a/.changeset/combobox-search-matching.md
+++ b/.changeset/combobox-search-matching.md
@@ -1,10 +1,10 @@
 ---
-"@telegraph/combobox": minor
+"@telegraph/combobox": patch
 ---
 
 Fix client-side search matching in `Combobox`
 
-- Add a `searchValue` prop to `Combobox.Option`, for options whose visible text is rendered by a child component and so can't be read off the element tree. When set, it replaces the text derived from `label`/`children`/`value`.
+- Match options by their rendered DOM text, so text produced inside a child component (a custom option row, for example) is searchable. Previously the filter only read text off the React element tree, where a child component's render output doesn't exist.
 - Match queries that span sibling text nodes — searching `"Kyle McDonald"` now matches `<Text>Kyle</Text><Text>McDonald</Text>`.
 - Match numeric children, which were previously skipped entirely.
 - Trim the search query, so a pasted value with surrounding whitespace still matches.

--- a/.changeset/combobox-search-matching.md
+++ b/.changeset/combobox-search-matching.md
@@ -8,4 +8,4 @@ Fix client-side search matching in `Combobox`
 - Match queries that span sibling text nodes — searching `"Kyle McDonald"` now matches `<Text>Kyle</Text><Text>McDonald</Text>`.
 - Match numeric children, which were previously skipped entirely.
 - Trim the search query, so a pasted value with surrounding whitespace still matches.
-- Stop treating a controlled `<Combobox.Search value={...} />` as an option. Its `value` prop was collected as a phantom option that could shadow the real one and mislabel the trigger.
+- Stop treating a controlled `<Combobox.Search value={...} />` — or any controlled input inside `Combobox.Content`, including a search wrapped in a consumer component — as an option. Its `value` prop was collected as a phantom option that could shadow the real one and mislabel the trigger.

--- a/.changeset/combobox-search-matching.md
+++ b/.changeset/combobox-search-matching.md
@@ -1,0 +1,11 @@
+---
+"@telegraph/combobox": minor
+---
+
+Fix client-side search matching in `Combobox`
+
+- Add a `searchValue` prop to `Combobox.Option`, for options whose visible text is rendered by a child component and so can't be read off the element tree. When set, it replaces the text derived from `label`/`children`/`value`.
+- Match queries that span sibling text nodes — searching `"Kyle McDonald"` now matches `<Text>Kyle</Text><Text>McDonald</Text>`.
+- Match numeric children, which were previously skipped entirely.
+- Trim the search query, so a pasted value with surrounding whitespace still matches.
+- Stop treating a controlled `<Combobox.Search value={...} />` as an option. Its `value` prop was collected as a phantom option that could shadow the real one and mislabel the trigger.

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -340,17 +340,17 @@ export const CustomTrigger = () => (
 
 Individual selectable option item.
 
-| Prop          | Type                  | Default     | Description                            |
-| ------------- | --------------------- | ----------- | -------------------------------------- |
-| `value`       | `string`              | required    | Option value                           |
-| `label`       | `string \| ReactNode` | `undefined` | Display label                          |
-| `selected`    | `boolean \| null`     | `undefined` | Force selected state                   |
-| `searchValue` | `string`              | `undefined` | Text to match the search query against |
+| Prop       | Type                  | Default     | Description          |
+| ---------- | --------------------- | ----------- | -------------------- |
+| `value`    | `string`              | required    | Option value         |
+| `label`    | `string \| ReactNode` | `undefined` | Display label        |
+| `selected` | `boolean \| null`     | `undefined` | Force selected state |
 
-`<Combobox.Search>` filters options by the text it can read from `label`,
-`children` and `value`. It reads that text off the React element tree, so text
-produced _inside_ a child component is invisible to it — the option below
-renders an email that searching for it will never match:
+`<Combobox.Search>` matches the query against the option's `value`, its
+`label`/`children` text, and its rendered DOM text. The last one is what makes
+text produced _inside_ a child component searchable — an option like the one
+below matches a search for the user's email even though the email only exists
+in `UserRow`'s render output:
 
 ```tsx
 <Combobox.Option value={user.id}>
@@ -358,15 +358,10 @@ renders an email that searching for it will never match:
 </Combobox.Option>
 ```
 
-Pass `searchValue` for those options. It replaces the derived text entirely, so
-include everything that should match (and nothing that shouldn't — the option's
-`value` is no longer matched either):
-
-```tsx
-<Combobox.Option value={user.id} searchValue={`${user.name} ${user.email}`}>
-  <UserRow user={user} />
-</Combobox.Option>
-```
+Rendered text is captured while an option is on screen. The popup always opens
+unfiltered, so every option is captured before the first keystroke; an option
+inserted while a query is active is matchable by its element-tree text only
+until it first renders.
 
 ### `<Combobox.Search>`
 

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -340,11 +340,33 @@ export const CustomTrigger = () => (
 
 Individual selectable option item.
 
-| Prop       | Type                  | Default     | Description          |
-| ---------- | --------------------- | ----------- | -------------------- |
-| `value`    | `string`              | required    | Option value         |
-| `label`    | `string \| ReactNode` | `undefined` | Display label        |
-| `selected` | `boolean \| null`     | `undefined` | Force selected state |
+| Prop          | Type                  | Default     | Description                            |
+| ------------- | --------------------- | ----------- | -------------------------------------- |
+| `value`       | `string`              | required    | Option value                           |
+| `label`       | `string \| ReactNode` | `undefined` | Display label                          |
+| `selected`    | `boolean \| null`     | `undefined` | Force selected state                   |
+| `searchValue` | `string`              | `undefined` | Text to match the search query against |
+
+`<Combobox.Search>` filters options by the text it can read from `label`,
+`children` and `value`. It reads that text off the React element tree, so text
+produced _inside_ a child component is invisible to it — the option below
+renders an email that searching for it will never match:
+
+```tsx
+<Combobox.Option value={user.id}>
+  <UserRow user={user} />
+</Combobox.Option>
+```
+
+Pass `searchValue` for those options. It replaces the derived text entirely, so
+include everything that should match (and nothing that shouldn't — the option's
+`value` is no longer matched either):
+
+```tsx
+<Combobox.Option value={user.id} searchValue={`${user.name} ${user.email}`}>
+  <UserRow user={user} />
+</Combobox.Option>
+```
 
 ### `<Combobox.Search>`
 

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -136,10 +136,8 @@ type DoesOptionMatchSearchQueryProps = {
   searchQuery: string;
 };
 
-// Compares text the way it reads on screen: case-insensitive, with runs of
-// whitespace collapsed. Collapsing matters because text assembled from sibling
-// nodes ("Kyle " + "McDonald") would otherwise carry a doubled gap that no
-// realistic query contains, and because pasted queries carry stray whitespace.
+// Lowercase and collapse whitespace so joined sibling text and pasted
+// queries compare like on-screen text.
 const normalize = (text: string) =>
   text.replace(/\s+/g, " ").trim().toLowerCase();
 
@@ -153,14 +151,11 @@ export const doesOptionMatchSearchQuery = ({
 
   if (!query) return true;
 
-  // Search the option value and any rendered text because labels can be
-  // supplied through nested React children. Joining the strings lets a query
-  // spanning sibling nodes ("Kyle McDonald") match.
+  // Join child strings so a query can span sibling nodes
   const childText = normalize(findStringNodes(children).join(" "));
 
-  // renderedText holds the option's captured DOM text variants. They're what
-  // make text produced inside child components searchable — that text exists
-  // only in render output, which the element walk above can't reach.
+  // renderedText covers text rendered inside child components, which the
+  // element walk can't reach
   return (
     normalize(value ?? "").includes(query) ||
     childText.includes(query) ||
@@ -168,13 +163,9 @@ export const doesOptionMatchSearchQuery = ({
   );
 };
 
-// Extracts an option's on-screen text for search matching. Returns both
-// joining variants because DOM text nodes alone can't settle word boundaries:
-// raw concatenation keeps words split by inline markup intact ("<b>K</b>yle"
-// stays "Kyle"), while space-joining keeps words in separate elements apart
-// ("<span>Kyle</span><span>Smith</span>" reads "Kyle Smith", not "KyleSmith").
-// The variants stay separate strings so a query can only match text that
-// actually appears in one of them, never across an artificial seam.
+// Returns the element's text two ways: concatenated (keeps words split by
+// inline markup whole) and space-joined (keeps words in separate elements
+// apart). Kept as separate strings so a query can't match across the seam.
 export const getRenderedSearchText = (element: Element | null): string[] => {
   if (!element) return [];
 
@@ -200,15 +191,14 @@ export const findStringNodes = (children: ReactNode): string[] => {
       strNodes.push(child);
     }
 
-    // React renders numbers as text, so they're searchable like strings.
+    // Numbers render as text, so they're searchable
     if (typeof child === "number") {
       strNodes.push(String(child));
     }
 
     if (isValidElement(child)) {
       const childProps = child.props as Record<string, unknown>;
-      // Recurse unconditionally. A falsy but renderable child like 0 still
-      // contributes text, and an absent one just yields an empty array.
+      // Recurse even when children is falsy, since 0 still renders
       strNodes.push(...findStringNodes(childProps.children as ReactNode));
     }
   });

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -122,7 +122,7 @@ export const getCurrentOption = (
 type DoesOptionMatchSearchQueryProps = {
   children?: React.ReactNode;
   value?: string;
-  renderedText?: string;
+  renderedText?: string[];
   searchQuery: string;
 };
 
@@ -148,13 +148,13 @@ export const doesOptionMatchSearchQuery = ({
   // spanning sibling nodes ("Kyle McDonald") match.
   const childText = normalize(findStringNodes(children).join(" "));
 
-  // renderedText is the option's DOM textContent, captured after render. It's
-  // what makes text produced inside child components searchable — that text
-  // exists only in render output, which the element walk above can't reach.
+  // renderedText holds the option's captured DOM text variants. They're what
+  // make text produced inside child components searchable — that text exists
+  // only in render output, which the element walk above can't reach.
   return (
     normalize(value ?? "").includes(query) ||
     childText.includes(query) ||
-    normalize(renderedText ?? "").includes(query)
+    (renderedText ?? []).some((variant) => normalize(variant).includes(query))
   );
 };
 
@@ -163,9 +163,10 @@ export const doesOptionMatchSearchQuery = ({
 // raw concatenation keeps words split by inline markup intact ("<b>K</b>yle"
 // stays "Kyle"), while space-joining keeps words in separate elements apart
 // ("<span>Kyle</span><span>Smith</span>" reads "Kyle Smith", not "KyleSmith").
-// A query matches if it appears in either variant.
-export const getRenderedSearchText = (element: Element | null): string => {
-  if (!element) return "";
+// The variants stay separate strings so a query can only match text that
+// actually appears in one of them, never across an artificial seam.
+export const getRenderedSearchText = (element: Element | null): string[] => {
+  if (!element) return [];
 
   const parts: string[] = [];
   const collect = (node: Node) => {
@@ -176,7 +177,7 @@ export const getRenderedSearchText = (element: Element | null): string => {
   };
   collect(element);
 
-  return `${parts.join("")} ${parts.join(" ")}`;
+  return [parts.join(""), parts.join(" ")];
 };
 
 // Exported for testing

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -1,4 +1,9 @@
-import React from "react";
+import {
+  Children,
+  type ReactElement,
+  type ReactNode,
+  isValidElement,
+} from "react";
 
 import type { DefinedOption, Option } from "./Combobox.types";
 
@@ -22,27 +27,32 @@ export const isSingleSelect = (
   );
 };
 
-export const getOptions = (
-  children: React.ReactNode,
-  isOptionElement: (element: React.ReactElement) => boolean,
-): Array<DefinedOption> => {
+type GetOptionsProps = {
+  children: ReactNode;
+  isOptionElement: (element: ReactElement) => boolean;
+};
+
+export const getOptions = ({
+  children,
+  isOptionElement,
+}: GetOptionsProps): Array<DefinedOption> => {
   const recursivelyFindOptionElements = (
-    children: React.ReactNode,
-    options: Array<React.ReactNode> = [],
+    children: ReactNode,
+    options: Array<ReactNode> = [],
   ) => {
     // Options can be wrapped in grouping/layout components, so walk the child
     // tree instead of assuming direct Combobox.Option children.
-    const childrenArray = React.Children.toArray(children);
+    const childrenArray = Children.toArray(children);
 
     childrenArray.forEach((child) => {
-      if (React.isValidElement(child)) {
+      if (isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
         if (isOptionElement(child)) {
           options.push(child);
         } else if (childProps.children) {
           // Non-option wrappers may still contain options further down.
           recursivelyFindOptionElements(
-            childProps.children as React.ReactNode,
+            childProps.children as ReactNode,
             options,
           );
         }
@@ -55,10 +65,10 @@ export const getOptions = (
   const optionElements = recursivelyFindOptionElements(children);
 
   const options = optionElements.map((_element) => {
-    const element = _element as React.ReactElement<{
+    const element = _element as ReactElement<{
       value: string;
-      label?: string | React.ReactNode;
-      children?: React.ReactNode;
+      label?: string | ReactNode;
+      children?: ReactNode;
     }>;
     return {
       value: element.props.value,
@@ -120,7 +130,7 @@ export const getCurrentOption = (
 };
 
 type DoesOptionMatchSearchQueryProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   value?: string;
   renderedText?: string[];
   searchQuery: string;
@@ -181,8 +191,8 @@ export const getRenderedSearchText = (element: Element | null): string[] => {
 };
 
 // Exported for testing
-export const findStringNodes = (children: React.ReactNode): string[] => {
-  const childrenArray = React.Children.toArray(children);
+export const findStringNodes = (children: ReactNode): string[] => {
+  const childrenArray = Children.toArray(children);
   const strNodes: string[] = [];
 
   childrenArray.forEach((child) => {
@@ -195,11 +205,11 @@ export const findStringNodes = (children: React.ReactNode): string[] => {
       strNodes.push(String(child));
     }
 
-    if (React.isValidElement(child)) {
+    if (isValidElement(child)) {
       const childProps = child.props as Record<string, unknown>;
       // Recurse unconditionally. A falsy but renderable child like 0 still
       // contributes text, and an absent one just yields an empty array.
-      strNodes.push(...findStringNodes(childProps.children as React.ReactNode));
+      strNodes.push(...findStringNodes(childProps.children as ReactNode));
     }
   });
 

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -122,7 +122,7 @@ export const getCurrentOption = (
 type DoesOptionMatchSearchQueryProps = {
   children?: React.ReactNode;
   value?: string;
-  searchValue?: string;
+  renderedText?: string;
   searchQuery: string;
 };
 
@@ -136,27 +136,47 @@ const normalize = (text: string) =>
 export const doesOptionMatchSearchQuery = ({
   children,
   value,
-  searchValue,
+  renderedText,
   searchQuery,
 }: DoesOptionMatchSearchQueryProps) => {
   const query = normalize(searchQuery);
 
   if (!query) return true;
 
-  // searchValue is authoritative: it's the escape hatch for options whose text
-  // is produced inside a child component, where the walk below can't reach it.
-  // It's typically derived from user data (names, emails), so a null from an
-  // untyped caller falls through to the derived text instead of throwing.
-  if (searchValue != null) {
-    return normalize(String(searchValue)).includes(query);
-  }
-
-  // Search both the option value and any rendered text because labels can be
+  // Search the option value and any rendered text because labels can be
   // supplied through nested React children. Joining the strings lets a query
   // spanning sibling nodes ("Kyle McDonald") match.
   const childText = normalize(findStringNodes(children).join(" "));
 
-  return normalize(value ?? "").includes(query) || childText.includes(query);
+  // renderedText is the option's DOM textContent, captured after render. It's
+  // what makes text produced inside child components searchable — that text
+  // exists only in render output, which the element walk above can't reach.
+  return (
+    normalize(value ?? "").includes(query) ||
+    childText.includes(query) ||
+    normalize(renderedText ?? "").includes(query)
+  );
+};
+
+// Extracts an option's on-screen text for search matching. Returns both
+// joining variants because DOM text nodes alone can't settle word boundaries:
+// raw concatenation keeps words split by inline markup intact ("<b>K</b>yle"
+// stays "Kyle"), while space-joining keeps words in separate elements apart
+// ("<span>Kyle</span><span>Smith</span>" reads "Kyle Smith", not "KyleSmith").
+// A query matches if it appears in either variant.
+export const getRenderedSearchText = (element: Element | null): string => {
+  if (!element) return "";
+
+  const parts: string[] = [];
+  const collect = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE && node.nodeValue) {
+      parts.push(node.nodeValue);
+    }
+    node.childNodes.forEach(collect);
+  };
+  collect(element);
+
+  return `${parts.join("")} ${parts.join(" ")}`;
 };
 
 // Exported for testing

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -126,30 +126,35 @@ type DoesOptionMatchSearchQueryProps = {
   searchQuery: string;
 };
 
+// Compares text the way it reads on screen: case-insensitive, with runs of
+// whitespace collapsed. Collapsing matters because text assembled from sibling
+// nodes ("Kyle " + "McDonald") would otherwise carry a doubled gap that no
+// realistic query contains, and because pasted queries carry stray whitespace.
+const normalize = (text: string) =>
+  text.replace(/\s+/g, " ").trim().toLowerCase();
+
 export const doesOptionMatchSearchQuery = ({
   children,
   value,
   searchValue,
   searchQuery,
 }: DoesOptionMatchSearchQueryProps) => {
-  // Pasted queries routinely carry surrounding whitespace, which shouldn't
-  // drop an otherwise exact match.
-  const query = searchQuery.trim().toLowerCase();
+  const query = normalize(searchQuery);
 
   if (!query) return true;
 
   // searchValue is authoritative: it's the escape hatch for options whose text
   // is produced inside a child component, where the walk below can't reach it.
   if (searchValue !== undefined) {
-    return searchValue.toLowerCase().includes(query);
+    return normalize(searchValue).includes(query);
   }
 
   // Search both the option value and any rendered text because labels can be
   // supplied through nested React children. Joining the strings lets a query
   // spanning sibling nodes ("Kyle McDonald") match.
-  const childText = findStringNodes(children).join(" ").toLowerCase();
+  const childText = normalize(findStringNodes(children).join(" "));
 
-  return value?.toLowerCase().includes(query) || childText.includes(query);
+  return normalize(value ?? "").includes(query) || childText.includes(query);
 };
 
 // Exported for testing
@@ -169,11 +174,9 @@ export const findStringNodes = (children: React.ReactNode): string[] => {
 
     if (React.isValidElement(child)) {
       const childProps = child.props as Record<string, unknown>;
-      if (childProps.children) {
-        strNodes.push(
-          ...findStringNodes(childProps.children as React.ReactNode),
-        );
-      }
+      // Recurse unconditionally. A falsy but renderable child like 0 still
+      // contributes text, and an absent one just yields an empty array.
+      strNodes.push(...findStringNodes(childProps.children as React.ReactNode));
     }
   });
 

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -22,7 +22,10 @@ export const isSingleSelect = (
   );
 };
 
-export const getOptions = (children: React.ReactNode): Array<DefinedOption> => {
+export const getOptions = (
+  children: React.ReactNode,
+  isOptionElement: (element: React.ReactElement) => boolean,
+): Array<DefinedOption> => {
   const recursivelyFindOptionElements = (
     children: React.ReactNode,
     options: Array<React.ReactNode> = [],
@@ -34,8 +37,7 @@ export const getOptions = (children: React.ReactNode): Array<DefinedOption> => {
     childrenArray.forEach((child) => {
       if (React.isValidElement(child)) {
         const childProps = child.props as Record<string, unknown>;
-        if (childProps.value) {
-          // Combobox.Option is identified by its public value prop.
+        if (isOptionElement(child)) {
           options.push(child);
         } else if (childProps.children) {
           // Non-option wrappers may still contain options further down.
@@ -120,24 +122,34 @@ export const getCurrentOption = (
 type DoesOptionMatchSearchQueryProps = {
   children?: React.ReactNode;
   value?: string;
+  searchValue?: string;
   searchQuery: string;
 };
 
 export const doesOptionMatchSearchQuery = ({
   children,
   value,
+  searchValue,
   searchQuery,
 }: DoesOptionMatchSearchQueryProps) => {
-  // Search both the option value and any rendered text because labels can be
-  // supplied through nested React children.
-  const childStrings = findStringNodes(children);
+  // Pasted queries routinely carry surrounding whitespace, which shouldn't
+  // drop an otherwise exact match.
+  const query = searchQuery.trim().toLowerCase();
 
-  return (
-    value?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    childStrings.some((str) =>
-      str.toLowerCase().includes(searchQuery.toLowerCase()),
-    )
-  );
+  if (!query) return true;
+
+  // searchValue is authoritative: it's the escape hatch for options whose text
+  // is produced inside a child component, where the walk below can't reach it.
+  if (searchValue !== undefined) {
+    return searchValue.toLowerCase().includes(query);
+  }
+
+  // Search both the option value and any rendered text because labels can be
+  // supplied through nested React children. Joining the strings lets a query
+  // spanning sibling nodes ("Kyle McDonald") match.
+  const childText = findStringNodes(children).join(" ").toLowerCase();
+
+  return value?.toLowerCase().includes(query) || childText.includes(query);
 };
 
 // Exported for testing
@@ -148,6 +160,11 @@ export const findStringNodes = (children: React.ReactNode): string[] => {
   childrenArray.forEach((child) => {
     if (typeof child === "string") {
       strNodes.push(child);
+    }
+
+    // React renders numbers as text, so they're searchable like strings.
+    if (typeof child === "number") {
+      strNodes.push(String(child));
     }
 
     if (React.isValidElement(child)) {

--- a/packages/combobox/src/Combobox/Combobox.helpers.ts
+++ b/packages/combobox/src/Combobox/Combobox.helpers.ts
@@ -145,8 +145,10 @@ export const doesOptionMatchSearchQuery = ({
 
   // searchValue is authoritative: it's the escape hatch for options whose text
   // is produced inside a child component, where the walk below can't reach it.
-  if (searchValue !== undefined) {
-    return normalize(searchValue).includes(query);
+  // It's typically derived from user data (names, emails), so a null from an
+  // untyped caller falls through to the derived text instead of throwing.
+  if (searchValue != null) {
+    return normalize(String(searchValue)).includes(query);
   }
 
   // Search both the option value and any rendered text because labels can be

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -620,8 +620,8 @@ const USERS = [
   { id: "usr_3", name: "Chris Bell", email: "chris@example.com" },
 ];
 
-// This option's text is rendered inside a component, so it can't be read off
-// the element tree — searchValue is what keeps it findable.
+// This option's text is rendered inside a component. It stays searchable
+// because each option captures its rendered DOM text for matching.
 const UserRow = ({ user }: { user: (typeof USERS)[number] }) => (
   <Stack direction="column" align="flex-start">
     <Text as="span" size="1">
@@ -633,7 +633,7 @@ const UserRow = ({ user }: { user: (typeof USERS)[number] }) => (
   </Stack>
 );
 
-export const OptionsWithSearchValue: Story = {
+export const OptionsWithComponentContent: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
     const [value, setValue] = React.useState<string | undefined>(undefined);
@@ -651,12 +651,7 @@ export const OptionsWithSearchValue: Story = {
             <TelegraphCombobox.Search />
             <TelegraphCombobox.Options>
               {USERS.map((user) => (
-                <TelegraphCombobox.Option
-                  key={user.id}
-                  value={user.id}
-                  h="9"
-                  searchValue={`${user.name} ${user.email}`}
-                >
+                <TelegraphCombobox.Option key={user.id} value={user.id} h="9">
                   <UserRow user={user} />
                 </TelegraphCombobox.Option>
               ))}

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -4,7 +4,7 @@ import type { TgphComponentProps } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { Modal } from "@telegraph/modal";
 import { Text } from "@telegraph/typography";
-import React from "react";
+import { useState } from "react";
 
 import { Combobox as TelegraphCombobox } from "../Combobox";
 
@@ -29,7 +29,7 @@ const FIRST_VALUE = VALUES[0] as string;
 export const SingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_VALUE);
+    const [value, setValue] = useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -59,7 +59,7 @@ export const SingleSelect: Story = {
 export const SingleSelectWithSearch: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_VALUE);
+    const [value, setValue] = useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -90,7 +90,7 @@ export const SingleSelectWithSearch: Story = {
 export const SingleSelectWithLongLabel: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_VALUE);
+    const [value, setValue] = useState(FIRST_VALUE);
     return (
       <Box w="80">
         <TelegraphCombobox.Root
@@ -123,7 +123,7 @@ export const SingleSelectWithLongLabel: Story = {
 export const MultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_VALUE]);
+    const [value, setValue] = useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -159,7 +159,7 @@ export const MultiSelect: Story = {
 export const MultiSelectWithWrapLayout: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_VALUE]);
+    const [value, setValue] = useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -192,7 +192,7 @@ export const MultiSelectWithWrapLayout: Story = {
 export const SingleSelectWithCreate: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<string | undefined>(undefined);
+    const [value, setValue] = useState<string | undefined>(undefined);
 
     return (
       <Box w="80">
@@ -230,7 +230,7 @@ export const SingleSelectWithCreate: Story = {
 export const MultiSelectWithCreate: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<Array<string>>([FIRST_VALUE]);
+    const [value, setValue] = useState<Array<string>>([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -269,7 +269,7 @@ export const MultiSelectWithCreate: Story = {
 export const MultiSelectWithClear: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_VALUE]);
+    const [value, setValue] = useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -308,9 +308,9 @@ export const MultiSelectWithClear: Story = {
 export const ComboboxInModal: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [open, setOpen] = React.useState(false);
+    const [open, setOpen] = useState(false);
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_VALUE]);
+    const [value, setValue] = useState([FIRST_VALUE]);
     return (
       <>
         <Button size="1" variant="outline" onClick={() => setOpen(true)}>
@@ -377,7 +377,7 @@ const FIRST_LEGACY_VALUE = LEGACY_VALUES[0] as Option;
 export const LegacyComboboxSingleSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
+    const [value, setValue] = useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -407,7 +407,7 @@ export const LegacyComboboxSingleSelect: Story = {
 export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_LEGACY_VALUE);
+    const [value, setValue] = useState(FIRST_LEGACY_VALUE);
 
     return (
       <Box w="80">
@@ -441,7 +441,7 @@ export const LegacyComboboxSingleSelectWithLabelOverride: Story = {
 export const LegacyComboboxMultiSelect: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_LEGACY_VALUE]);
+    const [value, setValue] = useState([FIRST_LEGACY_VALUE]);
 
     return (
       <Box w="80">
@@ -481,7 +481,7 @@ export const LegacyComboboxMultiSelect: Story = {
 export const SingleSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState(FIRST_VALUE);
+    const [value, setValue] = useState(FIRST_VALUE);
 
     return (
       <Box w="80">
@@ -518,7 +518,7 @@ export const SingleSelectWithCustomTrigger: Story = {
 export const MultiSelectWithCustomTrigger: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState([FIRST_VALUE]);
+    const [value, setValue] = useState([FIRST_VALUE]);
 
     return (
       <Box w="80">
@@ -585,7 +585,7 @@ export const YearPicker: Story = {
 export const YearPickerWithScrollToValue: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<string | undefined>(undefined);
+    const [value, setValue] = useState<string | undefined>(undefined);
 
     return (
       <Box w="80">
@@ -636,7 +636,7 @@ const UserRow = ({ user }: { user: (typeof USERS)[number] }) => (
 export const OptionsWithComponentContent: Story = {
   render: ({ ...args }) => {
     // eslint-disable-next-line
-    const [value, setValue] = React.useState<string | undefined>(undefined);
+    const [value, setValue] = useState<string | undefined>(undefined);
 
     return (
       <Box w="80">

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -615,9 +615,9 @@ export const YearPickerWithScrollToValue: Story = {
 };
 
 const USERS = [
-  { id: "usr_1", name: "Kyle McDonald", email: "kyle@knock.app" },
-  { id: "usr_2", name: "Sam Seely", email: "sam@knock.app" },
-  { id: "usr_3", name: "Chris Bell", email: "chris@example.com" },
+  { id: "usr_1", name: "Jane Doe", email: "jane@example.com" },
+  { id: "usr_2", name: "John Smith", email: "john@example.com" },
+  { id: "usr_3", name: "Sam Lee", email: "sam@example.com" },
 ];
 
 // This option's text is rendered inside a component. It stays searchable

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
 import type { TgphComponentProps } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Box, Stack } from "@telegraph/layout";
 import { Modal } from "@telegraph/modal";
+import { Text } from "@telegraph/typography";
 import React from "react";
 
 import { Combobox as TelegraphCombobox } from "../Combobox";
@@ -602,6 +603,61 @@ export const YearPickerWithScrollToValue: Story = {
               {YEARS.map((year) => (
                 <TelegraphCombobox.Option key={year} value={year}>
                   {year}
+                </TelegraphCombobox.Option>
+              ))}
+            </TelegraphCombobox.Options>
+            <TelegraphCombobox.Empty />
+          </TelegraphCombobox.Content>
+        </TelegraphCombobox.Root>
+      </Box>
+    );
+  },
+};
+
+const USERS = [
+  { id: "usr_1", name: "Kyle McDonald", email: "kyle@knock.app" },
+  { id: "usr_2", name: "Sam Seely", email: "sam@knock.app" },
+  { id: "usr_3", name: "Chris Bell", email: "chris@example.com" },
+];
+
+// This option's text is rendered inside a component, so it can't be read off
+// the element tree — searchValue is what keeps it findable.
+const UserRow = ({ user }: { user: (typeof USERS)[number] }) => (
+  <Stack direction="column" align="flex-start">
+    <Text as="span" size="1">
+      {user.name}
+    </Text>
+    <Text as="span" size="0" color="gray">
+      {user.email}
+    </Text>
+  </Stack>
+);
+
+export const OptionsWithSearchValue: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = React.useState<string | undefined>(undefined);
+
+    return (
+      <Box w="80">
+        <TelegraphCombobox.Root
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          placeholder={"Select a user"}
+        >
+          <TelegraphCombobox.Trigger size="1" />
+          <TelegraphCombobox.Content>
+            <TelegraphCombobox.Search />
+            <TelegraphCombobox.Options>
+              {USERS.map((user) => (
+                <TelegraphCombobox.Option
+                  key={user.id}
+                  value={user.id}
+                  h="9"
+                  searchValue={`${user.name} ${user.email}`}
+                >
+                  <UserRow user={user} />
                 </TelegraphCombobox.Option>
               ))}
             </TelegraphCombobox.Options>

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -28,6 +28,7 @@ import {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -42,6 +43,7 @@ import {
   getCurrentOption,
   getOptionAccessibleLabel,
   getOptions,
+  getRenderedSearchText,
   getValueFromOption,
   isMultiSelect,
   isSingleSelect,
@@ -689,20 +691,12 @@ export type OptionProps<T extends TgphElement = "button"> = Omit<
   value: DefinedOption["value"];
   label?: DefinedOption["label"];
   selected?: boolean | null;
-  /**
-   * Text the search query is matched against, replacing the text derived from
-   * `label`/`children`/`value`. Needed when an option's visible text is
-   * rendered by a child component, since that text isn't readable from the
-   * element tree.
-   */
-  searchValue?: string;
 };
 
 const Option = <T extends TgphElement>({
   value,
   label,
   selected,
-  searchValue,
   onSelect,
   children,
   closeOnClick,
@@ -719,12 +713,27 @@ const Option = <T extends TgphElement>({
     optionRef,
   );
 
+  // Text produced inside child components (a custom option row, say) exists
+  // only in render output — the element-tree walk in the matcher can't reach
+  // it. Capture the rendered text whenever this option is in the DOM, so the
+  // query can be matched against what's actually on screen. The popup always
+  // opens with an empty query, so every option renders and captures before
+  // filtering starts; the ref persists while the option is filtered out. A ref
+  // (not state) is enough because matching only runs during renders, and every
+  // query change re-renders each option through context.
+  const renderedTextRef = useRef("");
+  useLayoutEffect(() => {
+    if (optionRef.current) {
+      renderedTextRef.current = getRenderedSearchText(optionRef.current);
+    }
+  });
+
   const isVisible =
     !context.searchQuery ||
     doesOptionMatchSearchQuery({
       children: label || children,
       value,
-      searchValue,
+      renderedText: renderedTextRef.current,
       searchQuery: context.searchQuery,
     });
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -961,9 +961,12 @@ const Search = ({
  * by identity; consumer components that forward a `value` prop down to one keep
  * being matched by that prop. Controlled inputs also carry a `value`, though —
  * a `<Combobox.Search value>` (matched by identity), a consumer's wrapper
- * around it (matched by its change handler, which no Option wrapper passes),
- * or any raw controlled input. Without the exclusions the current search text
- * is collected as a phantom option that shadows the real one.
+ * around it, or any raw controlled input. Without the exclusions the current
+ * search text is collected as a phantom option that shadows the real one.
+ *
+ * A change handler alone can't settle it: option wrappers may expose one too.
+ * Option-shaped props (label, selected, onSelect, children) break the tie —
+ * search inputs carry none of them.
  */
 function isOptionElement(element: ReactElement) {
   if (element.type === Option) return true;
@@ -971,11 +974,22 @@ function isOptionElement(element: ReactElement) {
 
   const props = element.props as {
     value?: unknown;
+    label?: unknown;
+    selected?: unknown;
+    onSelect?: unknown;
+    children?: unknown;
     onChange?: unknown;
     onValueChange?: unknown;
   };
 
-  if (props?.onChange || props?.onValueChange) return false;
+  const hasChangeHandler = Boolean(props?.onChange || props?.onValueChange);
+  const isOptionShaped =
+    props?.label !== undefined ||
+    props?.selected !== undefined ||
+    props?.onSelect !== undefined ||
+    props?.children !== undefined;
+
+  if (hasChangeHandler && !isOptionShaped) return false;
   return Boolean(props?.value);
 }
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -718,13 +718,23 @@ const Option = <T extends TgphElement>({
   // it. Capture the rendered text whenever this option is in the DOM, so the
   // query can be matched against what's actually on screen. The popup always
   // opens with an empty query, so every option renders and captures before
-  // filtering starts; the ref persists while the option is filtered out. A ref
-  // (not state) is enough because matching only runs during renders, and every
-  // query change re-renders each option through context.
-  const renderedTextRef = useRef("");
+  // filtering starts; the state persists while the option is filtered out.
+  // State (not a ref) so that content changing under an active query
+  // recomputes visibility immediately instead of waiting for a keystroke.
+  const [renderedText, setRenderedText] = useState<string[]>([]);
+  // Runs after every render on purpose: content can change without any value
+  // this effect could list as a dependency. The equality guard terminates the
+  // update chain, and the option's DOM being gone (filtered out) keeps the
+  // last capture.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
-    if (optionRef.current) {
-      renderedTextRef.current = getRenderedSearchText(optionRef.current);
+    if (!optionRef.current) return;
+    const captured = getRenderedSearchText(optionRef.current);
+    const changed =
+      captured.length !== renderedText.length ||
+      captured.some((variant, index) => variant !== renderedText[index]);
+    if (changed) {
+      setRenderedText(captured);
     }
   });
 
@@ -733,7 +743,7 @@ const Option = <T extends TgphElement>({
     doesOptionMatchSearchQuery({
       children: label || children,
       value,
-      renderedText: renderedTextRef.current,
+      renderedText,
       searchQuery: context.searchQuery,
     });
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -959,14 +959,24 @@ const Search = ({
 /**
  * Identifies which elements in the tree are options. Combobox.Option is matched
  * by identity; consumer components that forward a `value` prop down to one keep
- * being matched by that prop. Combobox.Search also takes a `value` when it's
- * controlled, so it has to be excluded explicitly — otherwise the current search
- * text is collected as a phantom option that shadows the real one.
+ * being matched by that prop. Controlled inputs also carry a `value`, though —
+ * a `<Combobox.Search value>` (matched by identity), a consumer's wrapper
+ * around it (matched by its change handler, which no Option wrapper passes),
+ * or any raw controlled input. Without the exclusions the current search text
+ * is collected as a phantom option that shadows the real one.
  */
 function isOptionElement(element: ReactElement) {
   if (element.type === Option) return true;
   if (element.type === Search) return false;
-  return Boolean((element.props as { value?: unknown })?.value);
+
+  const props = element.props as {
+    value?: unknown;
+    onChange?: unknown;
+    onValueChange?: unknown;
+  };
+
+  if (props?.onChange || props?.onValueChange) return false;
+  return Boolean(props?.value);
 }
 
 export type EmptyProps<T extends TgphElement = "div"> = TgphComponentProps<

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -713,20 +713,13 @@ const Option = <T extends TgphElement>({
     optionRef,
   );
 
-  // Text produced inside child components (a custom option row, say) exists
-  // only in render output — the element-tree walk in the matcher can't reach
-  // it. Capture the rendered text whenever this option is in the DOM, so the
-  // query can be matched against what's actually on screen. The popup always
-  // opens with an empty query, so every option renders and captures before
-  // filtering starts; the state persists while the option is filtered out.
-  // State (not a ref) so that content changing under an active query
-  // recomputes visibility immediately instead of waiting for a keystroke.
+  // Capture the option's rendered text so search can match text produced
+  // inside child components, which isn't readable from the element tree.
+  // The popup opens unfiltered, so every option captures before filtering
+  // starts; the state persists while the option is filtered out.
   const [renderedText, setRenderedText] = useState<string[]>([]);
-  // Runs after every render on purpose: content can change without any value
-  // this effect could list as a dependency. The updater returns the current
-  // state when the capture is unchanged, so React bails out and the update
-  // chain terminates; the option's DOM being gone (filtered out) keeps the
-  // last capture.
+  // No deps on purpose: content can change without anything to depend on.
+  // The updater bails out when the capture is unchanged.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     if (!optionRef.current) return;
@@ -976,18 +969,11 @@ const Search = ({
   );
 };
 
-/**
- * Identifies which elements in the tree are options. Combobox.Option is matched
- * by identity; consumer components that forward a `value` prop down to one keep
- * being matched by that prop. Controlled inputs also carry a `value`, though —
- * a `<Combobox.Search value>` (matched by identity), a consumer's wrapper
- * around it, or any raw controlled input. Without the exclusions the current
- * search text is collected as a phantom option that shadows the real one.
- *
- * A change handler alone can't settle it: option wrappers may expose one too.
- * Option-shaped props (label, selected, onSelect, children) break the tie —
- * search inputs carry none of them.
- */
+// Combobox.Option matches by type; a truthy `value` prop keeps consumer
+// wrappers around Option matching. Controlled inputs also carry `value` and
+// would become phantom options, so a change handler excludes an element
+// unless option-shaped props (label/selected/onSelect/children) mark it as
+// a wrapped option.
 const isOptionElement = (element: ReactElement) => {
   if (element.type === Option) return true;
   if (element.type === Search) return false;
@@ -1040,9 +1026,8 @@ const Empty = <T extends TgphElement>({
 
     recount();
 
-    // Options can appear and disappear without anything this effect could
-    // depend on changing — a content update can hide the last match without a
-    // keystroke. Watching the DOM directly covers every source of change.
+    // Options can come and go without anything to depend on (a content
+    // update can hide the last match), so watch the DOM directly
     const observer = new MutationObserver(recount);
     observer.observe(content, { childList: true, subtree: true });
 

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -147,7 +147,7 @@ const Root = <
   const contentRef = useRef<HTMLDivElement>(null);
 
   const options = useMemo(() => {
-    return getOptions(children, isOptionElement);
+    return getOptions({ children, isOptionElement });
   }, [children]);
 
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -723,19 +723,20 @@ const Option = <T extends TgphElement>({
   // recomputes visibility immediately instead of waiting for a keystroke.
   const [renderedText, setRenderedText] = useState<string[]>([]);
   // Runs after every render on purpose: content can change without any value
-  // this effect could list as a dependency. The equality guard terminates the
-  // update chain, and the option's DOM being gone (filtered out) keeps the
+  // this effect could list as a dependency. The updater returns the current
+  // state when the capture is unchanged, so React bails out and the update
+  // chain terminates; the option's DOM being gone (filtered out) keeps the
   // last capture.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useLayoutEffect(() => {
     if (!optionRef.current) return;
     const captured = getRenderedSearchText(optionRef.current);
-    const changed =
-      captured.length !== renderedText.length ||
-      captured.some((variant, index) => variant !== renderedText[index]);
-    if (changed) {
-      setRenderedText(captured);
-    }
+    setRenderedText((current) => {
+      const changed =
+        captured.length !== current.length ||
+        captured.some((variant, index) => variant !== current[index]);
+      return changed ? captured : current;
+    });
   });
 
   const isVisible =
@@ -987,7 +988,7 @@ const Search = ({
  * Option-shaped props (label, selected, onSelect, children) break the tie —
  * search inputs carry none of them.
  */
-function isOptionElement(element: ReactElement) {
+const isOptionElement = (element: ReactElement) => {
   if (element.type === Option) return true;
   if (element.type === Search) return false;
 
@@ -1010,7 +1011,7 @@ function isOptionElement(element: ReactElement) {
 
   if (hasChangeHandler && !isOptionShaped) return false;
   return Boolean(props?.value);
-}
+};
 
 export type EmptyProps<T extends TgphElement = "div"> = TgphComponentProps<
   typeof Stack<T>

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1029,16 +1029,24 @@ const Empty = <T extends TgphElement>({
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
-    const options = context.contentRef?.current?.querySelectorAll(
-      "[data-tgph-combobox-option]",
-    );
+    const content = context.contentRef?.current;
+    if (!content) return undefined;
 
-    if (options?.length === 0) {
-      setIsVisible(true);
-    } else {
-      setIsVisible(false);
-    }
-  }, [context.searchQuery, context.contentRef, children]);
+    const recount = () => {
+      const options = content.querySelectorAll("[data-tgph-combobox-option]");
+      setIsVisible(options.length === 0);
+    };
+
+    recount();
+
+    // Options can appear and disappear without anything this effect could
+    // depend on changing — a content update can hide the last match without a
+    // keystroke. Watching the DOM directly covers every source of change.
+    const observer = new MutationObserver(recount);
+    observer.observe(content, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, [context.contentRef]);
 
   if (isVisible) {
     return (

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -17,6 +17,7 @@ import {
   type CSSProperties,
   type ChangeEvent,
   type MouseEvent,
+  type ReactElement,
   type KeyboardEvent as ReactKeyboardEvent,
   type KeyboardEventHandler as ReactKeyboardEventHandler,
   type ReactNode,
@@ -144,7 +145,7 @@ const Root = <
   const contentRef = useRef<HTMLDivElement>(null);
 
   const options = useMemo(() => {
-    return getOptions(children);
+    return getOptions(children, isOptionElement);
   }, [children]);
 
   const [searchQuery, setSearchQuery] = useState<string>("");
@@ -688,12 +689,20 @@ export type OptionProps<T extends TgphElement = "button"> = Omit<
   value: DefinedOption["value"];
   label?: DefinedOption["label"];
   selected?: boolean | null;
+  /**
+   * Text the search query is matched against, replacing the text derived from
+   * `label`/`children`/`value`. Needed when an option's visible text is
+   * rendered by a child component, since that text isn't readable from the
+   * element tree.
+   */
+  searchValue?: string;
 };
 
 const Option = <T extends TgphElement>({
   value,
   label,
   selected,
+  searchValue,
   onSelect,
   children,
   closeOnClick,
@@ -715,6 +724,7 @@ const Option = <T extends TgphElement>({
     doesOptionMatchSearchQuery({
       children: label || children,
       value,
+      searchValue,
       searchQuery: context.searchQuery,
     });
 
@@ -945,6 +955,19 @@ const Search = ({
     </Box>
   );
 };
+
+/**
+ * Identifies which elements in the tree are options. Combobox.Option is matched
+ * by identity; consumer components that forward a `value` prop down to one keep
+ * being matched by that prop. Combobox.Search also takes a `value` when it's
+ * controlled, so it has to be excluded explicitly — otherwise the current search
+ * text is collected as a phantom option that shadows the real one.
+ */
+function isOptionElement(element: ReactElement) {
+  if (element.type === Option) return true;
+  if (element.type === Search) return false;
+  return Boolean((element.props as { value?: unknown })?.value);
+}
 
 export type EmptyProps<T extends TgphElement = "div"> = TgphComponentProps<
   typeof Stack<T>

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -250,6 +250,42 @@ describe("Combobox search matching", () => {
       rerender(<Cmp email="kyle@example.com" />);
       expect(queryOptions().length).toBe(0);
     });
+
+    it("shows the empty state when a content change hides the last match", async () => {
+      const Cmp = ({ email }: { email: string }) => {
+        const [value, setValue] = useState<string>("");
+        return (
+          <Combobox.Root value={value} onValueChange={setValue}>
+            <Combobox.Trigger />
+            <Combobox.Content>
+              <Combobox.Search />
+              <Combobox.Options>
+                <Combobox.Option value="u_1">
+                  <UserRow name="Kyle McDonald" email={email} />
+                </Combobox.Option>
+              </Combobox.Options>
+              <Combobox.Empty />
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+
+      const { container, rerender } = render(<Cmp email="kyle@knock.app" />);
+      const user = await open(container);
+
+      await user.keyboard("knock.app");
+      expect(queryOptions().length).toBe(1);
+      expect(document.querySelector("[data-tgph-combobox-empty]")).toBeNull();
+
+      // The last match hides from a content update, not a keystroke — the
+      // empty message must still appear.
+      rerender(<Cmp email="kyle@example.com" />);
+      await waitFor(() =>
+        expect(
+          document.querySelector("[data-tgph-combobox-empty]"),
+        ).not.toBeNull(),
+      );
+    });
   });
 
   describe("findStringNodes", () => {

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -139,55 +139,63 @@ describe("Combobox search matching", () => {
     expect(queryOptions().length).toBe(1);
   });
 
-  describe("searchValue", () => {
-    it("matches text rendered by a child component", async () => {
-      // The email is produced inside UserRow's render output, so it can't be
-      // read off the element tree — searchValue is how it stays findable.
-      const UserRow = ({ email }: { email: string }) => (
+  describe("text rendered by child components", () => {
+    // The email exists only in UserRow's render output — unreachable from the
+    // element tree. Matching works because each option captures its rendered
+    // DOM text while visible and the query is matched against the capture.
+    const UserRow = ({ name, email }: { name: string; email: string }) => (
+      <Stack direction="column">
+        <Text as="span">{name}</Text>
         <Text as="span">{email}</Text>
-      );
+      </Stack>
+    );
 
+    it("matches automatically, with no extra props", async () => {
       const { container } = render(
         <Harness>
-          <Combobox.Option
-            value="u_1"
-            searchValue="Kyle McDonald kyle@knock.app"
-          >
-            <UserRow email="kyle@knock.app" />
+          <Combobox.Option value="u_1">
+            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
+          </Combobox.Option>
+          <Combobox.Option value="u_2">
+            <UserRow name="Sam Seely" email="sam@knock.app" />
           </Combobox.Option>
         </Harness>,
       );
       const user = await open(container);
-      await user.keyboard("knock.app");
+      await user.keyboard("kyle@knock.app");
       expect(queryOptions().length).toBe(1);
     });
 
-    it("replaces the derived text rather than adding to it", async () => {
+    it("re-matches after being filtered out and back", async () => {
+      // The capture must survive the option unmounting while filtered out.
       const { container } = render(
         <Harness>
-          <Combobox.Option value="usr_internal_id" searchValue="Alpha">
-            <Text as="span">Alpha</Text>
+          <Combobox.Option value="u_1">
+            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
           </Combobox.Option>
         </Harness>,
       );
       const user = await open(container);
-      // The option value would otherwise match; searchValue excludes it.
-      await user.keyboard("internal");
+
+      await user.keyboard("sam");
       expect(queryOptions().length).toBe(0);
+
+      await user.keyboard("{Backspace}{Backspace}{Backspace}kyle");
+      expect(queryOptions().length).toBe(1);
     });
 
-    it("is not forwarded to the DOM", async () => {
+    it("matches a query spanning the wrapper's sibling text nodes", async () => {
       const { container } = render(
         <Harness>
-          <Combobox.Option value="u_1" searchValue="findme">
-            <Text as="span">Alpha</Text>
+          <Combobox.Option value="u_1">
+            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
           </Combobox.Option>
         </Harness>,
       );
-      await open(container);
-      expect(
-        document.querySelector("[data-tgph-combobox-option]"),
-      ).not.toHaveAttribute("searchValue");
+      const user = await open(container);
+      // "McDonald" and the email are separate DOM nodes inside the wrapper.
+      await user.keyboard("McDonald kyle@knock.app");
+      expect(queryOptions().length).toBe(1);
     });
   });
 
@@ -321,23 +329,6 @@ describe("Combobox search matching", () => {
       expect(
         document.querySelector('[data-testid="resolved"]')?.textContent,
       ).toBe(JSON.stringify({ value: "email", label: "Email" }));
-    });
-  });
-
-  describe("searchValue hardening", () => {
-    it("a null searchValue falls back to derived text instead of crashing", async () => {
-      // The documented pattern derives searchValue from user data, where null
-      // emails are realistic for JS consumers outside the string type.
-      const { container } = render(
-        <Harness>
-          <Combobox.Option value="u_1" searchValue={null as unknown as string}>
-            <Text as="span">Alpha</Text>
-          </Combobox.Option>
-        </Harness>,
-      );
-      const user = await open(container);
-      await user.keyboard("alp");
-      expect(queryOptions().length).toBe(1);
     });
   });
 });

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -76,6 +76,32 @@ describe("Combobox search matching", () => {
     expect(queryOptions().length).toBe(1);
   });
 
+  it("matches when inline markup already carries a trailing space", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="u_1">
+          Kyle <Text as="span">McDonald</Text>
+        </Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("Kyle McDonald");
+    expect(queryOptions().length).toBe(1);
+  });
+
+  it("ignores repeated whitespace inside the query", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="u_1">
+          <Text as="span">Kyle McDonald</Text>
+        </Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("Kyle  McDonald");
+    expect(queryOptions().length).toBe(1);
+  });
+
   it("ignores surrounding whitespace in the query", async () => {
     const { container } = render(
       <Harness>
@@ -173,6 +199,17 @@ describe("Combobox search matching", () => {
           children: <span>{2024}</span>,
           value: "y",
           searchQuery: "2024",
+        }),
+      ).toBe(true);
+    });
+
+    it("collects a nested zero, which is falsy but still renders", () => {
+      expect(findStringNodes(<span>{0}</span>)).toEqual(["0"]);
+      expect(
+        doesOptionMatchSearchQuery({
+          children: <span>{0}</span>,
+          value: "y",
+          searchQuery: "0",
         }),
       ).toBe(true);
     });

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -51,12 +51,12 @@ describe("Combobox search matching", () => {
     const { container } = render(
       <Harness>
         <Combobox.Option value="u_1">
-          <Text as="span">kyle@knock.app</Text>
+          <Text as="span">jane@example.com</Text>
         </Combobox.Option>
       </Harness>,
     );
     const user = await open(container);
-    await user.keyboard("kyle@knock.app");
+    await user.keyboard("jane@example.com");
     expect(queryOptions().length).toBe(1);
   });
 
@@ -65,14 +65,14 @@ describe("Combobox search matching", () => {
       <Harness>
         <Combobox.Option value="u_1">
           <Stack direction="column">
-            <Text as="span">Kyle</Text>
-            <Text as="span">McDonald</Text>
+            <Text as="span">Jane</Text>
+            <Text as="span">Doe</Text>
           </Stack>
         </Combobox.Option>
       </Harness>,
     );
     const user = await open(container);
-    await user.keyboard("Kyle McDonald");
+    await user.keyboard("Jane Doe");
     expect(queryOptions().length).toBe(1);
   });
 
@@ -80,12 +80,12 @@ describe("Combobox search matching", () => {
     const { container } = render(
       <Harness>
         <Combobox.Option value="u_1">
-          Kyle <Text as="span">McDonald</Text>
+          Jane <Text as="span">Doe</Text>
         </Combobox.Option>
       </Harness>,
     );
     const user = await open(container);
-    await user.keyboard("Kyle McDonald");
+    await user.keyboard("Jane Doe");
     expect(queryOptions().length).toBe(1);
   });
 
@@ -93,12 +93,12 @@ describe("Combobox search matching", () => {
     const { container } = render(
       <Harness>
         <Combobox.Option value="u_1">
-          <Text as="span">Kyle McDonald</Text>
+          <Text as="span">Jane Doe</Text>
         </Combobox.Option>
       </Harness>,
     );
     const user = await open(container);
-    await user.keyboard("Kyle  McDonald");
+    await user.keyboard("Jane  Doe");
     expect(queryOptions().length).toBe(1);
   });
 
@@ -106,12 +106,12 @@ describe("Combobox search matching", () => {
     const { container } = render(
       <Harness>
         <Combobox.Option value="u_1">
-          <Text as="span">kyle@knock.app</Text>
+          <Text as="span">jane@example.com</Text>
         </Combobox.Option>
       </Harness>,
     );
     const user = await open(container);
-    await user.keyboard("  kyle@knock.app  ");
+    await user.keyboard("  jane@example.com  ");
     expect(queryOptions().length).toBe(1);
   });
 
@@ -140,9 +140,8 @@ describe("Combobox search matching", () => {
   });
 
   describe("text rendered by child components", () => {
-    // The email exists only in UserRow's render output — unreachable from the
-    // element tree. Matching works because each option captures its rendered
-    // DOM text while visible and the query is matched against the capture.
+    // The email only exists in UserRow's render output, so matching relies
+    // on the captured rendered text
     const UserRow = ({ name, email }: { name: string; email: string }) => (
       <Stack direction="column">
         <Text as="span">{name}</Text>
@@ -154,24 +153,24 @@ describe("Combobox search matching", () => {
       const { container } = render(
         <Harness>
           <Combobox.Option value="u_1">
-            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
+            <UserRow name="Jane Doe" email="jane@example.com" />
           </Combobox.Option>
           <Combobox.Option value="u_2">
-            <UserRow name="Sam Seely" email="sam@knock.app" />
+            <UserRow name="John Smith" email="john@example.com" />
           </Combobox.Option>
         </Harness>,
       );
       const user = await open(container);
-      await user.keyboard("kyle@knock.app");
+      await user.keyboard("jane@example.com");
       expect(queryOptions().length).toBe(1);
     });
 
     it("re-matches after being filtered out and back", async () => {
-      // The capture must survive the option unmounting while filtered out.
+      // The capture must survive being filtered out
       const { container } = render(
         <Harness>
           <Combobox.Option value="u_1">
-            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
+            <UserRow name="Jane Doe" email="jane@example.com" />
           </Combobox.Option>
         </Harness>,
       );
@@ -180,7 +179,7 @@ describe("Combobox search matching", () => {
       await user.keyboard("sam");
       expect(queryOptions().length).toBe(0);
 
-      await user.keyboard("{Backspace}{Backspace}{Backspace}kyle");
+      await user.keyboard("{Backspace}{Backspace}{Backspace}jane");
       expect(queryOptions().length).toBe(1);
     });
 
@@ -188,20 +187,19 @@ describe("Combobox search matching", () => {
       const { container } = render(
         <Harness>
           <Combobox.Option value="u_1">
-            <UserRow name="Kyle McDonald" email="kyle@knock.app" />
+            <UserRow name="Jane Doe" email="jane@example.com" />
           </Combobox.Option>
         </Harness>,
       );
       const user = await open(container);
-      // "McDonald" and the email are separate DOM nodes inside the wrapper.
-      await user.keyboard("McDonald kyle@knock.app");
+      // The name and email are separate DOM nodes inside the wrapper
+      await user.keyboard("Doe jane@example.com");
       expect(queryOptions().length).toBe(1);
     });
 
     it("does not match across the captured variants' seam", async () => {
-      // Captured text has two joining variants ("abcd" and "ab cd"). A query
-      // assembled from the end of one and the start of the other ("cd ab")
-      // appears in neither and never on screen, so it must not match.
+      // "cd ab" spans the seam between the captured variants ("abcd" and
+      // "ab cd") and never appears on screen, so it must not match
       const Row = () => (
         <Stack direction="column">
           <Text as="span">ab</Text>
@@ -231,7 +229,7 @@ describe("Combobox search matching", () => {
               <Combobox.Search />
               <Combobox.Options>
                 <Combobox.Option value="u_1">
-                  <UserRow name="Kyle McDonald" email={email} />
+                  <UserRow name="Jane Doe" email={email} />
                 </Combobox.Option>
               </Combobox.Options>
             </Combobox.Content>
@@ -239,15 +237,15 @@ describe("Combobox search matching", () => {
         );
       };
 
-      const { container, rerender } = render(<Cmp email="kyle@knock.app" />);
+      const { container, rerender } = render(<Cmp email="jane@acme.com" />);
       const user = await open(container);
 
-      await user.keyboard("knock.app");
+      await user.keyboard("acme.com");
       expect(queryOptions().length).toBe(1);
 
-      // The on-screen text stops matching the query; the option must hide
-      // without needing another keystroke.
-      rerender(<Cmp email="kyle@example.com" />);
+      // Content stopped matching, so the option must hide without another
+      // keystroke
+      rerender(<Cmp email="jane@example.com" />);
       expect(queryOptions().length).toBe(0);
     });
 
@@ -261,7 +259,7 @@ describe("Combobox search matching", () => {
               <Combobox.Search />
               <Combobox.Options>
                 <Combobox.Option value="u_1">
-                  <UserRow name="Kyle McDonald" email={email} />
+                  <UserRow name="Jane Doe" email={email} />
                 </Combobox.Option>
               </Combobox.Options>
               <Combobox.Empty />
@@ -270,16 +268,16 @@ describe("Combobox search matching", () => {
         );
       };
 
-      const { container, rerender } = render(<Cmp email="kyle@knock.app" />);
+      const { container, rerender } = render(<Cmp email="jane@acme.com" />);
       const user = await open(container);
 
-      await user.keyboard("knock.app");
+      await user.keyboard("acme.com");
       expect(queryOptions().length).toBe(1);
       expect(document.querySelector("[data-tgph-combobox-empty]")).toBeNull();
 
-      // The last match hides from a content update, not a keystroke — the
-      // empty message must still appear.
-      rerender(<Cmp email="kyle@example.com" />);
+      // The last match hid from a content update, not a keystroke; the
+      // empty message must still appear
+      rerender(<Cmp email="jane@example.com" />);
       await waitFor(() =>
         expect(
           document.querySelector("[data-tgph-combobox-empty]"),
@@ -335,7 +333,7 @@ describe("Combobox search matching", () => {
       const { container } = render(<Cmp />);
       const user = await open(container);
 
-      // Typing the selected value must not shadow the real option.
+      // Typing the selected value must not shadow the real option
       await user.keyboard("email");
       expect(
         document.querySelector('[data-testid="resolved"]')?.textContent,
@@ -343,9 +341,8 @@ describe("Combobox search matching", () => {
     });
 
     it("also excludes a search input wrapped in a consumer component", async () => {
-      // The wrapper's element type isn't Search, so the exclusion can't rely
-      // on identity alone — the controlled-input signature (value paired with
-      // a change handler) is what marks it as a non-option.
+      // A wrapped search isn't Search by type; its value + change handler
+      // signature is what excludes it
       const MySearch = (props: {
         value: string;
         onValueChange: (v: string) => void;
@@ -379,10 +376,8 @@ describe("Combobox search matching", () => {
     });
 
     it("does not exclude an Option wrapper that exposes a change callback", async () => {
-      // The controlled-input exclusion must not swallow option wrappers: this
-      // one carries value + onValueChange like a controlled input would, but
-      // its label prop marks it as option-shaped, so getOptions keeps it and
-      // the trigger can resolve the selected value's label.
+      // value + onValueChange looks like a controlled input, but the label
+      // prop marks it option-shaped, so getOptions keeps it
       const MyOption = ({
         value,
         label,

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -1,0 +1,211 @@
+import { Stack } from "@telegraph/layout";
+import { Text } from "@telegraph/typography";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode, useState } from "react";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { Combobox } from "./Combobox";
+import {
+  doesOptionMatchSearchQuery,
+  findStringNodes,
+} from "./Combobox.helpers";
+
+// Mock ResizeObserver
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const queryOptions = () =>
+  document.querySelectorAll("[data-tgph-combobox-option]");
+
+const Harness = ({ children }: { children: ReactNode }) => {
+  const [value, setValue] = useState<string>("");
+  return (
+    <Combobox.Root value={value} onValueChange={setValue}>
+      <Combobox.Trigger />
+      <Combobox.Content>
+        <Combobox.Search />
+        <Combobox.Options>{children}</Combobox.Options>
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+
+const open = async (container: HTMLElement) => {
+  const user = userEvent.setup();
+  const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+  await user.click(trigger!);
+  await waitFor(() =>
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true"),
+  );
+  return user;
+};
+
+describe("Combobox search matching", () => {
+  it("matches text rendered directly in nested children", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="u_1">
+          <Text as="span">kyle@knock.app</Text>
+        </Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("kyle@knock.app");
+    expect(queryOptions().length).toBe(1);
+  });
+
+  it("matches a query spanning sibling text nodes", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="u_1">
+          <Stack direction="column">
+            <Text as="span">Kyle</Text>
+            <Text as="span">McDonald</Text>
+          </Stack>
+        </Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("Kyle McDonald");
+    expect(queryOptions().length).toBe(1);
+  });
+
+  it("ignores surrounding whitespace in the query", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="u_1">
+          <Text as="span">kyle@knock.app</Text>
+        </Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("  kyle@knock.app  ");
+    expect(queryOptions().length).toBe(1);
+  });
+
+  it("shows every option when the query is only whitespace", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="a">Alpha</Combobox.Option>
+        <Combobox.Option value="b">Beta</Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("   ");
+    expect(queryOptions().length).toBe(2);
+  });
+
+  it("still filters out options that do not match", async () => {
+    const { container } = render(
+      <Harness>
+        <Combobox.Option value="a">Alpha</Combobox.Option>
+        <Combobox.Option value="b">Beta</Combobox.Option>
+      </Harness>,
+    );
+    const user = await open(container);
+    await user.keyboard("Alph");
+    expect(queryOptions().length).toBe(1);
+  });
+
+  describe("searchValue", () => {
+    it("matches text rendered by a child component", async () => {
+      // The email is produced inside UserRow's render output, so it can't be
+      // read off the element tree — searchValue is how it stays findable.
+      const UserRow = ({ email }: { email: string }) => (
+        <Text as="span">{email}</Text>
+      );
+
+      const { container } = render(
+        <Harness>
+          <Combobox.Option
+            value="u_1"
+            searchValue="Kyle McDonald kyle@knock.app"
+          >
+            <UserRow email="kyle@knock.app" />
+          </Combobox.Option>
+        </Harness>,
+      );
+      const user = await open(container);
+      await user.keyboard("knock.app");
+      expect(queryOptions().length).toBe(1);
+    });
+
+    it("replaces the derived text rather than adding to it", async () => {
+      const { container } = render(
+        <Harness>
+          <Combobox.Option value="usr_internal_id" searchValue="Alpha">
+            <Text as="span">Alpha</Text>
+          </Combobox.Option>
+        </Harness>,
+      );
+      const user = await open(container);
+      // The option value would otherwise match; searchValue excludes it.
+      await user.keyboard("internal");
+      expect(queryOptions().length).toBe(0);
+    });
+
+    it("is not forwarded to the DOM", async () => {
+      const { container } = render(
+        <Harness>
+          <Combobox.Option value="u_1" searchValue="findme">
+            <Text as="span">Alpha</Text>
+          </Combobox.Option>
+        </Harness>,
+      );
+      await open(container);
+      expect(
+        document.querySelector("[data-tgph-combobox-option]"),
+      ).not.toHaveAttribute("searchValue");
+    });
+  });
+
+  describe("findStringNodes", () => {
+    it("collects numbers as searchable text", () => {
+      expect(findStringNodes(<span>{2024}</span>)).toEqual(["2024"]);
+      expect(
+        doesOptionMatchSearchQuery({
+          children: <span>{2024}</span>,
+          value: "y",
+          searchQuery: "2024",
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("a controlled Combobox.Search is not treated as an option", () => {
+    it("keeps resolving the selected value to the real option's label", async () => {
+      const Cmp = () => {
+        const [query, setQuery] = useState<string>("");
+        return (
+          <Combobox.Root value="email">
+            <Combobox.Trigger>
+              {({ value: resolved }) => (
+                <span data-testid="resolved">{JSON.stringify(resolved)}</span>
+              )}
+            </Combobox.Trigger>
+            <Combobox.Content>
+              <Combobox.Search value={query} onValueChange={setQuery} />
+              <Combobox.Options>
+                <Combobox.Option value="email" label="Email" />
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+      const { container } = render(<Cmp />);
+      const user = await open(container);
+
+      // Typing the selected value must not shadow the real option.
+      await user.keyboard("email");
+      expect(
+        document.querySelector('[data-testid="resolved"]')?.textContent,
+      ).toBe(JSON.stringify({ value: "email", label: "Email" }));
+    });
+  });
+});

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -280,6 +280,48 @@ describe("Combobox search matching", () => {
         document.querySelector('[data-testid="resolved"]')?.textContent,
       ).toBe(JSON.stringify({ value: "email", label: "Email" }));
     });
+
+    it("does not exclude an Option wrapper that exposes a change callback", async () => {
+      // The controlled-input exclusion must not swallow option wrappers: this
+      // one carries value + onValueChange like a controlled input would, but
+      // its label prop marks it as option-shaped, so getOptions keeps it and
+      // the trigger can resolve the selected value's label.
+      const MyOption = ({
+        value,
+        label,
+        onValueChange,
+      }: {
+        value: string;
+        label: string;
+        onValueChange: (v: string) => void;
+      }) => (
+        <Combobox.Option
+          value={value}
+          label={label}
+          onSelect={() => onValueChange(value)}
+        />
+      );
+
+      const Cmp = () => (
+        <Combobox.Root value="email">
+          <Combobox.Trigger>
+            {({ value: resolved }) => (
+              <span data-testid="resolved">{JSON.stringify(resolved)}</span>
+            )}
+          </Combobox.Trigger>
+          <Combobox.Content>
+            <Combobox.Options>
+              <MyOption value="email" label="Email" onValueChange={() => {}} />
+            </Combobox.Options>
+          </Combobox.Content>
+        </Combobox.Root>
+      );
+      render(<Cmp />);
+
+      expect(
+        document.querySelector('[data-testid="resolved"]')?.textContent,
+      ).toBe(JSON.stringify({ value: "email", label: "Email" }));
+    });
   });
 
   describe("searchValue hardening", () => {

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -197,6 +197,59 @@ describe("Combobox search matching", () => {
       await user.keyboard("McDonald kyle@knock.app");
       expect(queryOptions().length).toBe(1);
     });
+
+    it("does not match across the captured variants' seam", async () => {
+      // Captured text has two joining variants ("abcd" and "ab cd"). A query
+      // assembled from the end of one and the start of the other ("cd ab")
+      // appears in neither and never on screen, so it must not match.
+      const Row = () => (
+        <Stack direction="column">
+          <Text as="span">ab</Text>
+          <Text as="span">cd</Text>
+        </Stack>
+      );
+
+      const { container } = render(
+        <Harness>
+          <Combobox.Option value="u_1">
+            <Row />
+          </Combobox.Option>
+        </Harness>,
+      );
+      const user = await open(container);
+      await user.keyboard("cd ab");
+      expect(queryOptions().length).toBe(0);
+    });
+
+    it("re-filters when an option's content changes under an active query", async () => {
+      const Cmp = ({ email }: { email: string }) => {
+        const [value, setValue] = useState<string>("");
+        return (
+          <Combobox.Root value={value} onValueChange={setValue}>
+            <Combobox.Trigger />
+            <Combobox.Content>
+              <Combobox.Search />
+              <Combobox.Options>
+                <Combobox.Option value="u_1">
+                  <UserRow name="Kyle McDonald" email={email} />
+                </Combobox.Option>
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+
+      const { container, rerender } = render(<Cmp email="kyle@knock.app" />);
+      const user = await open(container);
+
+      await user.keyboard("knock.app");
+      expect(queryOptions().length).toBe(1);
+
+      // The on-screen text stops matching the query; the option must hide
+      // without needing another keystroke.
+      rerender(<Cmp email="kyle@example.com" />);
+      expect(queryOptions().length).toBe(0);
+    });
   });
 
   describe("findStringNodes", () => {

--- a/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxSearch.test.tsx
@@ -244,5 +244,58 @@ describe("Combobox search matching", () => {
         document.querySelector('[data-testid="resolved"]')?.textContent,
       ).toBe(JSON.stringify({ value: "email", label: "Email" }));
     });
+
+    it("also excludes a search input wrapped in a consumer component", async () => {
+      // The wrapper's element type isn't Search, so the exclusion can't rely
+      // on identity alone — the controlled-input signature (value paired with
+      // a change handler) is what marks it as a non-option.
+      const MySearch = (props: {
+        value: string;
+        onValueChange: (v: string) => void;
+      }) => <Combobox.Search {...props} />;
+
+      const Cmp = () => {
+        const [query, setQuery] = useState<string>("");
+        return (
+          <Combobox.Root value="email">
+            <Combobox.Trigger>
+              {({ value: resolved }) => (
+                <span data-testid="resolved">{JSON.stringify(resolved)}</span>
+              )}
+            </Combobox.Trigger>
+            <Combobox.Content>
+              <MySearch value={query} onValueChange={setQuery} />
+              <Combobox.Options>
+                <Combobox.Option value="email" label="Email" />
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+      const { container } = render(<Cmp />);
+      const user = await open(container);
+
+      await user.keyboard("email");
+      expect(
+        document.querySelector('[data-testid="resolved"]')?.textContent,
+      ).toBe(JSON.stringify({ value: "email", label: "Email" }));
+    });
+  });
+
+  describe("searchValue hardening", () => {
+    it("a null searchValue falls back to derived text instead of crashing", async () => {
+      // The documented pattern derives searchValue from user data, where null
+      // emails are realistic for JS consumers outside the string type.
+      const { container } = render(
+        <Harness>
+          <Combobox.Option value="u_1" searchValue={null as unknown as string}>
+            <Text as="span">Alpha</Text>
+          </Combobox.Option>
+        </Harness>,
+      );
+      const user = await open(container);
+      await user.keyboard("alp");
+      expect(queryOptions().length).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## What changed

`Combobox`'s client-side search read option text off the React element tree, so it missed text it renders on screen — most visibly, text produced inside a child component.

**Before** — typing `kyle@knock.app` filters out the option showing that email:

<img width="524" height="265" alt="before" src="https://github.com/user-attachments/assets/0f1b5b2f-6cd3-4890-bc1b-e7128b6e6e3f" />

**After** — the same option matches, with no consumer changes:

<img width="524" height="265" alt="after" src="https://github.com/user-attachments/assets/a0a44497-33c8-4d5b-adaa-fd45769793b8" />

- Matches options by their rendered DOM text, captured per option while it's on screen. Text inside wrapper components (like a custom user row) is now searchable automatically.
- Normalizes whitespace on the query and option text.
- Matches across sibling nodes, and collects numeric children.
- Stops treating a controlled `<Combobox.Search value>` (or any controlled input inside `Content`) as an option.

## Why

Reported as email search breaking after the Base UI migration. Not a regression, these are long-standing bugs. Only affects an uncontrolled `<Combobox.Search />` — server-side search bypasses this filter.

Resolves KNO-14268
