### PR TITLE
fix(truncate): stop useTruncate effect re-running on every render

### DIFF
--- a/.changeset/truncate-max-update-depth-fix.md
+++ b/.changeset/truncate-max-update-depth-fix.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/truncate": patch
+---
+
+fix(truncate): prevent "Maximum update depth exceeded" crash in re-render-heavy environments
+
+`TooltipIfTruncated` keyed `useTruncate`'s measurement effect on the freshly-created `children` element, so the effect re-mounted and called `setState` on every render. In continuously re-rendering trees (e.g. a ReactFlow graph editor) React's same-value bailout could be defeated, cascading into a runaway synchronous update loop (React error #185). The effect now depends on the stable rendered text instead of the element identity, and `useTruncate` only writes state when the truncation value actually changes.

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -163,4 +163,43 @@ describe("TooltipIfTruncated", () => {
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
+
+  // Regression test for KNO-14285: the truncation effect must not re-mount on
+  // every render. `children` is a freshly-created element each render, so
+  // keying the effect on its identity re-ran the effect (and its `setState`)
+  // continuously inside re-render-heavy environments like the ReactFlow-based
+  // Workflow Graph Editor, tipping React into a "Maximum update depth exceeded"
+  // loop. A stable dependency (the rendered text) constructs one ResizeObserver
+  // for the lifetime of the content, not one per render.
+  it("does not re-run the truncation effect on re-renders with identical content", () => {
+    let observerCount = 0;
+    class CountingResizeObserver {
+      constructor() {
+        observerCount += 1;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", CountingResizeObserver);
+
+    // A brand-new child element on every render, with unchanged content —
+    // exactly what ReactFlow does to the step-card nodes.
+    const renderTree = () => (
+      <TooltipIfTruncated delayDuration={0} skipAnimation>
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Long value
+        </TestTrigger>
+      </TooltipIfTruncated>
+    );
+
+    const { rerender } = render(renderTree());
+    for (let i = 0; i < 10; i += 1) {
+      rerender(renderTree());
+    }
+
+    // Before the fix this was 11 (one observer per render). The stable text
+    // dependency means the effect runs exactly once.
+    expect(observerCount).toBe(1);
+  });
 });

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -14,13 +14,41 @@ export type TooltipIfTruncatedProps = Optional<
   "label"
 >;
 
+/**
+ * Recursively extract the rendered text from a node.
+ *
+ * `useTruncate` re-measures whenever its dependencies change, and the content
+ * we render is what determines whether it overflows. But `children` is a
+ * freshly-created element on every render, so depending on the element itself
+ * (`[children]`) re-runs the effect — and its `setState` — on *every* render.
+ * In a re-render-heavy tree (e.g. a ReactFlow graph) that can tip React into a
+ * "Maximum update depth exceeded" loop (React #185). The visible text stays
+ * referentially stable across renders when the content is unchanged, so it is
+ * the correct thing to key on.
+ */
+const getTextContent = (node: ReactNode): string => {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(getTextContent).join("");
+  }
+  if (isValidElement(node)) {
+    const { children } = node.props as { children?: ReactNode };
+    return getTextContent(children);
+  }
+  return "";
+};
+
 const TooltipIfTruncated = ({
   label,
   children,
   ...props
 }: TooltipIfTruncatedProps) => {
   const truncateRef = useRef<HTMLElement>(null);
-  const { truncated } = useTruncate({ tgphRef: truncateRef }, [children]);
+  const { truncated } = useTruncate({ tgphRef: truncateRef }, [
+    getTextContent(children),
+  ]);
 
   const textToDisplayInTooltip = (() => {
     if (label !== undefined) return label;

--- a/packages/truncate/src/useTruncate/useTruncate.ts
+++ b/packages/truncate/src/useTruncate/useTruncate.ts
@@ -11,12 +11,28 @@ const useTruncate = (
   const [truncated, setTruncated] = React.useState(false);
 
   React.useEffect(() => {
-    if (!tgphRef.current) return setTruncated(false);
-
     const tgphRefElement = tgphRef.current;
 
+    // Only write when the value actually changes. React usually absorbs a
+    // same-value `setState` via its bailout, but in a continuously
+    // re-rendering tree (e.g. ReactFlow) the fiber's update lanes stay dirty
+    // and that bailout can be defeated — an unconditional `setState` here then
+    // feeds a runaway synchronous update loop ("Maximum update depth
+    // exceeded", React #185). Returning the previous value keeps a redundant
+    // update a genuine no-op even when lanes are dirty.
+    const setTruncatedIfChanged = (next: boolean) => {
+      setTruncated((prev) => (prev === next ? prev : next));
+    };
+
+    if (!tgphRefElement) {
+      setTruncatedIfChanged(false);
+      return;
+    }
+
     const checkTruncation = () => {
-      setTruncated(tgphRefElement.scrollWidth > tgphRefElement.clientWidth);
+      setTruncatedIfChanged(
+        tgphRefElement.scrollWidth > tgphRefElement.clientWidth,
+      );
     };
 
     // Initial check


### PR DESCRIPTION
Resolves [KNO-14285](https://linear.app/knock/issue/KNO-14285/maximum-update-depth-crash-in-workflow-graph-editor-from)

## What changed

- **`TooltipIfTruncated`** now keys `useTruncate`'s measurement effect on the child's stable rendered **text** (`getTextContent(children)`) instead of the freshly-created `children` element.
- **`useTruncate`** only writes `truncated` state when the value actually changes (`setTruncated(prev => (prev === next ? prev : next))`).

## Why

The dashboard was throwing React error #185 ("Maximum update depth exceeded") from `useTruncate`, rendered inside the ReactFlow-based Workflow Graph Editor step cards (`BaseStepCard` title).

`children` is a brand-new element on every render, so keying the effect on `[children]` re-mounted it — and called `setState` — on **every** render. That's harmless while React's same-value `setState` bailout absorbs it, but in a continuously re-rendering tree (ReactFlow) the fiber's lanes stay dirty, defeating the bailout, and the passive `setState` cascades into a runaway synchronous update loop past React's 50-nested-update limit.

Two independent fixes, either of which breaks the loop; together they're belt-and-suspenders:
1. Stable text dependency → the effect stops re-mounting on every render.
2. Value-guarded `setState` → a redundant write is a genuine no-op even when lanes are dirty.

The Base UI tooltip migration (#10170) is what tipped this latent defect into a crash, but the root cause lives in `@telegraph/truncate`, so it's fixed here.

## Testing

- **New regression test** (`TooltipIfTruncated.test.tsx`): 10 parent re-renders with fresh-but-identical children now construct exactly **1** `ResizeObserver` — before the fix it was 11 (one per render, matching the ticket's evidence). Verified the test fails against the old `[children]` dep.
- `@telegraph/truncate` jsdom (11) + browser (2) tests, lint, prettier, and typecheck all pass. Real-overflow tooltip behavior is unchanged.
- Changeset included (`@telegraph/truncate` patch).

## Follow-up

Bump `@telegraph/truncate` in the dashboard once this patch releases.
