### PR TITLE
feat(truncate): add front, middle, and fade truncation to TruncatedText (KNO-13728)

### DIFF
--- a/.changeset/truncate-truncatedtext-modes.md
+++ b/.changeset/truncate-truncatedtext-modes.md
@@ -1,0 +1,11 @@
+---
+"@telegraph/truncate": minor
+---
+
+Add front, middle, and fade truncation to `TruncatedText`, plus supporting fixes:
+
+- **`TruncatedText`** gains `mode="truncate" | "fruncate" | "middle"`, a `fade` `variant`, a custom `marker`, and (for `middle`) `split` / `priority`. `TruncatedText` remains the single public truncation component — the extra modes are folded in. End (`truncate`) and front (`fruncate`, via `direction: rtl`) use native `text-overflow: ellipsis` — glyph-boundary clip, no stylesheet. `mode="middle"` measures the rendered text and slices it to exactly the `head…tail` characters that fit — a crisp "…", **no gap**, and **never a cut glyph**, at every width (pure CSS can't do all three at once). Its measurement is scoped to `middle`, runs only on real resizes via a guarded `ResizeObserver` (so it can't reproduce the #185 loop), needs no stylesheet, and honors `maxWidth`. For `middle`, `split="center"` (the default) balances both ends — a prefix and a suffix with the "…" in the visual middle — while the anchored splits (`leaf-path`/`extension`) keep one end whole, chosen by `priority`. `variant="fade"` instead dissolves the edge via a CSS-only engine (a container size-query, ported from Pierre).
+- **`TooltipIfTruncated`** now measures truncation lazily on hover/focus (controlled `open`) instead of in a render effect, and accepts an `isTruncated` predicate. This removes the "Maximum update depth exceeded" (React #185) loop.
+- **`useTruncate`** is hardened with a value-guarded state update so redundant measurements are genuine no-ops even in re-render-heavy trees.
+
+`TruncatedText`'s `fade` variant (and a custom `marker` on end/front truncation) requires importing `@telegraph/truncate/default.css` and modern browsers (CSS container queries, the `1lh` unit, and `color-mix`). The `truncate` / `fruncate` / `middle` modes, `TooltipIfTruncated`, and `useTruncate` have no such requirement.

--- a/packages/truncate/README.md
+++ b/packages/truncate/README.md
@@ -14,7 +14,16 @@
 npm install @telegraph/truncate
 ```
 
-> **Note**: This package has no stylesheets required.
+> **Note**: all truncation `mode`s (`truncate`, `fruncate`, `middle`),
+> `TooltipIfTruncated`, and `useTruncate` need no stylesheet. Only the **`fade`
+> variant** (and a custom `marker`, unless it is a plain string in `middle`) uses
+> the CSS engine —
+> import the package stylesheet and require a modern browser (see
+> [Browser support](#browser-support)).
+>
+> ```tsx
+> import "@telegraph/truncate/default.css";
+> ```
 
 ## Quick Start
 
@@ -62,23 +71,29 @@ const CustomTruncatedComponent = () => {
 
 A text component that automatically truncates content with an ellipsis and shows a tooltip when truncated.
 
-| Prop           | Type                                                     | Default     | Description                                                     |
-| -------------- | -------------------------------------------------------- | ----------- | --------------------------------------------------------------- |
-| `maxWidth`     | `string`                                                 | `undefined` | Maximum width of the text container                             |
-| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>` | `undefined` | Props to pass to the underlying TooltipIfTruncated component    |
-| `...TextProps` | `TgphComponentProps<typeof Text>`                        | -           | All props from [@telegraph/typography](../typography/README.md) |
+| Prop           | Type                                                                                                  | Default      | Description                                                                                                                                                                                                      |
+| -------------- | ----------------------------------------------------------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxWidth`     | `string`                                                                                              | `undefined`  | Max width of the container (works for end/front/middle truncation; the `fade` engine takes width via `style` instead)                                                                                            |
+| `mode`         | `"truncate" \| "fruncate" \| "middle"`                                                                | `"truncate"` | `truncate` (end) and `fruncate` (start) are native `text-overflow: ellipsis`; `middle` (string content) measures the text and renders the `head…tail` characters that fit — crisp "…", no gap, never a cut glyph |
+| `variant`      | `"default" \| "fade"`                                                                                 | `"default"`  | Ellipsis (default) or a soft fade into the background (`fade` uses the engine + stylesheet)                                                                                                                      |
+| `marker`       | `ReactNode`                                                                                           | `"…"`        | A custom overflow indicator (default: the native ellipsis). Uses the engine on end/front (and for a ReactNode in `middle`); a string marker in `middle` is spliced into the measured slice                       |
+| `split`        | `"center" \| "extension" \| "leaf-path" \| number \| ["last"\|"first", n] \| (s) => [string, string]` | `"center"`   | `middle` mode: where to split the string (`center` balances both ends; the others anchor one end)                                                                                                                |
+| `priority`     | `"start" \| "end"`                                                                                    | `"end"`      | `middle` mode: the favored end — anchored splits (`leaf-path`/`extension`) keep it whole; `center` gives it the odd char. `end` favors the tail (e.g. a file name)                                               |
+| `tooltipProps` | `Partial<TgphComponentProps<typeof TooltipIfTruncated>>`                                              | `undefined`  | Props for the underlying TooltipIfTruncated                                                                                                                                                                      |
+| `...TextProps` | `TgphComponentProps<typeof Text>`                                                                     | -            | All props from [@telegraph/typography](../typography/README.md)                                                                                                                                                  |
 
 ### `<TooltipIfTruncated>`
 
 A component that conditionally shows a tooltip only when its content is truncated.
 
-| Prop              | Type                                 | Default     | Description                                                                                |
-| ----------------- | ------------------------------------ | ----------- | ------------------------------------------------------------------------------------------ |
-| `label`           | `string \| ReactNode`                | `undefined` | The text to show in the tooltip. When provided, it takes precedence over the child content |
-| `children`        | `ReactNode`                          | -           | **Required.** Content to monitor for truncation                                            |
-| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -           | All props from [@telegraph/tooltip](../tooltip/README.md)                                  |
+| Prop              | Type                                 | Default                     | Description                                                                                               |
+| ----------------- | ------------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `label`           | `string \| ReactNode`                | `undefined`                 | The text to show in the tooltip. When provided, it takes precedence over the child content                |
+| `children`        | `ReactNode`                          | -                           | **Required.** Content to monitor for truncation                                                           |
+| `isTruncated`     | `(trigger: HTMLElement) => boolean`  | `scrollWidth > clientWidth` | Custom truncation test — for content whose container never overflows (e.g. `TruncatedText mode="middle"`) |
+| `...TooltipProps` | `TgphComponentProps<typeof Tooltip>` | -                           | All props from [@telegraph/tooltip](../tooltip/README.md)                                                 |
 
-`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It measures the wrapped child with `useTruncate`, passes that same element ref to Tooltip as the trigger, and only enables the tooltip when overflow is detected. Tooltip props continue to pass through unchanged, including focus and hover behavior such as `disableFocusOpen`.
+`TooltipIfTruncated` delegates overlay behavior to the Base UI-backed `@telegraph/tooltip` package. It measures the wrapped child **lazily — at the moment the tooltip tries to open (hover/focus)** rather than in a render effect, and only opens when overflow is detected (`scrollWidth > clientWidth` by default, or a custom `isTruncated` test). Measuring on the open transition instead of continuously avoids the every-render `setState` that could otherwise cascade into a "Maximum update depth exceeded" loop (React #185) in re-render-heavy trees. Tooltip props continue to pass through unchanged, including focus and hover behavior such as `disableFocusOpen`.
 
 ### `useTruncate`
 
@@ -96,6 +111,89 @@ A hook that detects whether an element's content is truncated.
 | Name        | Type      | Description                                |
 | ----------- | --------- | ------------------------------------------ |
 | `truncated` | `boolean` | Whether the element's content is truncated |
+
+### Truncation modes
+
+`truncate` (default, end) and `fruncate` (start, via `direction: rtl`) use native
+`text-overflow: ellipsis` — they clip on glyph boundaries (**never mid-character**),
+run no JavaScript, and need no stylesheet.
+
+```tsx
+import { TruncatedText } from "@telegraph/truncate";
+
+// End truncation (default) — native ellipsis, no stylesheet.
+<TruncatedText as="span" maxWidth="40">
+  apps/web/src/components/BaseStepCard.tsx
+</TruncatedText>;
+
+// Front truncation — keeps the end visible.
+<TruncatedText as="span" mode="fruncate" maxWidth="40">
+  apps/web/src/components/BaseStepCard.tsx
+</TruncatedText>;
+```
+
+`mode="middle"` measures the rendered text and slices it to exactly the
+`head…tail` characters that fit — a crisp "…", **no gap**, and **never a cut
+glyph**, at every width (pure CSS can't do all three at once). The measurement is
+scoped to `middle`, runs only on real size changes via a guarded `ResizeObserver`,
+needs no stylesheet, and honors `maxWidth`. `split="center"` (the default) balances
+both ends — a prefix and a suffix with the "…" in the visual middle — while the
+anchored splits (`leaf-path`, `extension`) keep one whole end, chosen by `priority`.
+
+```tsx
+// Middle truncation (string content) — one end stays whole (`priority`), the
+// other is trimmed. `leaf-path` keeps the file name whole.
+<TruncatedText as="span" mode="middle" split="leaf-path" maxWidth="60">
+  apps/web/src/components/BaseStepCard.tsx
+</TruncatedText>
+```
+
+`variant="fade"` dissolves the truncated edge into the background instead of an
+ellipsis, and a custom `marker` on end/front truncation swaps the glyph. Both use
+an internal CSS-only engine (a container size-query — no JS measurement, no
+`ResizeObserver`, no state — ported from Pierre), so they need the package
+stylesheet and a modern browser (see [Browser support](#browser-support)); the
+engine's clip box is its root, so constrain its width via `style`, not `maxWidth`.
+
+```tsx
+import "@telegraph/truncate/default.css";
+
+// required for the fade variant
+
+// Fade instead of an ellipsis (end / front truncation).
+<TruncatedText as="span" variant="fade" style={{ maxWidth: 200 }}>
+  apps/web/src/components/BaseStepCard.tsx
+</TruncatedText>;
+```
+
+### `TruncatedText` vs `useTruncate`
+
+Two tools for two needs:
+
+- **`TruncatedText`** (any mode) — when you just need to _render_ truncated text.
+  End and front run no JS; `middle` uses a tiny guarded measurement (scoped to
+  that mode); the `fade` engine keeps its overflow detection in CSS.
+- **`useTruncate`** — when you need the truncation state _as a value in render_
+  (to gate your own tooltip, toggle "show more", swap an icon). It measures
+  `scrollWidth > clientWidth` with a guarded `ResizeObserver`, so it works on any
+  clipped element you point it at.
+
+## Browser support
+
+`TruncatedText`'s **`fade` variant** (and a custom `marker` on end/front
+truncation) uses a CSS engine that requires evergreen browsers from ~2023 onward:
+
+| Feature                                       | Chrome | Safari | Firefox |
+| --------------------------------------------- | ------ | ------ | ------- |
+| CSS container **size** queries (`@container`) | 105+   | 16+    | 110+    |
+| The `1lh` unit                                | 109+   | 16.4+  | 120+    |
+| `color-mix()` (text-matched ellipsis)         | 111+   | 16.2+  | 113+    |
+
+There is **no graceful fallback** on older browsers, so use the `fade` engine only
+where a modern browser is guaranteed. Everything else — `mode="truncate"`,
+`mode="fruncate"`, `mode="middle"`, `TooltipIfTruncated`, and `useTruncate` —
+relies on native `text-overflow: ellipsis` or a `ResizeObserver` measurement and
+has no such requirement.
 
 ## Usage Patterns
 

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test.tsx
@@ -163,4 +163,29 @@ describe("TooltipIfTruncated", () => {
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
+
+  it("still gates on truncation when the caller passes onOpenChange, and forwards it", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <TooltipIfTruncated
+        delayDuration={0}
+        skipAnimation
+        onOpenChange={onOpenChange}
+      >
+        <TestTrigger data-scroll-width="200" data-client-width="100">
+          Long value
+        </TestTrigger>
+      </TooltipIfTruncated>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Long value" }));
+
+    // A pass-through `onOpenChange` must not replace the internal open control —
+    // the truncation gate still opens the tooltip …
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Long value");
+    // … and the caller's handler is still notified.
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
 });

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.tsx
@@ -5,22 +5,45 @@ import {
 } from "@telegraph/helpers";
 import { Tooltip } from "@telegraph/tooltip";
 import { Text } from "@telegraph/typography";
-import { type ReactNode, isValidElement, useRef } from "react";
-
-import { useTruncate } from "../useTruncate";
+import { type ReactNode, isValidElement, useRef, useState } from "react";
 
 export type TooltipIfTruncatedProps = Optional<
   TgphComponentProps<typeof Tooltip>,
   "label"
->;
+> & {
+  /**
+   * How to decide whether the trigger is truncated. Defaults to
+   * `scrollWidth > clientWidth`, which is correct for a single clipped element.
+   * Pass a custom test for cases the default can't see — e.g. a middle-truncated
+   * group whose container never overflows but whose segments do.
+   */
+  isTruncated?: (trigger: HTMLElement) => boolean;
+};
 
+const overflows = (el: HTMLElement) => el.scrollWidth > el.clientWidth;
+
+/**
+ * Shows a tooltip only when the child is actually truncated.
+ *
+ * Truncation is measured lazily, at the moment the tooltip tries to open
+ * (hover/focus) — a discrete user event — rather than in a render effect. This
+ * removes the every-render `setState` + `ResizeObserver` machinery that could
+ * cascade into "Maximum update depth exceeded" (React #185, KNO-14285) in a
+ * re-render-heavy tree. Each open re-measures fresh, so a newly opened tooltip is
+ * never stale. An already-open tooltip is not force-closed if a later resize makes
+ * the trigger fit again — gating runs on open attempts, not continuously — so it
+ * closes on the next pointer-leave; that is the deliberate trade-off for dropping
+ * the continuous `ResizeObserver`.
+ */
 const TooltipIfTruncated = ({
   label,
   children,
+  isTruncated = overflows,
+  onOpenChange,
   ...props
 }: TooltipIfTruncatedProps) => {
-  const truncateRef = useRef<HTMLElement>(null);
-  const { truncated } = useTruncate({ tgphRef: truncateRef }, [children]);
+  const triggerRef = useRef<HTMLElement>(null);
+  const [open, setOpen] = useState(false);
 
   const textToDisplayInTooltip = (() => {
     if (label !== undefined) return label;
@@ -38,9 +61,23 @@ const TooltipIfTruncated = ({
           {textToDisplayInTooltip as ReactNode}
         </Text>
       }
-      enabled={truncated}
-      triggerRef={truncateRef}
+      triggerRef={triggerRef}
+      // Spread caller props first so the controlled `open` / `onOpenChange`
+      // gating below always wins — otherwise a pass-through `onOpenChange` (or
+      // `open`) would replace the truncation gate and leave `open` stuck at
+      // `false`, so the tooltip could never appear. A caller's `onOpenChange`
+      // is still honored — it's forwarded from inside our handler.
       {...props}
+      open={open}
+      onOpenChange={(next) => {
+        // Measure once, here — never during render. If the content isn't
+        // clipped, refuse to open. `setOpen` only ever fires from this user
+        // event, so there is no render→effect→setState cycle to run away.
+        const trigger = triggerRef.current;
+        if (next && !(trigger && isTruncated(trigger))) return;
+        setOpen(next);
+        onOpenChange?.(next);
+      }}
     >
       <RefToTgphRef>{children}</RefToTgphRef>
     </Tooltip>

--- a/packages/truncate/src/TruncatedText/TruncatedText.browser.test.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.browser.test.tsx
@@ -1,8 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 import { page, userEvent } from "vitest/browser";
 
 import { TruncatedText } from "./TruncatedText";
+// The engine modes detect overflow with a pure CSS container size-query: an
+// invisible `word-break: break-all` copy that wraps taller than one line flips
+// `@container (height > 1lh)`, which fades the marker in. jsdom reports
+// scrollWidth/clientWidth as 0 and does not evaluate container queries, so this
+// behavior can only be exercised in a real browser. The default (native) mode
+// uses inline styles, so only the engine tests below need the stylesheet.
+import "./TruncatedText.styles.css";
 
 // Real layout only. `useTruncate` decides truncation from
 // `scrollWidth > clientWidth`; jsdom reports both as 0, so every jsdom truncate
@@ -16,10 +23,13 @@ import { TruncatedText } from "./TruncatedText";
 // mounts and open the tooltip immediately — so `getByText` would match two
 // elements and throw a strict-mode violation.
 const LONG =
-  "This is a long label that overflows a narrow fixed-width container";
+  "apps/web/src/components/WorkflowGraphEditor/nodes/steps/BaseStepCard.tsx";
 const SHORT = "Short";
 
-describe("TruncatedText real overflow (real browser)", () => {
+const query = (root: HTMLElement, selector: string) =>
+  root.querySelector(selector) as HTMLElement;
+
+describe("TruncatedText native overflow (real browser)", () => {
   it("shows a tooltip on hover when the text is actually clipped", async () => {
     render(
       <TruncatedText
@@ -67,5 +77,154 @@ describe("TruncatedText real overflow (real browser)", () => {
     // Hovering a non-truncated label must not open a tooltip.
     await userEvent.hover(trigger);
     await expect.element(page.getByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("front-truncates with native RTL ellipsis (never mid-glyph) and shows the full path", async () => {
+    render(
+      <TruncatedText
+        as="span"
+        mode="fruncate"
+        data-testid="front"
+        style={{ maxWidth: 160 }}
+        tooltipProps={{ delayDuration: 0 }}
+      >
+        {LONG}
+      </TruncatedText>,
+    );
+
+    const trigger = page.getByTestId("front");
+    await expect.element(trigger).toBeInTheDocument();
+    const el = trigger.element() as HTMLElement;
+
+    // Native front truncation: RTL flips the ellipsis to the start, and
+    // `text-overflow: ellipsis` clips on a glyph boundary — no overlay marker
+    // that could leave a partial glyph exposed.
+    expect(getComputedStyle(el).direction).toBe("rtl");
+    expect(getComputedStyle(el).textOverflow).toBe("ellipsis");
+    expect(query(el, "[data-tgph-truncate]")).toBeNull();
+    expect(el.scrollWidth).toBeGreaterThan(el.clientWidth);
+
+    await userEvent.hover(trigger);
+    await expect.element(page.getByRole("tooltip")).toBeVisible();
+    await expect.element(page.getByRole("tooltip")).toHaveTextContent(LONG);
+  });
+
+  it("middle-truncates by measure-and-slice: crisp …, fits with no gap, no cut letter, full path in tooltip", async () => {
+    render(
+      <TruncatedText
+        as="span"
+        mode="middle"
+        data-testid="mid"
+        style={{ maxWidth: 200 }}
+        tooltipProps={{ delayDuration: 0 }}
+      >
+        {LONG}
+      </TruncatedText>,
+    );
+
+    const trigger = page.getByTestId("mid");
+    await expect.element(trigger).toBeInTheDocument();
+    const root = trigger.element() as HTMLElement;
+
+    // The layout effect measures and slices to fit (retried: it also re-measures
+    // once the webfont has loaded).
+    await vi.waitFor(() =>
+      expect(root.querySelector("[data-tgph-middle-truncated]")).not.toBeNull(),
+    );
+    const span = root.querySelector(
+      "[data-tgph-middle-truncated]",
+    ) as HTMLElement;
+    const rendered = span.textContent ?? "";
+
+    // It's the JS slice, not the CSS engine.
+    expect(query(root, "[data-tgph-truncate]")).toBeNull();
+    // A single crisp "…", shorter than the full path.
+    expect(rendered).toContain("…");
+    expect(rendered.length).toBeLessThan(LONG.length);
+    // It fits — the slice does not overflow its box, so there is no gap and no
+    // hard clip (the whole point of measuring).
+    expect(span.scrollWidth).toBeLessThanOrEqual(span.clientWidth);
+    // It never cuts a letter: both sides of the "…" are verbatim from LONG.
+    const [head, tail] = rendered.split("…");
+    expect(LONG).toContain(head);
+    expect(LONG).toContain(tail);
+
+    await userEvent.hover(trigger);
+    // The tooltip shows the original path, not the sliced version.
+    await expect.element(page.getByRole("tooltip")).toBeVisible();
+    await expect.element(page.getByRole("tooltip")).toHaveTextContent(LONG);
+  });
+});
+
+// A custom `marker` (here the default ellipsis) opts end-truncation into the
+// CSS engine, so these exercise the container size-query reveal directly.
+describe("TruncatedText engine modes (real browser)", () => {
+  it("reveals the marker when the engine actually clips the text", async () => {
+    render(
+      <div style={{ width: 120 }} data-testid="wrap">
+        <TruncatedText as="span" marker="…">
+          {LONG}
+        </TruncatedText>
+      </div>,
+    );
+
+    const wrap = page.getByTestId("wrap");
+    await expect.element(wrap).toBeInTheDocument();
+    const root = wrap.element() as HTMLElement;
+    const clip = query(root, "[data-tgph-truncate]");
+
+    // Real layout genuinely clips the text — the exact condition the CSS
+    // measures, and the whole reason jsdom (which reports 0) can't cover it.
+    expect(clip.scrollWidth).toBeGreaterThan(clip.clientWidth);
+
+    // The container query flips the marker to opacity 1 (after its fade-in).
+    const marker = query(root, "[data-tgph-truncate-marker]");
+    await vi.waitFor(() => expect(getComputedStyle(marker).opacity).toBe("1"));
+  });
+
+  it("keeps the marker hidden when the text fits", async () => {
+    render(
+      <div style={{ width: 400 }} data-testid="wrap">
+        <TruncatedText as="span" marker="…">
+          {SHORT}
+        </TruncatedText>
+      </div>,
+    );
+
+    const wrap = page.getByTestId("wrap");
+    await expect.element(wrap).toBeInTheDocument();
+    const root = wrap.element() as HTMLElement;
+    const clip = query(root, "[data-tgph-truncate]");
+
+    // The text fits, so nothing overflows and the container query never fires.
+    expect(clip.scrollWidth).not.toBeGreaterThan(clip.clientWidth);
+
+    const marker = query(root, "[data-tgph-truncate-marker]");
+    expect(getComputedStyle(marker).opacity).toBe("0");
+  });
+
+  it("fades the marker into the background for variant='fade'", async () => {
+    render(
+      <div style={{ width: 120 }} data-testid="wrap">
+        <TruncatedText as="span" variant="fade">
+          {LONG}
+        </TruncatedText>
+      </div>,
+    );
+
+    const wrap = page.getByTestId("wrap");
+    await expect.element(wrap).toBeInTheDocument();
+    const root = wrap.element() as HTMLElement;
+    const marker = query(root, "[data-tgph-truncate-marker]");
+
+    // Same reveal mechanism as the default marker.
+    await vi.waitFor(() => expect(getComputedStyle(marker).opacity).toBe("1"));
+
+    // Fade treatment (vs the default solid ellipsis): no solid marker
+    // background, and a gradient overlay painted via ::before.
+    expect(getComputedStyle(marker).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(marker, "::before").backgroundImage).toContain(
+      "gradient",
+    );
   });
 });

--- a/packages/truncate/src/TruncatedText/TruncatedText.helpers.test.ts
+++ b/packages/truncate/src/TruncatedText/TruncatedText.helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  splitByIndex,
+  splitCenter,
+  splitExtension,
+  splitFirst,
+  splitLast,
+  splitLeafPath,
+} from "./TruncatedText.helpers";
+
+// The split functions are pure string logic (no DOM), so jsdom is the right
+// home for them. Real overflow *detection* is CSS-only and can only be
+// exercised in a real browser — see TruncatedText.browser.test.tsx.
+describe("splitCenter", () => {
+  it("splits an even string in the middle", () => {
+    expect(splitCenter("abcdef")).toEqual(["abc", "def"]);
+  });
+
+  it("returns the whole string when it is too short to split", () => {
+    expect(splitCenter("a")).toEqual(["a", ""]);
+  });
+
+  it("nudges the split off a whitespace seam so the space is not collapsed", () => {
+    // A center split of "Hello world" lands on the space; `white-space: nowrap`
+    // would then swallow it. The nudge keeps the space interior to a segment.
+    const [head, tail] = splitCenter("Hello world");
+    expect(head + tail).toBe("Hello world");
+    expect(head.at(-1)).not.toBe(" ");
+    expect(tail.at(0)).not.toBe(" ");
+  });
+});
+
+describe("splitExtension", () => {
+  it("splits before a short trailing extension", () => {
+    expect(splitExtension("BaseStepCard.tsx")).toEqual([
+      "BaseStepCard.",
+      "tsx",
+    ]);
+  });
+
+  it("uses the last dot", () => {
+    expect(splitExtension("archive.tar.gz")).toEqual(["archive.tar.", "gz"]);
+  });
+
+  it("falls back to a center split when the extension is implausibly long", () => {
+    const input = "no.thisisnotarealextension";
+    const [head, tail] = splitExtension(input);
+    expect(head + tail).toBe(input);
+    // A center fallback is roughly balanced (not split right after the dot).
+    expect(Math.abs(head.length - tail.length)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("splitLeafPath", () => {
+  it("splits before the last path segment", () => {
+    expect(splitLeafPath("a/b/c.tsx")).toEqual(["a/b/", "c.tsx"]);
+  });
+});
+
+describe("offset splitters", () => {
+  it("splitByIndex splits at the given index", () => {
+    expect(splitByIndex("abcdef", 2)).toEqual(["ab", "cdef"]);
+  });
+
+  it("splitByIndex falls back to center for a non-finite index", () => {
+    expect(splitByIndex("abcd", Number.NaN)).toEqual(["ab", "cd"]);
+  });
+
+  it("splitLast keeps the last `offset` chars in the tail", () => {
+    expect(splitLast("file.txt", 3)).toEqual(["file.", "txt"]);
+  });
+
+  it("splitFirst keeps the first `offset` chars in the head", () => {
+    expect(splitFirst("file.txt", 4)).toEqual(["file", ".txt"]);
+  });
+
+  it("offset splitters fall back to center for an out-of-range offset", () => {
+    expect(splitLast("file.txt", 0)).toEqual(splitCenter("file.txt"));
+    expect(splitFirst("file.txt", 99)).toEqual(splitCenter("file.txt"));
+  });
+});

--- a/packages/truncate/src/TruncatedText/TruncatedText.helpers.ts
+++ b/packages/truncate/src/TruncatedText/TruncatedText.helpers.ts
@@ -1,0 +1,194 @@
+import { useEffect, useLayoutEffect } from "react";
+
+import type { Split, SplitMode, TruncatePriority } from "./TruncatedText.types";
+
+// ── Split strategies ────────────────────────────────────────────────────────
+// Pure string logic (no DOM): given the full string, return a `[head, tail]`
+// pair. The head is clipped from its end and the tail from its start, so the
+// elision lands in the middle ("apps/…/BaseStepCard.tsx"). Ported from Pierre's
+// `truncate`.
+
+const isWhitespace = (char: string | undefined) =>
+  char !== undefined && /\s/.test(char);
+
+// Nudge a split index away from a whitespace seam so `white-space: nowrap`
+// doesn't collapse the boundary space ("Hello world" → "Helloworld").
+const avoidWhitespaceBoundary = (contents: string, centerIndex: number) => {
+  const isOnBoundary = (index: number) =>
+    isWhitespace(contents[index - 1]) || isWhitespace(contents[index]);
+  if (!isOnBoundary(centerIndex)) return centerIndex;
+  for (let offset = 1; offset < contents.length; offset++) {
+    const before = centerIndex - offset;
+    if (before > 0 && !isOnBoundary(before)) return before;
+    const after = centerIndex + offset;
+    if (after < contents.length && !isOnBoundary(after)) return after;
+  }
+  return centerIndex;
+};
+
+const centerSplitIndex = (s: string) =>
+  avoidWhitespaceBoundary(s, Math.ceil(s.length / 2));
+
+export const splitCenter = (s: string): [string, string] => {
+  if (s.length < 2) return [s, ""];
+  const i = centerSplitIndex(s);
+  return [s.slice(0, i), s.slice(i)];
+};
+
+const splitAtLast = (
+  s: string,
+  char: string,
+  maxTailLength: number,
+): [string, string] => {
+  if (s.length < 4) return [s, ""];
+  const idx = s.lastIndexOf(char) + 1;
+  const tailLength = s.length - idx;
+  const i = idx >= 1 && tailLength <= maxTailLength ? idx : centerSplitIndex(s);
+  return [s.slice(0, i), s.slice(i)];
+};
+
+export const splitExtension = (s: string): [string, string] =>
+  splitAtLast(s, ".", 10);
+export const splitLeafPath = (s: string): [string, string] =>
+  splitAtLast(s, "/", 25);
+
+export const splitByIndex = (s: string, index: number): [string, string] =>
+  Number.isFinite(index) ? [s.slice(0, index), s.slice(index)] : splitCenter(s);
+
+/** Keep the last `offset` characters in the tail (e.g. a file extension). */
+export const splitLast = (s: string, offset: number): [string, string] =>
+  offset > 0 && offset < s.length
+    ? splitByIndex(s, s.length - offset)
+    : splitCenter(s);
+
+/** Keep the first `offset` characters in the head. */
+export const splitFirst = (s: string, offset: number): [string, string] =>
+  offset > 0 && offset < s.length ? splitByIndex(s, offset) : splitCenter(s);
+
+const SPLITTERS: Record<SplitMode, (s: string) => [string, string]> = {
+  center: splitCenter,
+  extension: splitExtension,
+  "leaf-path": splitLeafPath,
+};
+
+export const resolveSplit = (
+  split: Split,
+  contents: string,
+): [string, string] => {
+  if (typeof split === "function") return split(contents);
+  if (typeof split === "number") return splitByIndex(contents, split);
+  if (Array.isArray(split)) {
+    const [type, offset] = split;
+    return type === "last"
+      ? splitLast(contents, offset)
+      : splitFirst(contents, offset);
+  }
+  return SPLITTERS[split](contents);
+};
+
+// ── Measure-and-slice (middle truncation) ───────────────────────────────────
+
+// `useLayoutEffect` on the client (measures before paint, so no flash), plain
+// `useEffect` on the server (avoids React's SSR warning).
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+/**
+ * The longest `head…tail` slice of `text` that fits `available` px, measured with
+ * `measure`. Only whole characters are dropped, so it never cuts a glyph, and the
+ * result fits exactly, so there is no trailing-slack gap at the seam.
+ *
+ * `split="center"` is balanced — it keeps a prefix of the head AND a suffix of the
+ * tail so the marker sits in the visual middle and both ends stay visible at any
+ * width. The anchored strategies (`leaf-path`, `extension`, offsets) instead keep
+ * one whole side (chosen by `priority`) and truncate the other.
+ */
+export const sliceToFit = (
+  text: string,
+  split: Split,
+  priority: TruncatePriority,
+  marker: string,
+  available: number,
+  measure: (s: string) => number,
+): string => {
+  // Sub-pixel safety: `offsetWidth`/`clientWidth` are rounded, so a string that
+  // measures at exactly `available` can still render a fraction wider and get a
+  // "…" appended by the fallback `text-overflow`. Apply the 2px margin
+  // everywhere — including this early "fits" check — otherwise a string in that
+  // band is returned whole and left unflagged, yet the CSS ellipsis still clips
+  // it, so the trigger looks truncated but shows no tooltip.
+  const fits = (s: string) => measure(s) <= available - 2;
+  if (fits(text)) return text; // fits with the margin — no truncation
+  const [head, tail] = resolveSplit(split, text);
+  // Largest n in [0, max] for which `pick(n)` fits (fit is monotonic in n).
+  const largest = (max: number, pick: (n: number) => string) => {
+    let lo = 0;
+    let hi = max;
+    let best = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (fits(pick(mid))) {
+        best = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return best;
+  };
+
+  // `center` is balanced: keep a head prefix AND a tail suffix so the marker
+  // lands in the visual middle and both ends stay visible. `priority` gives the
+  // odd character to one side. (The anchored strategies below keep one side
+  // whole — right for a filename or extension, wrong for a centered elision.)
+  if (split === "center") {
+    const build = (k: number) => {
+      let h = Math.min(
+        priority === "start" ? Math.ceil(k / 2) : Math.floor(k / 2),
+        head.length,
+      );
+      const t = Math.min(k - h, tail.length);
+      h = Math.min(k - t, head.length);
+      return head.slice(0, h) + marker + tail.slice(tail.length - t);
+    };
+    return build(largest(head.length + tail.length, build));
+  }
+
+  if (priority === "start") {
+    // Keep the head whole, trim the tail from its start; if the head alone won't
+    // fit, drop the tail and trim the head from its end.
+    if (fits(head + marker)) {
+      const n = largest(
+        tail.length,
+        (n) => head + marker + tail.slice(tail.length - n),
+      );
+      return head + marker + tail.slice(tail.length - n);
+    }
+    const n = largest(head.length, (n) => head.slice(0, n) + marker);
+    return head.slice(0, n) + marker;
+  }
+
+  // priority "end" (default): keep the tail whole, trim the head from its end; if
+  // the tail alone won't fit, drop the head and trim the tail from its start.
+  if (fits(marker + tail)) {
+    const n = largest(head.length, (n) => head.slice(0, n) + marker + tail);
+    return head.slice(0, n) + marker + tail;
+  }
+  const n = largest(tail.length, (n) => marker + tail.slice(tail.length - n));
+  return marker + tail.slice(tail.length - n);
+};
+
+// ── Truncation predicates (for `TooltipIfTruncated`'s `isTruncated`) ─────────
+
+// The measure-and-slice output always fits, so the trigger never overflows; gate
+// the tooltip on whether the string was actually sliced instead of on `scrollWidth`.
+export const middleSliceIsTruncated = (el: HTMLElement) =>
+  el.matches("[data-tgph-middle-truncated]") ||
+  el.querySelector("[data-tgph-middle-truncated]") != null;
+
+// A `variant="fade"` middle group never overflows its own box (its segments do),
+// so the tooltip gates on whether either engine segment is clipped, not the trigger.
+export const middleIsTruncated = (el: HTMLElement) =>
+  Array.from(el.querySelectorAll("[data-tgph-truncate]")).some(
+    (seg) => seg.scrollWidth > seg.clientWidth,
+  );

--- a/packages/truncate/src/TruncatedText/TruncatedText.primitives.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.primitives.tsx
@@ -1,0 +1,110 @@
+import { useRef, useState } from "react";
+
+import { sliceToFit, useIsomorphicLayoutEffect } from "./TruncatedText.helpers";
+import type { Split, TruncatePriority } from "./TruncatedText.types";
+
+type MiddleTruncateProps = {
+  text: string;
+  split?: Split;
+  priority?: TruncatePriority;
+  /** The elision marker. Concatenated into the string, so it must be a string. */
+  marker?: string;
+};
+
+/**
+ * Middle truncation by measurement: render exactly the `head…tail` characters
+ * that fit — crisp ellipsis, no gap, and never a cut glyph, at every width.
+ *
+ * The measurement is deliberately minimal and only runs where it's needed: this
+ * component is mounted solely for `TruncatedText mode="middle"`, and it recomputes
+ * only on real size changes (a `ResizeObserver`), guarding `setState` so redundant
+ * ticks are no-ops. There is no measure-in-render or unconditional `setState`, so
+ * it cannot reproduce the "Maximum update depth exceeded" loop (React #185).
+ */
+const MiddleTruncate = ({
+  text,
+  split = "center",
+  priority = "end",
+  marker = "…",
+}: MiddleTruncateProps) => {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [display, setDisplay] = useState(text);
+
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    // A hidden probe measures candidate strings at their real rendered width — no
+    // canvas/font guessing. It is 0×0 + `overflow:hidden` (so it never adds page
+    // scroll) and measured via `scrollWidth` (the natural, unclipped text width).
+    // It lives in `el`'s parent, not `el`: `el`'s text child is React-managed — a
+    // re-render wipes an appended probe (and would leave `measure` reading 0) —
+    // and `el`'s `textContent` is read as the rendered slice, which a probe child
+    // would pollute. The parent shares the inherited font, so measurements match.
+    const probe = document.createElement("span");
+    probe.setAttribute("aria-hidden", "true");
+    probe.style.cssText =
+      "position:absolute;top:0;left:0;width:0;height:0;overflow:hidden;visibility:hidden;pointer-events:none;white-space:nowrap;";
+    const host = el.parentElement ?? el;
+    host.appendChild(probe);
+    const measure = (s: string) => {
+      if (!probe.isConnected) host.appendChild(probe); // survive a host re-render
+      probe.textContent = s;
+      return probe.scrollWidth;
+    };
+
+    const compute = () => {
+      const available = el.clientWidth;
+      // Until the box has a width and the font has loaded (an unloaded webfont
+      // measures 0-width), the text can't be sliced. Fall back to the full text
+      // — correct content, with the CSS ellipsis as a crude cue — rather than
+      // leaving a stale slice of a previous `text`; a later resize or
+      // `fonts.ready` re-slices. (Never a bare `return`, so `display` always
+      // tracks the current `text`.)
+      const next =
+        !available || measure(text) === 0
+          ? text
+          : sliceToFit(text, split, priority, marker, available, measure);
+      setDisplay((prev) => (prev === next ? prev : next));
+    };
+
+    compute();
+    const observer = new ResizeObserver(compute);
+    observer.observe(el);
+    // A webfont's metrics change the fit, but loading one doesn't resize the box
+    // (so the observer won't fire) — re-measure once fonts settle.
+    let active = true;
+    void document.fonts?.ready?.then(() => active && compute());
+
+    return () => {
+      active = false;
+      observer.disconnect();
+      probe.remove();
+    };
+  }, [text, split, priority, marker]);
+
+  return (
+    <span
+      ref={ref}
+      // Flags "this was sliced" → gates the tooltip. Full text shows unflagged
+      // only when we couldn't measure (no width / unloaded font) — i.e. while the
+      // element isn't visibly rendered — so there is never a visibly clipped
+      // label without a tooltip; the next measure slices and flags it.
+      data-tgph-middle-truncated={display === text ? undefined : ""}
+      style={{
+        display: "block",
+        minWidth: 0,
+        overflow: "hidden",
+        whiteSpace: "nowrap",
+        // Fallback for the pre-measurement paint (SSR / first frame): end-clip
+        // crisply rather than hard-cut. Once sliced, the text fits and this is a
+        // no-op.
+        textOverflow: "ellipsis",
+      }}
+    >
+      {display}
+    </span>
+  );
+};
+
+export { MiddleTruncate };

--- a/packages/truncate/src/TruncatedText/TruncatedText.stories.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.stories.tsx
@@ -1,74 +1,201 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Stack } from "@telegraph/layout";
 
-import { TruncatedText } from "./TruncatedText";
+import {
+  type Split,
+  TruncatedText,
+  type TruncatedTextProps,
+} from "./TruncatedText";
 
-const meta: Meta = {
+const PATH =
+  "apps/web/src/components/WorkflowGraphEditor/nodes/steps/BaseStepCard.tsx";
+
+const meta = {
   title: "Components/TruncatedText",
   component: TruncatedText,
   tags: ["autodocs"],
+  parameters: {
+    controls: {
+      include: [
+        "children",
+        "mode",
+        "variant",
+        "priority",
+        "split",
+        "marker",
+        "color",
+        "size",
+        "maxWidth",
+      ],
+    },
+  },
+  argTypes: {
+    children: {
+      control: { type: "text" },
+      description: "The text to truncate.",
+    },
+    mode: {
+      options: ["truncate", "fruncate", "middle"],
+      control: { type: "inline-radio" },
+      description:
+        "`truncate` clips the end, `fruncate` the start, `middle` elides the middle (string children only).",
+    },
+    variant: {
+      options: ["default", "fade"],
+      control: { type: "inline-radio" },
+      description:
+        "An ellipsis marker vs. a soft fade into the background (`fade` uses the CSS engine).",
+    },
+    priority: {
+      options: ["end", "start"],
+      control: { type: "inline-radio" },
+      description:
+        "`middle` only — the favored end: kept whole for `leaf-path`/`extension`, or given the odd character for the balanced `center`.",
+    },
+    split: {
+      options: ["center", "extension", "leaf-path"],
+      control: { type: "select" },
+      description: "`middle` only — where the elision lands.",
+    },
+    marker: {
+      control: { type: "text" },
+      description:
+        "A custom overflow marker (upgrades to the CSS engine). Empty = the native ellipsis.",
+    },
+    color: {
+      options: [
+        "default",
+        "gray",
+        "red",
+        "blue",
+        "green",
+        "yellow",
+        "purple",
+        "accent",
+      ],
+      control: { type: "select" },
+      description: "The marker takes on the text color.",
+    },
+    size: {
+      options: ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+      control: { type: "select" },
+    },
+    maxWidth: {
+      control: { type: "range", min: 80, max: 600, step: 10 },
+      description: "The clip width, in px.",
+    },
+  },
+  args: {
+    as: "span",
+    children: PATH,
+    mode: "middle",
+    variant: "default",
+    priority: "end",
+    split: "center",
+    marker: "",
+    color: "default",
+    size: "2",
+  },
 } satisfies Meta<typeof TruncatedText>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    as: "span",
-    children:
-      "This is a long text that will be truncated if it exceeds the container width",
-    maxWidth: "40",
-  },
+// `maxWidth` is exposed as a px number — an intuitive slider that clips in every
+// mode — and applied via `style` rather than the component's spacing-token
+// `maxWidth` prop. An empty `marker` maps to `undefined` (the native ellipsis).
+type ControlArgs = Omit<TruncatedTextProps, "maxWidth"> & {
+  maxWidth?: number;
 };
 
-export const WithCustomTooltip: Story = {
-  args: {
-    as: "span",
-    children: "This text has a custom tooltip configuration",
-    maxWidth: "40",
-    tooltipProps: {
-      delayDuration: 2000,
-    },
-  },
+// The one controllable story: flip mode, variant, color, size, split, width, and
+// the marker live in the Controls panel. Hover a clipped result for the
+// full-text tooltip.
+export const Playground: StoryObj<ControlArgs> = {
+  args: { maxWidth: 280 },
+  render: ({ maxWidth, marker, style, as, ...args }) => (
+    <TruncatedText
+      as={as ?? "span"}
+      {...args}
+      marker={marker || undefined}
+      style={{ maxWidth, ...style }}
+    />
+  ),
 };
 
-export const DifferentWidths: Story = {
-  args: {
-    as: "span",
-  },
-  render: (args) => (
-    <Stack gap="4" direction="column">
-      <TruncatedText {...args} as="span" maxWidth="20">
-        This text will be truncated at 20 spacing units
+// A fixed, side-by-side comparison the single-value controls can't show: the
+// three modes, plus `middle` + `leaf-path` (which keeps the file name whole).
+export const Modes: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <Stack gap="4" direction="column" style={{ width: 260 }}>
+      <TruncatedText as="span" mode="truncate" style={{ maxWidth: 260 }}>
+        {PATH}
       </TruncatedText>
-      <TruncatedText {...args} as="span" maxWidth="40">
-        This text will be truncated at 40 spacing units
+      <TruncatedText as="span" mode="fruncate" style={{ maxWidth: 260 }}>
+        {PATH}
       </TruncatedText>
-      <TruncatedText {...args} as="span" maxWidth="60">
-        This text will be truncated at 60 spacing units
+      <TruncatedText as="span" mode="middle" style={{ maxWidth: 260 }}>
+        {PATH}
+      </TruncatedText>
+      <TruncatedText
+        as="span"
+        mode="middle"
+        split="leaf-path"
+        style={{ maxWidth: 260 }}
+      >
+        {PATH}
       </TruncatedText>
     </Stack>
   ),
 };
 
-export const WithDifferentTextContent: Story = {
-  args: {
-    as: "span",
+// `split` (middle mode) accepts more than the named strategies in the control —
+// an offset tuple or a raw index, too.
+export const SplitStrategies: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => {
+    const splits: { label: string; split: Split }[] = [
+      { label: "center", split: "center" },
+      { label: "extension", split: "extension" },
+      { label: "leaf-path", split: "leaf-path" },
+      { label: '["last", 8]', split: ["last", 8] },
+      { label: "16", split: 16 },
+    ];
+    return (
+      <Stack gap="4" direction="column" style={{ width: 220 }}>
+        {splits.map(({ label, split }) => (
+          <TruncatedText
+            key={label}
+            as="span"
+            mode="middle"
+            split={split}
+            style={{ maxWidth: 220 }}
+          >
+            {PATH}
+          </TruncatedText>
+        ))}
+      </Stack>
+    );
   },
-  render: (args) => (
-    <Stack gap="4" direction="column">
-      <TruncatedText {...args} as="span" maxWidth="40">
-        Short text that won't be truncated
-      </TruncatedText>
-      <TruncatedText {...args} as="span" maxWidth="40">
-        This is a medium length text that might be truncated depending on the
-        screen size
-      </TruncatedText>
-      <TruncatedText {...args} as="span" maxWidth="40">
-        This is a very long text that will definitely be truncated because it
-        contains many words and exceeds the maximum width of the container by a
-        significant margin
-      </TruncatedText>
-    </Stack>
+};
+
+// `tooltipProps` forwards straight to the underlying Tooltip — here opening it
+// instantly and swapping in a custom label in place of the auto-extracted full
+// text. It still only appears when the text is actually truncated.
+export const WithCustomTooltip: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <TruncatedText
+      as="span"
+      style={{ maxWidth: 240 }}
+      tooltipProps={{
+        delayDuration: 0,
+        label: "Custom label shown in place of the full text",
+      }}
+    >
+      This text has a custom tooltip configuration
+    </TruncatedText>
   ),
 };

--- a/packages/truncate/src/TruncatedText/TruncatedText.styles.css
+++ b/packages/truncate/src/TruncatedText/TruncatedText.styles.css
@@ -1,0 +1,217 @@
+/*
+ * TruncatedText engine modes — CSS-only truncation, ported from Pierre's
+ * `truncate`. Backs `TruncatedText`'s `fruncate` / `middle` / `variant="fade"`
+ * modes (and `truncate` with a custom marker). The default `mode="truncate"`
+ * uses native `text-overflow: ellipsis` and needs none of this.
+ *
+ * There is NO JavaScript measurement here: no ResizeObserver, no state, no
+ * `scrollWidth`/`clientWidth` reads. Overflow is detected entirely by a CSS
+ * container size-query.
+ *
+ * Mechanism: the content is rendered twice inside a size-query container — a
+ * visible `white-space: nowrap` copy (what the user sees, hard-clipped to one
+ * line) and an invisible `word-break: break-all` copy that is allowed to wrap.
+ * When the text is clipped, the wrapping copy is taller than one line, so the
+ * container's `height > 1lh` query is true and the marker (…) fades in. Native
+ * container queries re-evaluate on resize automatically — nothing to loop.
+ */
+
+[data-tgph-truncate] {
+  --tgph-truncate-line-height: 1lh;
+  /* Solid backdrop the marker paints over the clipped edge. Override per-context. */
+  --tgph-truncate-marker-bg: var(--tgph-surface-1, #fff);
+  /* Pierre's defaults: a 2px feather softens the seam where the clipped text
+     meets the opaque marker backdrop; the backdrop itself hides the glyph.
+     `gap` is a solid (un-faded) lead before the fade begins. */
+  --tgph-truncate-marker-fade-width: 2px;
+  --tgph-truncate-marker-gap: 0px;
+  /* The ellipsis is a muted tint of the *text* color so it matches colored
+     labels. `color-mix` fades only the glyph — the opaque backdrop stays put
+     (element `opacity` would fade the backdrop too and leak the clipped text).
+     `--tgph-truncate-marker-opacity` is inheritable so the middle group can
+     bump it; override `--tgph-truncate-marker-color` for a fixed color. */
+  --tgph-truncate-marker-color: color-mix(
+    in srgb,
+    currentColor var(--tgph-truncate-marker-opacity, 50%),
+    transparent
+  );
+
+  height: var(--tgph-truncate-line-height);
+  min-width: 0;
+  overflow: hidden;
+}
+
+[data-tgph-truncate-grid] {
+  display: grid;
+  position: relative;
+}
+
+[data-tgph-truncate-content="visible"] {
+  white-space: nowrap;
+}
+
+/* The invisible "ruler": forced to wrap and overlaid on the visible line. */
+[data-tgph-truncate-content="overflow"] {
+  opacity: 0;
+  pointer-events: none;
+  user-select: none;
+  word-break: break-all;
+  margin-top: calc(-1 * var(--tgph-truncate-line-height));
+}
+
+[data-tgph-truncate-marker-cell] {
+  container: tgph-measure / size;
+  overflow: visible;
+  user-select: none;
+  pointer-events: none;
+}
+
+[data-tgph-truncate-marker] {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  z-index: 1;
+  height: var(--tgph-truncate-line-height);
+  background-color: var(--tgph-truncate-marker-bg);
+  color: var(--tgph-truncate-marker-color);
+  opacity: 0; /* hidden until overflow */
+  transition: opacity 0.12s ease-in-out;
+}
+
+/* THE TRICK: wrapping ruler taller than one line ⇒ clipped ⇒ reveal the marker. */
+@container tgph-measure (height > 1lh) {
+  [data-tgph-truncate-marker] {
+    opacity: 1;
+  }
+}
+
+/* ── end truncate: content | zero-width marker cell (marker pinned right) ── */
+[data-tgph-truncate="truncate"] [data-tgph-truncate-grid] {
+  grid-template-columns: minmax(0, max-content) 0;
+}
+[data-tgph-truncate="truncate"] [data-tgph-truncate-marker] {
+  right: 0;
+}
+
+/* ── front truncate ("fruncate"): RTL content clips at the start, marker left ── */
+[data-tgph-truncate="fruncate"] [data-tgph-truncate-grid] {
+  grid-template-columns: 0 minmax(0, max-content) auto;
+}
+[data-tgph-truncate="fruncate"] [data-tgph-truncate-content] {
+  direction: rtl;
+}
+[data-tgph-truncate="fruncate"] [data-tgph-truncate-content] > span {
+  unicode-bidi: plaintext;
+}
+[data-tgph-truncate="fruncate"] [data-tgph-truncate-marker] {
+  left: 0;
+}
+
+/* Default marker fade — Pierre's masked solid-fill feather (opaque through
+   `gap`, then fading to transparent across `fade-width`). Pierre paints it on
+   both sides of the marker; we paint only the side that sits *over the text*
+   (via the mode-specific pseudo below). The off-container side would extend
+   past the clipped edge and inflate the root's `scrollWidth` — harmless to
+   Pierre (pure CSS) but our tooltip / `useTruncate` read `scrollWidth`, so it
+   would report every element as truncated. */
+[data-tgph-truncate="truncate"][data-tgph-truncate-variant="default"]
+  [data-tgph-truncate-marker]::before,
+[data-tgph-truncate="fruncate"][data-tgph-truncate-variant="default"]
+  [data-tgph-truncate-marker]::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  height: var(--tgph-truncate-line-height);
+  width: calc(
+    var(--tgph-truncate-marker-fade-width) + var(--tgph-truncate-marker-gap)
+  );
+  background-color: var(--tgph-truncate-marker-bg);
+  -webkit-mask-image: linear-gradient(
+    var(--tgph-truncate-fade-dir),
+    #000 0%,
+    #000 var(--tgph-truncate-marker-gap),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    var(--tgph-truncate-fade-dir),
+    #000 0%,
+    #000 var(--tgph-truncate-marker-gap),
+    transparent 100%
+  );
+}
+/* end-truncation: the text is to the left of the marker, so feather leftward. */
+[data-tgph-truncate="truncate"][data-tgph-truncate-variant="default"]
+  [data-tgph-truncate-marker]::before {
+  --tgph-truncate-fade-dir: to left;
+  right: 100%;
+}
+/* front-truncation: the text is to the right of the marker, so feather rightward. */
+[data-tgph-truncate="fruncate"][data-tgph-truncate-variant="default"]
+  [data-tgph-truncate-marker]::after {
+  --tgph-truncate-fade-dir: to right;
+  left: 100%;
+}
+
+/* ── middle truncate: head truncates from the end, tail from the front ── */
+[data-tgph-truncate-group="middle"] {
+  display: flex;
+  min-width: 0;
+  /* Pierre bumps middle-truncate markers to 80% (more visible at the seam). */
+  --tgph-truncate-marker-opacity: var(
+    --tgph-truncate-middle-marker-opacity,
+    80%
+  );
+}
+[data-tgph-truncate-group="middle"] > [data-tgph-truncate-segment] {
+  min-width: 0;
+}
+/* `priority` keeps one end whole and lets the other yield (and fade). `end`
+   (default) keeps the tail — e.g. a filename with `split="leaf-path"` — while the
+   head fades into it; `start` mirrors it. The kept end is capped at the row width
+   so an over-long "whole" side still clips and fades rather than overflowing.
+   `overflow: hidden` fills the box exactly, so the fading half abuts the whole
+   half with no gap. */
+[data-tgph-truncate-priority="end"] > [data-tgph-truncate-segment="head"] {
+  flex: 0 1 auto;
+}
+[data-tgph-truncate-priority="end"] > [data-tgph-truncate-segment="tail"] {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+[data-tgph-truncate-priority="start"] > [data-tgph-truncate-segment="head"] {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+[data-tgph-truncate-priority="start"] > [data-tgph-truncate-segment="tail"] {
+  flex: 0 1 auto;
+}
+
+/* ── fade variant: the marker becomes a gradient that fades text into the bg ── */
+[data-tgph-truncate-variant="fade"] [data-tgph-truncate-marker] {
+  width: 2.5rem;
+  background-color: transparent;
+  color: transparent;
+  padding: 0;
+}
+[data-tgph-truncate-variant="fade"] [data-tgph-truncate-marker]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+[data-tgph-truncate="truncate"][data-tgph-truncate-variant="fade"]
+  [data-tgph-truncate-marker]::before {
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--tgph-truncate-marker-bg) 90%
+  );
+}
+[data-tgph-truncate="fruncate"][data-tgph-truncate-variant="fade"]
+  [data-tgph-truncate-marker]::before {
+  background: linear-gradient(
+    to left,
+    transparent,
+    var(--tgph-truncate-marker-bg) 90%
+  );
+}

--- a/packages/truncate/src/TruncatedText/TruncatedText.test.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.test.tsx
@@ -1,0 +1,235 @@
+import "@testing-library/jest-dom/vitest";
+import { render } from "@testing-library/react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { TruncatedText } from "./TruncatedText";
+import { sliceToFit } from "./TruncatedText.helpers";
+
+// `MiddleTruncate` uses a ResizeObserver, which jsdom lacks. Real measurement is
+// covered in the browser suite; here it's a no-op so middle renders.
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+beforeAll(() => vi.stubGlobal("ResizeObserver", MockResizeObserver));
+afterAll(() => vi.unstubAllGlobals());
+
+const engineRoot = (c: HTMLElement) => c.querySelector("[data-tgph-truncate]");
+const engineGroup = (c: HTMLElement) =>
+  c.querySelector('[data-tgph-truncate-group="middle"]');
+const rtlEl = (c: HTMLElement) =>
+  Array.from(c.querySelectorAll<HTMLElement>("*")).find(
+    (e) => e.style?.direction === "rtl",
+  );
+
+// Routing only — which path each mode takes. End and front are native
+// `text-overflow: ellipsis`. `middle` is JS measure-and-slice (no engine markup).
+// `variant="fade"` (and a custom `marker` on end/front) opts into the CSS engine.
+// Real measurement/overflow behavior needs a browser.
+describe("TruncatedText modes", () => {
+  it("uses native ellipsis (no engine) for the default mode", () => {
+    const { container } = render(
+      <TruncatedText as="span">A long label</TruncatedText>,
+    );
+    expect(engineRoot(container)).toBeNull();
+    expect(container.textContent).toContain("A long label");
+  });
+
+  it("uses native RTL ellipsis (no engine) for fruncate", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="fruncate">
+        a/b/c.tsx
+      </TruncatedText>,
+    );
+    expect(engineRoot(container)).toBeNull();
+    // `direction: rtl` is what flips the native ellipsis to the start.
+    expect(rtlEl(container)).toBeTruthy();
+    expect(rtlEl(container)).toHaveTextContent("a/b/c.tsx");
+  });
+
+  it("measures and slices (no engine) for middle string content by default", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="middle">
+        a/b/c.tsx
+      </TruncatedText>,
+    );
+    // The default middle path is JS measure-and-slice — no CSS engine markup.
+    // (jsdom reports 0-width, so nothing is sliced here; slicing is unit-tested
+    // via sliceToFit and exercised for real in the browser suite.)
+    expect(engineRoot(container)).toBeNull();
+    expect(engineGroup(container)).toBeNull();
+    expect(container.textContent).toContain("a/b/c.tsx");
+  });
+
+  it("follows the string when middle content changes (no stale slice)", () => {
+    const { container, rerender } = render(
+      <TruncatedText as="span" mode="middle">
+        apps/old/OldCard.tsx
+      </TruncatedText>,
+    );
+    expect(container.textContent).toContain("apps/old/OldCard.tsx");
+    // Same instance, new text, while unmeasurable (jsdom reports 0 width, so
+    // `compute` can't slice): the shown text must follow `children`, not stay
+    // on the previous value.
+    rerender(
+      <TruncatedText as="span" mode="middle">
+        lib/new/NewThing.tsx
+      </TruncatedText>,
+    );
+    expect(container.textContent).toContain("lib/new/NewThing.tsx");
+    expect(container.textContent).not.toContain("apps/old/OldCard.tsx");
+  });
+
+  it("uses the fade engine for middle when variant='fade'", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="middle" variant="fade">
+        a/b/c.tsx
+      </TruncatedText>,
+    );
+    expect(engineGroup(container)).toBeInTheDocument();
+    expect(
+      container.querySelectorAll('[data-tgph-truncate-variant="fade"]'),
+    ).toHaveLength(2);
+  });
+
+  it("upgrades to the engine when a fade is requested", () => {
+    const { container } = render(
+      <TruncatedText as="span" variant="fade">
+        A long label
+      </TruncatedText>,
+    );
+    expect(
+      container.querySelector('[data-tgph-truncate="truncate"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("upgrades to the engine when a custom marker is given", () => {
+    const { container } = render(
+      <TruncatedText as="span" marker="→">
+        A long label
+      </TruncatedText>,
+    );
+    expect(
+      container.querySelector('[data-tgph-truncate="truncate"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("treats an empty marker as no marker (stays native, no engine)", () => {
+    const { container } = render(
+      <TruncatedText as="span" marker="">
+        A long label
+      </TruncatedText>,
+    );
+    expect(engineRoot(container)).toBeNull();
+    expect(container.textContent).toContain("A long label");
+  });
+
+  it("routes a ReactNode marker in middle mode through the engine", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="middle" marker={<b>x</b>}>
+        apps/web/BaseStepCard.tsx
+      </TruncatedText>,
+    );
+    // Measure-and-slice can only splice a string; a node marker must use the engine.
+    expect(engineGroup(container)).toBeInTheDocument();
+  });
+
+  it("routes fruncate + fade through the engine", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="fruncate" variant="fade">
+        a/b/c.tsx
+      </TruncatedText>,
+    );
+    expect(
+      container.querySelector('[data-tgph-truncate="fruncate"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to native end ellipsis for middle mode with non-string children", () => {
+    const { container } = render(
+      <TruncatedText as="span" mode="middle">
+        <span>node</span>
+      </TruncatedText>,
+    );
+    expect(engineRoot(container)).toBeNull();
+    expect(engineGroup(container)).toBeNull();
+  });
+});
+
+// The middle-truncation algorithm: find the longest `head…tail` that fits, only
+// dropping whole characters (never cuts a glyph) and fitting exactly (no gap).
+// Measured here with 1 unit per character (so `available` is a character budget);
+// real pixel measurement is exercised in the browser suite. Note the 2px
+// sub-pixel safety margin baked into sliceToFit — budgets below account for it.
+describe("sliceToFit", () => {
+  const measure = (s: string) => s.length;
+
+  it("returns the full text when it fits", () => {
+    expect(
+      sliceToFit("apps/Card.tsx", "center", "end", "…", 100, measure),
+    ).toBe("apps/Card.tsx");
+  });
+
+  it("slices when the text only fits within the sub-pixel margin", () => {
+    // measure(text) === available exactly: the 2px margin treats it as not
+    // fitting, so it slices (and flags truncation) rather than returning the
+    // full string, which the CSS `text-overflow` could still clip with no
+    // tooltip to reveal it.
+    const out = sliceToFit("aaaa/bbbb", "center", "end", "…", 9, measure);
+    expect(out).not.toBe("aaaa/bbbb");
+    expect(out).toContain("…");
+  });
+
+  it("keeps the tail whole and trims the head (priority=end)", () => {
+    // leaf-path → head "aaaaaaaa/" (the "/" ends the head), tail "bbbbbbbb".
+    // Budget 15 (−2 margin = 13): "…bbbbbbbb" (9) fits, then 4 head chars fit.
+    expect(
+      sliceToFit("aaaaaaaa/bbbbbbbb", "leaf-path", "end", "…", 15, measure),
+    ).toBe("aaaa…bbbbbbbb");
+  });
+
+  it("keeps the head whole and trims the tail (priority=start)", () => {
+    expect(
+      sliceToFit("aaaaaaaa/bbbbbbbb", "leaf-path", "start", "…", 15, measure),
+    ).toBe("aaaaaaaa/…bbb");
+  });
+
+  it("drops the head and front-trims the tail when the tail alone won't fit", () => {
+    // Budget 8 (−2 = 6): even "…/bbbbbbbb" doesn't fit, so head goes and the tail
+    // is trimmed from its start → "…bbbbb".
+    expect(
+      sliceToFit("aaaaaaaa/bbbbbbbb", "leaf-path", "end", "…", 8, measure),
+    ).toBe("…bbbbb");
+  });
+
+  it("only ever drops whole characters (never a partial glyph)", () => {
+    const text = "apps/web/src/components/BaseStepCard.tsx";
+    const out = sliceToFit(text, "center", "end", "…", 20, measure);
+    // Everything except the single "…" comes verbatim from the original string.
+    const parts = out.split("…");
+    expect(parts).toHaveLength(2);
+    expect(text.includes(parts[0])).toBe(true);
+    expect(text.includes(parts[1])).toBe(true);
+  });
+
+  it("keeps both ends and centers the marker for split='center'", () => {
+    // 8 "a" + 8 "b"; center splits into equal halves. Budget 11 (−2 = 9) fits
+    // 4 + "…" + 4 — both ends stay visible with the marker in the middle, not
+    // the leading "…" the anchored (keep-one-side-whole) path would produce.
+    expect(
+      sliceToFit("aaaaaaaabbbbbbbb", "center", "end", "…", 11, measure),
+    ).toBe("aaaa…bbbb");
+  });
+
+  it("biases the odd character by priority for split='center'", () => {
+    // Budget 10 (−2 = 8) fits 7 chars around the marker; priority takes the
+    // extra one — the tail for `end`, the head for `start`.
+    expect(
+      sliceToFit("aaaaaaaabbbbbbbb", "center", "end", "…", 10, measure),
+    ).toBe("aaa…bbbb");
+    expect(
+      sliceToFit("aaaaaaaabbbbbbbb", "center", "start", "…", 10, measure),
+    ).toBe("aaaa…bbb");
+  });
+});

--- a/packages/truncate/src/TruncatedText/TruncatedText.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.tsx
@@ -1,29 +1,333 @@
 import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
 import { Text } from "@telegraph/typography";
+import { type ComponentPropsWithoutRef, type ReactNode, type Ref } from "react";
 
 import { TooltipIfTruncated } from "../TooltipIfTruncated";
 
+import {
+  middleIsTruncated,
+  middleSliceIsTruncated,
+  resolveSplit,
+} from "./TruncatedText.helpers";
+import { MiddleTruncate } from "./TruncatedText.primitives";
+import type {
+  Split,
+  TruncatePriority,
+  TruncateVariant,
+  TruncatedTextMode,
+} from "./TruncatedText.types";
+
+export type {
+  CustomSplitFn,
+  Split,
+  SplitOffset,
+  TruncatedTextMode,
+  TruncatePriority,
+  TruncateVariant,
+} from "./TruncatedText.types";
+
+// ── Internal CSS engine ─────────────────────────────────────────────────────
+// The extra modes are purely presentational: no state, no effects, no
+// ResizeObserver, no `scrollWidth` measurement. Overflow detection lives
+// entirely in `TruncatedText.styles.css` via a container size-query (ported from
+// Pierre's `truncate`). Because there is no measure→setState machinery, these
+// helpers cannot produce the "Maximum update depth exceeded" loop that a
+// JS-measured path could (see KNO-14285). They are an implementation detail of
+// `TruncatedText` and are not exported.
+
+/** `truncate` clips the end; `fruncate` clips the start. */
+type ClipMode = "truncate" | "fruncate";
+
+type ClipProps = {
+  children?: ReactNode;
+  mode?: ClipMode;
+  /** The overflow indicator. Defaults to an ellipsis. */
+  marker?: ReactNode;
+  variant?: TruncateVariant;
+  /** Forwarded to the root element so it can act as a tooltip trigger. */
+  tgphRef?: Ref<HTMLDivElement>;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+const ClipContent = ({
+  mode,
+  children,
+}: {
+  mode: ClipMode;
+  children?: ReactNode;
+}) => (
+  <div>
+    <div data-tgph-truncate-content="visible">
+      {mode === "fruncate" ? <span>{children}</span> : children}
+    </div>
+    <div data-tgph-truncate-content="overflow" aria-hidden>
+      {mode === "fruncate" ? <span>{children}</span> : children}
+    </div>
+  </div>
+);
+
+const ClipMarker = ({ marker }: { marker: ReactNode }) => (
+  <div aria-hidden data-tgph-truncate-marker-cell>
+    <div data-tgph-truncate-marker>{marker}</div>
+  </div>
+);
+
+/** One-line clip with a fade/ellipsis marker at the clipped edge. */
+const TruncateClip = ({
+  children,
+  mode = "truncate",
+  marker = "…",
+  variant = "default",
+  tgphRef,
+  ...props
+}: ClipProps) => {
+  const content = (
+    <ClipContent key="content" mode={mode}>
+      {children}
+    </ClipContent>
+  );
+  const markerNode = <ClipMarker key="marker" marker={marker} />;
+
+  return (
+    <div
+      ref={tgphRef}
+      data-tgph-truncate={mode}
+      data-tgph-truncate-variant={variant}
+      {...props}
+    >
+      <div data-tgph-truncate-grid>
+        {mode === "truncate"
+          ? [content, markerNode]
+          : [markerNode, content, <div key="fill" data-tgph-truncate-fill />]}
+      </div>
+    </div>
+  );
+};
+
+type MiddleClipProps = {
+  children: string;
+  split?: Split;
+  marker?: ReactNode;
+  variant?: TruncateVariant;
+  /** Which end stays intact first when space is tight. Defaults to `end`. */
+  priority?: TruncatePriority;
+} & Omit<ComponentPropsWithoutRef<"div">, "children">;
+
+// Middle truncation (string only, like Pierre): split the string, clip the head
+// from its end and the tail from its start, so the middle is elided.
+const MiddleClip = ({
+  children,
+  split = "center",
+  marker = "…",
+  variant = "default",
+  priority = "end",
+  ...props
+}: MiddleClipProps) => {
+  const [head, tail] = resolveSplit(split, children);
+
+  // Exactly one segment truncates (the other is kept whole by the priority flex
+  // in the stylesheet), so only that segment's container query fires and a single
+  // marker reveals at the seam — no de-duplication needed.
+  return (
+    <div
+      data-tgph-truncate-group="middle"
+      data-tgph-truncate-priority={priority}
+      {...props}
+    >
+      <div data-tgph-truncate-segment="head">
+        <TruncateClip mode="truncate" marker={marker} variant={variant}>
+          {head}
+        </TruncateClip>
+      </div>
+      <div data-tgph-truncate-segment="tail">
+        <TruncateClip mode="fruncate" marker={marker} variant={variant}>
+          {tail}
+        </TruncateClip>
+      </div>
+    </div>
+  );
+};
+
+// Wrap RTL-clipped (front-truncated) content so its own glyphs keep logical
+// order. The RTL base direction — which is what flips `text-overflow: ellipsis`
+// to the start — would otherwise reorder leading/trailing neutral characters
+// (a leading "/" or "." would jump to the opposite end).
+const LTR_ISOLATE = { direction: "ltr", unicodeBidi: "isolate" } as const;
+
+// ── Public component ────────────────────────────────────────────────────────
+
 export type TruncatedTextProps<T extends TgphElement = "span"> = {
   tooltipProps?: Partial<TgphComponentProps<typeof TooltipIfTruncated>>;
+  /**
+   * `truncate` (default) clips the end, `fruncate` the start, and `middle`
+   * elides the middle — all with native `text-overflow: ellipsis`, so they clip
+   * on glyph boundaries (never mid-glyph) and need no imported CSS. `middle`
+   * requires string children. A `fade` `variant` or a custom `marker` upgrades
+   * to the CSS engine (modern browsers only; constrain the engine clip box via
+   * `style`, not `maxWidth`).
+   */
+  mode?: TruncatedTextMode;
+  /** Ellipsis (default) vs. a soft fade into the background. `fade` uses the engine. */
+  variant?: TruncateVariant;
+  /** A custom overflow marker (defaults to the native ellipsis). Uses the engine. */
+  marker?: ReactNode;
+  /** `middle` mode: where to split the string. */
+  split?: Split;
+  /** `middle` mode: which end stays whole; the other truncates (one ellipsis). */
+  priority?: TruncatePriority;
 } & TgphComponentProps<typeof Text<T>>;
 
 const TruncatedText = <T extends TgphElement = "span">({
+  mode = "truncate",
+  variant,
+  marker: markerProp,
+  split,
+  priority,
   tooltipProps,
   style,
+  children,
+  as,
   ...props
 }: TruncatedTextProps<T>) => {
+  // The tooltip must show the full, unclipped string. Letting TooltipIfTruncated
+  // auto-extract it only unwraps one child level, so an engine/`middle` child
+  // would surface the elided, marker-laden markup instead. Pass the string
+  // explicitly; callers can still override it via `tooltipProps.label`.
+  const label = typeof children === "string" ? children : undefined;
+
+  // An empty marker means "no custom marker" — fall back to the native ellipsis
+  // rather than opting into the engine with a blank delimiter.
+  const marker = markerProp === "" ? undefined : markerProp;
+
+  // The overlay-marker engine (a container size-query + a masked marker) is used
+  // only for effects native truncation can't produce: the `fade` variant and
+  // custom `marker`s. Plain ellipsis truncation — end, front, and middle — uses
+  // native `text-overflow: ellipsis`, which clips on glyph boundaries (never
+  // mid-glyph), needs no JS/container query, and requires no imported CSS.
+  const useEngine = variant === "fade" || marker !== undefined;
+
+  // Middle truncation. `variant="fade"` uses the CSS engine (a dissolve). The
+  // default measures and slices the string to exactly the `head…tail` characters
+  // that fit — a crisp "…", no seam gap, and never a cut glyph, at every width.
+  // Pure CSS can't do all three at once (box-filling vs glyph-boundary clipping),
+  // so this is the one mode that measures; the JS is scoped to `middle`, runs only
+  // on real resizes, and is guarded (see TruncatedText.primitives).
+  if (mode === "middle" && typeof children === "string") {
+    // Measure-and-slice can only splice a *string* marker into the text; fall to
+    // the CSS engine for the `fade` variant or a ReactNode marker (which it can
+    // render as a node, while measure-and-slice would drop it).
+    const stringMarker = typeof marker === "string" ? marker : undefined;
+    if (
+      variant === "fade" ||
+      (marker !== undefined && stringMarker === undefined)
+    ) {
+      return (
+        <TooltipIfTruncated
+          label={label}
+          {...tooltipProps}
+          isTruncated={middleIsTruncated}
+        >
+          <Text
+            as={(as ?? "div") as T}
+            {...props}
+            style={{ display: "flex", minWidth: 0, ...style }}
+          >
+            <MiddleClip
+              variant={variant ?? "default"}
+              marker={marker}
+              split={split}
+              priority={priority}
+            >
+              {children}
+            </MiddleClip>
+          </Text>
+        </TooltipIfTruncated>
+      );
+    }
+    return (
+      <TooltipIfTruncated
+        label={label}
+        {...tooltipProps}
+        isTruncated={middleSliceIsTruncated}
+      >
+        <Text
+          as={(as ?? "div") as T}
+          {...props}
+          // `display: block` so an inline `as` (e.g. "span") still honors
+          // `maxWidth` — the slice measures this element's width.
+          style={{ display: "block", minWidth: 0, ...style }}
+        >
+          <MiddleTruncate
+            text={children}
+            split={split}
+            priority={priority}
+            marker={stringMarker}
+          />
+        </Text>
+      </TooltipIfTruncated>
+    );
+  }
+
+  // Engine end/front truncation. The inner Text carries typography; the engine
+  // root (which overflows when clipped) is the tooltip trigger.
+  if (useEngine && (mode === "truncate" || mode === "fruncate")) {
+    return (
+      <TooltipIfTruncated label={label} {...tooltipProps}>
+        <TruncateClip
+          mode={mode}
+          variant={variant}
+          marker={marker}
+          style={style}
+        >
+          <Text as={as} {...props}>
+            {children}
+          </Text>
+        </TruncateClip>
+      </TooltipIfTruncated>
+    );
+  }
+
+  // Native front truncation: `direction: rtl` flips `text-overflow: ellipsis` to
+  // clip (and place the ellipsis) at the start. The RTL base would reorder
+  // leading/trailing neutrals (a leading "/" would jump to the end), so the LTR
+  // content is wrapped in an isolate to keep its logical glyph order intact.
+  if (mode === "fruncate") {
+    return (
+      <TooltipIfTruncated label={label} {...tooltipProps}>
+        <Text
+          as={as}
+          style={{
+            display: "block",
+            overflow: "hidden",
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            direction: "rtl",
+            ...style,
+          }}
+          {...props}
+        >
+          <span style={LTR_ISOLATE}>{children}</span>
+        </Text>
+      </TooltipIfTruncated>
+    );
+  }
+
+  // Default: native end truncation. Also the fallback when `middle` is given
+  // non-string children.
   return (
-    <TooltipIfTruncated {...tooltipProps}>
+    <TooltipIfTruncated label={label} {...tooltipProps}>
       <Text
-        textOverflow="ellipsis"
-        overflow="hidden"
+        as={as}
         style={{
           display: "block",
+          overflow: "hidden",
           whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
           ...style,
         }}
         {...props}
-      />
+      >
+        {children}
+      </Text>
     </TooltipIfTruncated>
   );
 };

--- a/packages/truncate/src/TruncatedText/TruncatedText.types.ts
+++ b/packages/truncate/src/TruncatedText/TruncatedText.types.ts
@@ -1,0 +1,25 @@
+/*
+ * Shared types for `TruncatedText`, its primitives, and its helpers. Kept in a
+ * standalone module so the component, the `MiddleTruncate` primitive, and the
+ * split/slice helpers can all reference them without a circular import.
+ */
+
+/** How the content is clipped. */
+export type TruncatedTextMode = "truncate" | "fruncate" | "middle";
+
+/** `default` shows an ellipsis marker; `fade` dissolves the text into the bg. */
+export type TruncateVariant = "default" | "fade";
+
+/** Which end of a middle-truncated string is kept whole — the other truncates. */
+export type TruncatePriority = "start" | "end";
+
+/** Named split strategies for middle truncation. */
+export type SplitMode = "center" | "extension" | "leaf-path";
+
+/** `["last", n]` keeps the last n chars intact; `["first", n]` the first n. */
+export type SplitOffset = ["last" | "first", number];
+
+export type CustomSplitFn = (contents: string) => [string, string];
+
+/** A named strategy, a raw index, an offset tuple, or a custom function. */
+export type Split = SplitMode | number | SplitOffset | CustomSplitFn;

--- a/packages/truncate/src/TruncatedText/index.ts
+++ b/packages/truncate/src/TruncatedText/index.ts
@@ -1,2 +1,10 @@
 export { TruncatedText } from "./TruncatedText";
-export type { TruncatedTextProps } from "./TruncatedText";
+export type {
+  TruncatedTextProps,
+  TruncatedTextMode,
+  TruncateVariant,
+  TruncatePriority,
+  Split,
+  SplitOffset,
+  CustomSplitFn,
+} from "./TruncatedText";

--- a/packages/truncate/src/default.css
+++ b/packages/truncate/src/default.css
@@ -1,0 +1,1 @@
+@import "./TruncatedText/TruncatedText.styles.css";

--- a/packages/truncate/src/index.ts
+++ b/packages/truncate/src/index.ts
@@ -1,5 +1,16 @@
+export { TruncatedText } from "./TruncatedText";
+export type {
+  TruncatedTextProps,
+  TruncatedTextMode,
+  // Option types for TruncatedText's engine modes (`fruncate` / `middle` /
+  // `variant="fade"`). The CSS engine that backs them is an internal
+  // implementation detail of TruncatedText and is intentionally not exported.
+  TruncateVariant,
+  TruncatePriority,
+  Split,
+  SplitOffset,
+  CustomSplitFn,
+} from "./TruncatedText";
 export { TooltipIfTruncated } from "./TooltipIfTruncated";
 export type { TooltipIfTruncatedProps } from "./TooltipIfTruncated";
-export { TruncatedText } from "./TruncatedText";
-export type { TruncatedTextProps } from "./TruncatedText";
 export { useTruncate } from "./useTruncate";

--- a/packages/truncate/src/useTruncate/useTruncate.ts
+++ b/packages/truncate/src/useTruncate/useTruncate.ts
@@ -1,35 +1,72 @@
-import React from "react";
+import {
+  type DependencyList,
+  type RefObject,
+  useEffect,
+  useState,
+} from "react";
 
 type UseTruncateParams = {
-  tgphRef: React.RefObject<HTMLElement | null>;
+  tgphRef: RefObject<HTMLElement | null>;
 };
 
+/**
+ * Reactive "is this element currently truncated?" (`scrollWidth > clientWidth`),
+ * kept up to date with a `ResizeObserver`.
+ *
+ * This is the JS counterpart to `TruncatedText`'s CSS-only engine modes, for
+ * two different needs:
+ * - Use `TruncatedText` (`mode="fruncate"` / `"middle"`, `variant="fade"`) when
+ *   you only need to *render* truncated text — detection stays in CSS, no JS runs.
+ * - Use `useTruncate` when you need the truncation state *as a value in render*
+ *   — to gate a tooltip, toggle "show more", swap an icon, etc.
+ *
+ * A pure CSS container query can't be read back into React state without
+ * observation, so a `ResizeObserver` is the right bridge. It measures the
+ * element you point it at, so it works on any clipped element — native
+ * `text-overflow: ellipsis` or a `TruncatedText` engine root. (`mode="middle"`
+ * is the exception: its container never overflows, so measure a segment, or
+ * gate a tooltip with `TooltipIfTruncated`'s `isTruncated` prop instead.)
+ *
+ * The state write is value-guarded and the observer is created once per mounted
+ * element, so a redundant measurement is a genuine no-op even when the
+ * surrounding tree re-renders constantly (e.g. a ReactFlow graph). That is what
+ * keeps it from cascading into "Maximum update depth exceeded" (React #185,
+ * KNO-14285) — the crash came from the previous unconditional `setState`, not
+ * from measuring.
+ */
 const useTruncate = (
   { tgphRef }: UseTruncateParams,
-  deps: React.DependencyList = [],
+  deps: DependencyList = [],
 ) => {
-  const [truncated, setTruncated] = React.useState(false);
+  const [truncated, setTruncated] = useState(false);
 
-  React.useEffect(() => {
-    if (!tgphRef.current) return setTruncated(false);
+  useEffect(() => {
+    const element = tgphRef.current;
 
-    const tgphRefElement = tgphRef.current;
+    // Only write when the value actually changes. React usually absorbs a
+    // same-value `setState` via its bailout, but in a continuously
+    // re-rendering tree the fiber's lanes stay dirty and that bailout can be
+    // defeated; returning the previous value keeps a redundant update a true
+    // no-op regardless of how (un)stable the caller's `deps` are.
+    const setTruncatedIfChanged = (next: boolean) =>
+      setTruncated((prev) => (prev === next ? prev : next));
 
-    const checkTruncation = () => {
-      setTruncated(tgphRefElement.scrollWidth > tgphRefElement.clientWidth);
-    };
+    if (!element) {
+      setTruncatedIfChanged(false);
+      return;
+    }
+
+    const checkTruncation = () =>
+      setTruncatedIfChanged(element.scrollWidth > element.clientWidth);
 
     // Initial check
     checkTruncation();
 
-    // Add a resize observer to check for truncation when the element is resized
+    // Re-check whenever the element is resized.
     const resizeObserver = new ResizeObserver(checkTruncation);
-    resizeObserver.observe(tgphRefElement);
+    resizeObserver.observe(element);
 
-    // Clean up
-    return () => {
-      resizeObserver.disconnect();
-    };
+    return () => resizeObserver.disconnect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tgphRef, ...deps]);
 

--- a/packages/truncate/vite.config.mts
+++ b/packages/truncate/vite.config.mts
@@ -1,7 +1,10 @@
 import {
   defaultViteConfig,
-  styleEngineViteConfig,
+  scopedCssViteConfig,
 } from "@telegraph/vite-config";
 import { mergeConfig } from "vite";
 
-export default mergeConfig(defaultViteConfig, styleEngineViteConfig);
+// truncate now ships real CSS (OverflowText). Build `src/default.css` the same
+// way as other CSS-shipping packages (e.g. link) rather than the vanilla-extract
+// style-engine config, which emitted nothing here.
+export default mergeConfig(defaultViteConfig, scopedCssViteConfig);


### PR DESCRIPTION
## What changed

`TruncatedText` gains `mode="truncate" | "fruncate" | "middle"`, a `fade` `variant`, a custom `marker`, and `split` / `priority` (middle) — and is now the single truncation component, public exports unchanged:

- **`truncate` / `fruncate`** — end / start (via `direction: rtl`) clip with native `text-overflow: ellipsis`; glyph-boundary, no stylesheet.
- **`middle`** — measures and slices to exactly the `head…tail` that fits: crisp `…`, no gap, never a cut glyph. `split="center"` (default) balances both ends; `leaf-path` / `extension` keep one whole end via `priority`. Scoped to middle, real-resize-only (guarded `ResizeObserver`), honors `maxWidth`.
- **`variant="fade"` / custom `marker`** — dissolve / replace the edge via a CSS-only engine (a container size-query, ported from Pierre); the only paths needing the stylesheet.
- **`TooltipIfTruncated`** — measures lazily on hover/focus instead of in a render effect, plus an `isTruncated` predicate; removes the "Maximum update depth exceeded" (React #185) loop.
- **`useTruncate`** — value-guarded `setState`, so the reactive-boolean hook stays, safely.
- **Storybook** — one controls-driven `Playground`, plus `Modes` / `SplitStrategies` / `WithCustomTooltip` references.

## Why

The KNO-14285 crash was measure-in-an-effect plus unconditional `setState`. Every render path is now safe: `truncate` / `fruncate` are pure CSS, and `middle` — the one render path that must measure, since pure CSS can't do gapless middle truncation without cutting a glyph — is scoped to that mode with a value-guarded, real-resize-only `setState`. The remaining JS booleans (tooltip gating, `useTruncate`) are taken lazily on interaction instead of in a render effect, so no path can re-enter the #185 loop.

## Notes

- Only `variant="fade"` and a custom `marker` need `import "@telegraph/truncate/default.css"` and an evergreen browser (~2023+: container queries, `1lh`, `color-mix`). `truncate` / `fruncate` / `middle`, `TooltipIfTruncated`, and `useTruncate` don't.

Playground here: https://telegraph-storybook-git-kyle-kno-13728-improve-3ee4cc-knocklabs.vercel.app/?path=/story/components-truncatedtext--playground
