### PR TITLE
fix: tighten base-ui dismiss handler types so stale Radix usage fails to compile

### DIFF
--- a/.changeset/tidy-dismiss-handler-types.md
+++ b/.changeset/tidy-dismiss-handler-types.md
@@ -1,0 +1,11 @@
+---
+"@telegraph/popover": patch
+"@telegraph/menu": patch
+"@telegraph/modal": minor
+---
+
+Tighten base-ui dismiss-handler types so stale Radix `event.detail` usage fails to compile.
+
+`Popover.Content`, `Menu.Content`, and `Modal.Content` hand their dismiss callbacks (`onInteractOutside`, `onPointerDownOutside`, `onFocusOutside`, `onEscapeKeyDown`) the native DOM event, but the compat shim kept Radix's prop names. The callback's `event` param was resolving to `any` at the JSX call site instead of its concrete DOM `Event`, so in a consumer whose tsconfig doesn't flag implicit `any` a stale Radix-shaped handler reading `event.detail.originalEvent` compiled and then crashed at runtime (`Cannot read properties of undefined`). Each param now resolves to its concrete `Event` type, so `.detail`/`.originalEvent` access is a compile error.
+
+**Breaking (`@telegraph/modal`):** `Modal.Content` is now a plain function component instead of `forwardRef` (whose `PropsWithoutRef` wrapper caused the same widening), matching `Popover`/`Menu`. A `ref` on `Modal.Content` no longer forwards — pass `tgphRef` instead. (On React 19 a stray `ref` still reaches the node as a prop; on React 18 it does not.)

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -16,7 +16,15 @@ import {
   useEffect,
   useState,
 } from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 
 import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
 
@@ -98,6 +106,50 @@ describe("Menu", () => {
       // @ts-expect-error unknown prop rejected on MenuContentProps
       const invalidProp: MenuContentProps = { invalidProp: "invalid" };
       void invalidProp;
+    });
+
+    // Compile-time check for KNO-14309, asserted by `tsc`/the IDE — `vitest`
+    // does not typecheck, so these do not fail the jsdom run; the durable guard
+    // is the shipped `ContentProps` types, which error in any consumer's
+    // typecheck. Base UI hands dismiss handlers the native DOM event, but the
+    // shim kept Radix's prop names. When ContentProps wrapped the generic
+    // `Stack<T>` in an `Omit`, TypeScript stopped computing a contextual type
+    // for these callbacks and their `event` widened to implicit `any` at the
+    // JSX call site — letting a stale Radix handler read
+    // `event.detail.originalEvent` and crash at runtime. These render nothing;
+    // the handlers exist so `tsc` checks the inferred `event` type.
+    it("infers concrete Event types for inline dismiss handlers", () => {
+      const tree = (
+        <Menu.Content
+          onInteractOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<Event>();
+          }}
+          onPointerDownOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<
+              MouseEvent | PointerEvent | TouchEvent
+            >();
+          }}
+          onFocusOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<FocusEvent | KeyboardEvent>();
+          }}
+          onEscapeKeyDown={(event) => {
+            expectTypeOf(event).toEqualTypeOf<KeyboardEvent>();
+          }}
+        />
+      );
+      void tree;
+    });
+
+    it("rejects stale Radix event.detail access in inline dismiss handlers", () => {
+      const tree = (
+        <Menu.Content
+          onInteractOutside={(event) => {
+            // @ts-expect-error KNO-14309: native Event has no `detail` object
+            void event.detail.originalEvent.target;
+          }}
+        />
+      );
+      void tree;
     });
   });
 

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -3,12 +3,13 @@ import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type LegacyDismissEventHandler,
   type LegacyDismissHandlers,
+  type PolymorphicProps,
   type TgphComponentProps,
   type TgphElement,
   createTgphBaseUIRender,
   getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
