### PR TITLE
refactor(layout): remove raw size value passthrough from Box sizing props

### DIFF
--- a/.changeset/tidy-boxes-shrink.md
+++ b/.changeset/tidy-boxes-shrink.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/layout": patch
+"@telegraph/style-engine": patch
+---
+
+Remove raw size value passthrough from Box sizing props. `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight` and their shorthands (`w`, `h`, `minW`, `minH`, `maxW`, `maxH`) accept `@telegraph/tokens` spacing values only again — raw CSS values such as `maxH="400px"` or `w="100%"` are no longer accepted or passed through. This reverses the compatibility behavior added in #837; pass a spacing token, or use `style`/`className` for genuine raw CSS.

--- a/packages/layout/src/Box/Box.constants.ts
+++ b/packages/layout/src/Box/Box.constants.ts
@@ -8,7 +8,6 @@ import type { CSSProperties } from "react";
 
 // Type that allows both positive and negative spacing values
 type SpacingValue = WithNegativeSpacing<keyof typeof tokens.spacing>;
-type SizeValue = keyof typeof tokens.spacing | (string & {});
 
 export type BaseStyleProps = {
   display: "block" | "inline-block" | "inline" | "flex" | "inline-flex";
@@ -48,12 +47,12 @@ export type BaseStyleProps = {
   borderLeftRadius: keyof typeof tokens.rounded;
   borderRightRadius: keyof typeof tokens.rounded;
   boxShadow: keyof typeof tokens.shadow;
-  width: SizeValue;
-  height: SizeValue;
-  minWidth: SizeValue;
-  minHeight: SizeValue;
-  maxWidth: SizeValue;
-  maxHeight: SizeValue;
+  width: keyof typeof tokens.spacing;
+  height: keyof typeof tokens.spacing;
+  minWidth: keyof typeof tokens.spacing;
+  minHeight: keyof typeof tokens.spacing;
+  maxWidth: keyof typeof tokens.spacing;
+  maxHeight: keyof typeof tokens.spacing;
   zIndex: keyof (typeof tokens)["zIndex"];
   position: "relative" | "absolute" | "fixed" | "sticky";
   top: SpacingValue;
@@ -87,12 +86,12 @@ type ShorthandStyleProps = {
   ml: SpacingValue;
   mr: SpacingValue;
   shadow: keyof typeof tokens.shadow;
-  w: SizeValue;
-  h: SizeValue;
-  minW: SizeValue;
-  minH: SizeValue;
-  maxW: SizeValue;
-  maxH: SizeValue;
+  w: keyof typeof tokens.spacing;
+  h: keyof typeof tokens.spacing;
+  minW: keyof typeof tokens.spacing;
+  minH: keyof typeof tokens.spacing;
+  maxW: keyof typeof tokens.spacing;
+  maxH: keyof typeof tokens.spacing;
   rounded: keyof typeof tokens.rounded;
   roundedTopLeft: keyof typeof tokens.rounded;
   roundedTopRight: keyof typeof tokens.rounded;
@@ -291,32 +290,26 @@ const baseCssVars: Record<keyof BaseStyleProps, CssVarProp> = {
   width: {
     cssVar: "--width",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   height: {
     cssVar: "--height",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   minWidth: {
     cssVar: "--min-width",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   minHeight: {
     cssVar: "--min-height",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   maxWidth: {
     cssVar: "--max-width",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   maxHeight: {
     cssVar: "--max-height",
     value: "var(--tgph-spacing-VARIABLE)",
-    allowRawValue: true,
   },
   zIndex: {
     cssVar: "--z-index",

--- a/packages/layout/src/Box/Box.test.tsx
+++ b/packages/layout/src/Box/Box.test.tsx
@@ -162,7 +162,7 @@ describe("Box", () => {
         margin: "1",
         display: "flex",
         direction: "column",
-        maxH: "400px",
+        maxH: "10",
       };
       void validProps;
     });
@@ -194,7 +194,7 @@ describe("Box", () => {
           rounded: "2",
           w: "10",
           h: "8",
-          maxH: "400px",
+          maxH: "10",
         },
       };
       void shorthands;
@@ -239,6 +239,22 @@ describe("Box", () => {
       };
       void invalid;
     });
+
+    it("rejects raw css values on size props", () => {
+      const invalid: BoxProps = {
+        // @ts-expect-error raw css size values are not spacing tokens
+        maxHeight: "400px",
+      };
+      void invalid;
+    });
+
+    it("rejects raw css values on shorthand size props", () => {
+      const invalid: BoxProps = {
+        // @ts-expect-error raw css size values are not spacing tokens
+        w: "100%",
+      };
+      void invalid;
+    });
   });
 
   describe("flex and size compatibility props", () => {
@@ -257,15 +273,6 @@ describe("Box", () => {
 
       expect(box).toHaveStyle({
         "--direction": "column",
-      });
-    });
-
-    it("passes raw maxH css values through unchanged", () => {
-      const { container } = render(<Box maxH="400px" />);
-      const box = container.querySelector(".tgph-box");
-
-      expect(box).toHaveStyle({
-        "--max-height": "400px",
       });
     });
   });

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.test.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.test.ts
@@ -54,24 +54,6 @@ describe("getStyleProp", () => {
       "--display": "block",
     });
   });
-  it("passes raw values through when the css var allows them", () => {
-    const { styleProp } = getStyleProp({
-      props: {
-        maxHeight: "400px",
-      },
-      cssVars: {
-        maxHeight: {
-          cssVar: "--max-height",
-          value: "var(--tgph-spacing-VARIABLE)",
-          allowRawValue: true,
-        },
-      },
-    });
-
-    expect(styleProp).toStrictEqual({
-      "--max-height": "400px",
-    });
-  });
   it("when no values are passed empty objects are returned", () => {
     const { styleProp, otherProps } = getStyleProp({
       props: {},

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
@@ -1,5 +1,3 @@
-import tokenSource from "@telegraph/tokens";
-
 type Direction =
   | "x"
   | "y"
@@ -18,7 +16,6 @@ type Axis = "x" | "y" | "both";
 export type CssVarProp = {
   cssVar: string;
   value: string;
-  allowRawValue?: boolean;
   direction?: Direction;
   axis?: Axis;
 };
@@ -262,17 +259,6 @@ type GetStylePropParams<CssVars, Props> = {
   cssVars: CssVars;
 };
 
-const isSpacingTokenValue = (propValue: string): boolean => {
-  const normalizedValue = propValue.startsWith("-")
-    ? propValue.slice(1)
-    : propValue;
-
-  return Object.prototype.hasOwnProperty.call(
-    tokenSource.tokens.spacing,
-    normalizedValue,
-  );
-};
-
 // Resolves a single prop value against its matching CssVarProp definition.
 // Returns the mapped CSS variable value string, handling negative spacing.
 const resolveValue = (
@@ -280,10 +266,6 @@ const resolveValue = (
   propValue: string,
 ): string => {
   const isNegative = typeof propValue === "string" && propValue.startsWith("-");
-
-  if (matchingCssVar.allowRawValue && !isSpacingTokenValue(propValue)) {
-    return propValue;
-  }
 
   if (isNegative) {
     const positiveValue = propValue.slice(1);


### PR DESCRIPTION
## What changed

- Box sizing props — `width`, `height`, `minWidth`, `minHeight`, `maxWidth`, `maxHeight` and their `w`/`h`/`minW`/`minH`/`maxW`/`maxH` shorthands — accept `@telegraph/tokens` spacing values only again (`keyof typeof tokens.spacing`).
- Removed the `allowRawValue` flag from those props and the raw-value passthrough (`isSpacingTokenValue` + the `resolveValue` branch) in `@telegraph/style-engine`. `getStyleProp.ts` reverts to its exact pre-#837 state.
- Updated Box type tests to use tokens, added `@ts-expect-error` coverage that raw values are now rejected, and dropped the raw-passthrough unit/runtime tests.

## Why

Reverses the compatibility shim added in #837. We don't want raw CSS values (`maxH="400px"`, `w="100%"`) on Box sizing props — sizing should stay on the token scale. Genuine raw CSS is still available via `style` / `className`.

## Notes

- **Breaking** for consumers passing raw size values to Box; changeset is a `minor` on `@telegraph/layout` and `@telegraph/style-engine`.
- Verified: `layout` + `style-engine` build (dts) pass, 82 unit tests pass, lint + format clean, and `Box.test.tsx` typechecks clean (the raw-value rejections resolve correctly).

Resolves KNO-14396