-import { Box, Stack } from "@telegraph/layout";
+import { Box, Stack, type StackProps } from "@telegraph/layout";
 import { ChevronRight } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import {
@@ -417,7 +418,18 @@ export type ContentProps<T extends TgphElement = "div"> = Partial<
   Partial<
     Omit<BaseMenuPopupProps, "children" | "className" | "render" | "style">
   > &
-  Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
+  // Source the polymorphic element props from `PolymorphicProps<T>` and the
+  // Stack style props from the *non-generic* Stack. Wrapping the generic
+  // `typeof Stack<T>` in `Omit<…, "align">` produces a deferred mapped type,
+  // and TypeScript then fails to compute a contextual type for the sibling
+  // dismiss-handler callbacks below — their `event` param silently widens to
+  // `any` at the JSX call site. That is exactly what let a stale Radix-shaped
+  // handler reading `event.detail.originalEvent` compile and crash at runtime
+  // (KNO-14309). Keeping the `Omit` off the generic makes each handler's
+  // `event` resolve to its concrete `Event` type, so `.detail`/`.originalEvent`
+  // access fails to compile.
+  PolymorphicProps<T> &
+  Omit<StackProps, "align" | "as"> & {
     avoidCollisions?: boolean;
     contentStackRef?: Ref<HTMLDivElement>;
     forceMount?: BaseMenuPortalProps["keepMounted"];

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "@telegraph/button": "workspace:^",
-    "@telegraph/compose-refs": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
     "@telegraph/layout": "workspace:^",

--- a/packages/modal/src/Modal/Modal.test.tsx
+++ b/packages/modal/src/Modal/Modal.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { Modal } from "./Modal";
 import { ModalStackingProvider } from "./ModalStacking";
@@ -445,6 +445,48 @@ describe("Modal", () => {
       // @ts-expect-error unknown prop rejected on ModalFooterProps
       const invalidFooterProp: ModalFooterProps = { invalidProp: "invalid" };
       void invalidFooterProp;
+    });
+
+    // Compile-time check for KNO-14309, asserted by `tsc`/the IDE — `vitest`
+    // does not typecheck, so these do not fail the jsdom run; the durable guard
+    // is the shipped `ContentProps` types. Content is a plain `tgphRef` function
+    // component (not `forwardRef`) precisely so these dismiss-handler params
+    // keep a concrete contextual type at the JSX call site instead of widening
+    // to implicit `any` and letting a stale Radix `event.detail.originalEvent`
+    // handler compile and crash at runtime. Renders nothing; the handlers exist
+    // so `tsc` checks the inferred `event` type.
+    it("infers concrete Event types for inline dismiss handlers", () => {
+      const tree = (
+        <Modal.Content
+          onInteractOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<Event>();
+          }}
+          onPointerDownOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<
+              MouseEvent | PointerEvent | TouchEvent
+            >();
+          }}
+          onFocusOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<FocusEvent | KeyboardEvent>();
+          }}
+          onEscapeKeyDown={(event) => {
+            expectTypeOf(event).toEqualTypeOf<KeyboardEvent>();
+          }}
+        />
+      );
+      void tree;
+    });
+
+    it("rejects stale Radix event.detail access in inline dismiss handlers", () => {
+      const tree = (
+        <Modal.Content
+          onInteractOutside={(event) => {
+            // @ts-expect-error KNO-14309: native Event has no `detail` object
+            void event.detail.originalEvent.target;
+          }}
+        />
+      );
+      void tree;
     });
 
     it("rejects unknown props in JSX", () => {

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -1,6 +1,5 @@
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 import { Button } from "@telegraph/button";
-import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type LegacyDismissEventHandler,
   type LegacyDismissHandlers,
@@ -557,106 +556,110 @@ export type ContentProps = Partial<
   LegacyDismissHandlers & {
     onCloseAutoFocus?: LegacyDismissEventHandler;
     onOpenAutoFocus?: LegacyDismissEventHandler;
+    // `Content` is a plain function component (not `forwardRef`) so that the
+    // dismiss-handler callbacks above keep a concrete contextual type at the
+    // JSX call site. `forwardRef` wraps the props in React's
+    // `PropsWithoutRef<…>` mapped type, which — like an `Omit` over the generic
+    // Stack props — collapses those `event` params to implicit `any` and let a
+    // stale Radix `event.detail.originalEvent` handler compile and crash at
+    // runtime (KNO-14309). Expose the ref through `tgphRef`, matching
+    // Popover/Menu Content.
+    tgphRef?: Ref<ContentRef>;
   } & TgphComponentProps<typeof Stack>;
 type ContentRef = HTMLDivElement;
 
-type ModalContentStackProps = TgphComponentProps<typeof Stack> & {
-  tgphRef?: Ref<ContentRef>;
-};
+type ModalContentStackProps = TgphComponentProps<typeof Stack>;
 
+// Bridges the ref Base UI's `render` prop hands us onto Stack's `tgphRef`.
+// Content forwards the consumer's `tgphRef` to `BaseDialog.Popup` directly, so
+// this only needs to carry Base UI's own ref.
 const ModalContentStack = forwardRef<ContentRef, ModalContentStackProps>(
-  ({ tgphRef, ...props }, forwardedRef) => {
-    const composedRef = useComposedRefs(forwardedRef, tgphRef);
-
-    return <Stack tgphRef={composedRef} {...props} />;
+  (props, forwardedRef) => {
+    return <Stack tgphRef={forwardedRef} {...props} />;
   },
 );
 
 ModalContentStack.displayName = "ModalContentStack";
 
-const Content = forwardRef<ContentRef, ContentProps>(
-  (
-    {
-      children,
-      onCloseAutoFocus,
-      onEscapeKeyDown,
-      onFocusOutside,
-      onInteractOutside,
-      onOpenAutoFocus,
-      onPointerDownOutside,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    const compatibilityContext = useContext(ModalCompatibilityContext);
-    const resolvedInitialFocus = useCallback(() => {
-      // Combine Root and Content autofocus callbacks before converting their
-      // Radix-style preventDefault result into Base UI's boolean focus API.
-      const rootFocusPrevented = callAutoFocusHandler(
-        compatibilityContext?.rootFocusCallbacksRef.current.onMountAutoFocus,
-        "mountAutoFocus",
-      );
-      const contentFocusPrevented = callAutoFocusHandler(
-        onOpenAutoFocus,
-        "openAutoFocus",
-      );
-
-      return rootFocusPrevented || contentFocusPrevented ? false : true;
-    }, [compatibilityContext, onOpenAutoFocus]);
-    const resolvedFinalFocus = useCallback(() => {
-      // Close autofocus follows the same Radix preventDefault contract as open
-      // autofocus, but maps to Base UI's finalFocus callback.
-      const rootFocusPrevented = callAutoFocusHandler(
-        compatibilityContext?.rootFocusCallbacksRef.current.onUnmountAutoFocus,
-        "unmountAutoFocus",
-      );
-      const contentFocusPrevented = callAutoFocusHandler(
-        onCloseAutoFocus,
-        "closeAutoFocus",
-      );
-
-      return rootFocusPrevented || contentFocusPrevented ? false : true;
-    }, [compatibilityContext, onCloseAutoFocus]);
-
-    useEffect(() => {
-      if (!compatibilityContext) {
-        return;
-      }
-
-      // Store the latest content dismiss callbacks where Root can consult them
-      // from Base UI's single onOpenChange details callback.
-      compatibilityContext.contentCallbacksRef.current = {
-        onEscapeKeyDown,
-        onFocusOutside,
-        onInteractOutside,
-        onPointerDownOutside,
-      };
-
-      return () => {
-        compatibilityContext.contentCallbacksRef.current = {};
-      };
-    }, [
-      compatibilityContext,
-      onEscapeKeyDown,
-      onFocusOutside,
-      onInteractOutside,
-      onPointerDownOutside,
-    ]);
-
-    return (
-      <BaseDialog.Popup
-        ref={forwardedRef}
-        initialFocus={resolvedInitialFocus}
-        finalFocus={resolvedFinalFocus}
-        render={createTgphBaseUIRender(
-          <ModalContentStack direction="column" h="full" {...props}>
-            {children}
-          </ModalContentStack>,
-        )}
-      />
+const Content = ({
+  children,
+  onCloseAutoFocus,
+  onEscapeKeyDown,
+  onFocusOutside,
+  onInteractOutside,
+  onOpenAutoFocus,
+  onPointerDownOutside,
+  tgphRef,
+  ...props
+}: ContentProps) => {
+  const compatibilityContext = useContext(ModalCompatibilityContext);
+  const resolvedInitialFocus = useCallback(() => {
+    // Combine Root and Content autofocus callbacks before converting their
+    // Radix-style preventDefault result into Base UI's boolean focus API.
+    const rootFocusPrevented = callAutoFocusHandler(
+      compatibilityContext?.rootFocusCallbacksRef.current.onMountAutoFocus,
+      "mountAutoFocus",
     );
-  },
-);
+    const contentFocusPrevented = callAutoFocusHandler(
+      onOpenAutoFocus,
+      "openAutoFocus",
+    );
+
+    return rootFocusPrevented || contentFocusPrevented ? false : true;
+  }, [compatibilityContext, onOpenAutoFocus]);
+  const resolvedFinalFocus = useCallback(() => {
+    // Close autofocus follows the same Radix preventDefault contract as open
+    // autofocus, but maps to Base UI's finalFocus callback.
+    const rootFocusPrevented = callAutoFocusHandler(
+      compatibilityContext?.rootFocusCallbacksRef.current.onUnmountAutoFocus,
+      "unmountAutoFocus",
+    );
+    const contentFocusPrevented = callAutoFocusHandler(
+      onCloseAutoFocus,
+      "closeAutoFocus",
+    );
+
+    return rootFocusPrevented || contentFocusPrevented ? false : true;
+  }, [compatibilityContext, onCloseAutoFocus]);
+
+  useEffect(() => {
+    if (!compatibilityContext) {
+      return;
+    }
+
+    // Store the latest content dismiss callbacks where Root can consult them
+    // from Base UI's single onOpenChange details callback.
+    compatibilityContext.contentCallbacksRef.current = {
+      onEscapeKeyDown,
+      onFocusOutside,
+      onInteractOutside,
+      onPointerDownOutside,
+    };
+
+    return () => {
+      compatibilityContext.contentCallbacksRef.current = {};
+    };
+  }, [
+    compatibilityContext,
+    onEscapeKeyDown,
+    onFocusOutside,
+    onInteractOutside,
+    onPointerDownOutside,
+  ]);
+
+  return (
+    <BaseDialog.Popup
+      ref={tgphRef}
+      initialFocus={resolvedInitialFocus}
+      finalFocus={resolvedFinalFocus}
+      render={createTgphBaseUIRender(
+        <ModalContentStack direction="column" h="full" {...props}>
+          {children}
+        </ModalContentStack>,
+      )}
+    />
+  );
+};
 
 export type CloseProps<T extends TgphElement = "button"> = TgphComponentProps<
   typeof Button<T>

--- a/packages/popover/src/Popover/Popover.test.tsx
+++ b/packages/popover/src/Popover/Popover.test.tsx
@@ -7,7 +7,7 @@ import {
   createRef,
   useState,
 } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
 
@@ -63,6 +63,50 @@ describe("Popover", () => {
       // @ts-expect-error unknown prop rejected on PopoverContentProps
       const invalidProp: PopoverContentProps = { invalidProp: "invalid" };
       void invalidProp;
+    });
+
+    // Compile-time check for KNO-14309, asserted by `tsc`/the IDE — `vitest`
+    // does not typecheck, so these do not fail the jsdom run; the durable guard
+    // is the shipped `ContentProps` types, which error in any consumer's
+    // typecheck. Base UI hands dismiss handlers the native DOM event, but the
+    // shim kept Radix's prop names. When ContentProps wrapped the generic
+    // `Stack<T>` in an `Omit`, TypeScript stopped computing a contextual type
+    // for these callbacks and their `event` widened to implicit `any` at the
+    // JSX call site — letting a stale Radix handler read
+    // `event.detail.originalEvent` and crash at runtime. These render nothing;
+    // the handlers exist so `tsc` checks the inferred `event` type.
+    it("infers concrete Event types for inline dismiss handlers", () => {
+      const tree = (
+        <Popover.Content
+          onInteractOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<Event>();
+          }}
+          onPointerDownOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<
+              MouseEvent | PointerEvent | TouchEvent
+            >();
+          }}
+          onFocusOutside={(event) => {
+            expectTypeOf(event).toEqualTypeOf<FocusEvent | KeyboardEvent>();
+          }}
+          onEscapeKeyDown={(event) => {
+            expectTypeOf(event).toEqualTypeOf<KeyboardEvent>();
+          }}
+        />
+      );
+      void tree;
+    });
+
+    it("rejects stale Radix event.detail access in inline dismiss handlers", () => {
+      const tree = (
+        <Popover.Content
+          onInteractOutside={(event) => {
+            // @ts-expect-error KNO-14309: native Event has no `detail` object
+            void event.detail.originalEvent.target;
+          }}
+        />
+      );
+      void tree;
     });
   });
 

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -3,14 +3,14 @@ import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type LegacyDismissEventHandler,
   type LegacyDismissHandlers,
-  type TgphComponentProps,
+  type PolymorphicProps,
   type TgphElement,
   callLegacyDismissHandlers,
   createTgphBaseUIRender,
   getBaseUIMotionOffset,
   getBaseUIPositionerVisibilityStyle,
 } from "@telegraph/helpers";
-import { Stack } from "@telegraph/layout";
+import { Stack, type StackProps } from "@telegraph/layout";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
 import {
@@ -166,7 +166,18 @@ export type ContentProps<T extends TgphElement = "div"> = Omit<
   "children" | "className" | "render"
 > &
   Omit<BasePopoverPopupProps, "children" | "className" | "render" | "style"> &
-  Omit<TgphComponentProps<typeof Stack<T>>, "align"> & {
+  // Source the polymorphic element props from `PolymorphicProps<T>` and the
+  // Stack style props from the *non-generic* Stack. Wrapping the generic
+  // `typeof Stack<T>` in `Omit<…, "align">` produces a deferred mapped type,
+  // and TypeScript then fails to compute a contextual type for the sibling
+  // dismiss-handler callbacks below — their `event` param silently widens to
+  // `any` at the JSX call site. That is exactly what let a stale Radix-shaped
+  // handler reading `event.detail.originalEvent` compile and crash at runtime
+  // (KNO-14309). Keeping the `Omit` off the generic makes each handler's
+  // `event` resolve to its concrete `Event` type, so `.detail`/`.originalEvent`
+  // access fails to compile.
+  PolymorphicProps<T> &
+  Omit<StackProps, "align" | "as"> & {
     avoidCollisions?: boolean;
     contentStackRef?: Ref<HTMLDivElement>;
     forceMount?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3790,7 +3790,6 @@ __metadata:
     "@knocklabs/prettier-config": "npm:^0.0.1"
     "@knocklabs/typescript-config": "npm:^0.0.2"
     "@telegraph/button": "workspace:^"
-    "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"


### PR DESCRIPTION
## What changed

- **`Popover.Content` / `Menu.Content`** — dismiss-handler `event` params (`onInteractOutside`, `onPointerDownOutside`, `onFocusOutside`, `onEscapeKeyDown`) now resolve to their concrete DOM `Event` at the JSX call site instead of `any`; polymorphic props come from `PolymorphicProps<T>` + non-generic `Omit<StackProps, "align" | "as">` so the `align`-Omit no longer wraps the generic `Stack<T>`.
- **`Modal.Content`** — same fix, converted from `forwardRef` to a `tgphRef` function component (its `PropsWithoutRef` wrapper caused the same widening).
- **`*.test.tsx`** — compile-time guards that inline handler params are concrete `Event`s and that stale `event.detail` access fails to compile.

## Why

Telegraph's base-ui shim keeps Radix's dismiss-handler prop names but hands the callback the native DOM event. The param was silently widening to `any` at the JSX call site, so a stale Radix `event.detail.originalEvent` handler compiled and then crashed at runtime (`Cannot read properties of undefined`, Sentry `CONTROL-DASHBOARD-2H7`). jsdom can't exercise real outside-press, so the type-level guard is the durable prevention.

