### PR TITLE
feat(combobox, select): add required prop for native form validation (KNO-14400)

### DIFF
--- a/.changeset/combobox-select-required.md
+++ b/.changeset/combobox-select-required.md
@@ -1,0 +1,10 @@
+---
+"@telegraph/combobox": minor
+"@telegraph/select": minor
+---
+
+Add `required` (and `name`) props to `Combobox.Root` and `Select.Root` for native form integration. Base UI's combobox engine renders a hidden form input for the selection, so `required` enforces client-side required validation on submit — matching `<select required>` — and `name` submits the selected value under that key. `Select.Root` inherits both by forwarding to `Combobox.Root`.
+
+For a multi-select, `required` behaves as "at least one": the form is invalid while nothing is selected and validates once any value is chosen.
+
+Resolves KNO-14400.

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -91,6 +91,8 @@ The root component that manages the state and context for the combobox.
 | `closeOnSelect`      | `boolean`                                                   | `true`       | Close menu after selection                             |
 | `clearable`          | `boolean`                                                   | `false`      | Show clear button                                      |
 | `disabled`           | `boolean`                                                   | `false`      | Disable the combobox                                   |
+| `required`           | `boolean`                                                   | `false`      | Require a selection before form submission             |
+| `name`               | `string`                                                    | `undefined`  | Submit the selected value with this field name         |
 | `manualFiltering`    | `boolean`                                                   | automatic    | Show rendered options without the built-in text filter; controlled Search enables it by default |
 | `onItemHighlighted`  | `(value: string \| undefined, details: ComboboxHighlightDetails) => void` | `undefined` | Called when virtual option focus changes               |
 | `selectionMode`      | `"single" \| "multiple" \| "none"`                         | inferred     | Select one, select many, or accept free text           |

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -1393,6 +1393,91 @@ describe("Free-text autocomplete (selectionMode none)", () => {
   });
 });
 
+describe("required (form integration)", () => {
+  const RequiredForm = ({ value }: { value?: string }) => (
+    <form data-testid="form">
+      <Combobox.Root
+        value={value}
+        onValueChange={() => {}}
+        required
+        name="channel"
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </form>
+  );
+
+  it("blocks form submission until a value is selected", () => {
+    const { getByTestId, rerender } = render(<RequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // No selection: Base UI's hidden required input is empty → form invalid.
+    expect(form.checkValidity()).toBe(false);
+
+    // A selection populates the hidden input → the form validates.
+    rerender(<RequiredForm value="email" />);
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  it("submits the selected value under the given name", () => {
+    const { getByTestId, rerender } = render(<RequiredForm value="email" />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    const hidden = form.querySelector(
+      'input[name="channel"]',
+    ) as HTMLInputElement | null;
+    expect(hidden).not.toBeNull();
+    expect(hidden?.value).toBe("email");
+
+    rerender(<RequiredForm value="sms" />);
+    expect(
+      (form.querySelector('input[name="channel"]') as HTMLInputElement)?.value,
+    ).toBe("sms");
+  });
+
+  const MultiRequiredForm = ({ value }: { value?: Array<string> }) => (
+    <form data-testid="form">
+      <Combobox.Root
+        value={value ?? []}
+        onValueChange={() => {}}
+        required
+        name="channels"
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </form>
+  );
+
+  it("enforces required on a multi-select until at least one value is chosen", () => {
+    const { getByTestId, rerender } = render(<MultiRequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // Empty multi-select is required → invalid; Base UI drops `required` once a
+    // value exists, so a non-empty selection validates ("at least one" semantics).
+    expect(form.checkValidity()).toBe(false);
+
+    rerender(<MultiRequiredForm value={["email"]} />);
+    expect(form.checkValidity()).toBe(true);
+  });
+});
 describe("findStringNodes", () => {
   it("returns empty array for null node", () => {
     expect(findStringNodes(null)).toStrictEqual([]);

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -1192,6 +1192,92 @@ describe("Free-text autocomplete (selectionMode none)", () => {
   });
 });
 
+describe("required (form integration)", () => {
+  const RequiredForm = ({ value }: { value?: string }) => (
+    <form data-testid="form">
+      <Combobox.Root
+        value={value}
+        onValueChange={() => {}}
+        required
+        name="channel"
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </form>
+  );
+
+  it("blocks form submission until a value is selected", () => {
+    const { getByTestId, rerender } = render(<RequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // No selection: Base UI's hidden required input is empty → form invalid.
+    expect(form.checkValidity()).toBe(false);
+
+    // A selection populates the hidden input → the form validates.
+    rerender(<RequiredForm value="email" />);
+    expect(form.checkValidity()).toBe(true);
+  });
+
+  it("submits the selected value under the given name", () => {
+    const { getByTestId, rerender } = render(<RequiredForm value="email" />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    const hidden = form.querySelector(
+      'input[name="channel"]',
+    ) as HTMLInputElement | null;
+    expect(hidden).not.toBeNull();
+    expect(hidden?.value).toBe("email");
+
+    rerender(<RequiredForm value="sms" />);
+    expect(
+      (form.querySelector('input[name="channel"]') as HTMLInputElement)?.value,
+    ).toBe("sms");
+  });
+
+  const MultiRequiredForm = ({ value }: { value?: Array<string> }) => (
+    <form data-testid="form">
+      <Combobox.Root
+        value={value ?? []}
+        onValueChange={() => {}}
+        required
+        name="channels"
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </form>
+  );
+
+  it("enforces required on a multi-select until at least one value is chosen", () => {
+    const { getByTestId, rerender } = render(<MultiRequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // Empty multi-select is required → invalid; Base UI drops `required` once a
+    // value exists, so a non-empty selection validates ("at least one" semantics).
+    expect(form.checkValidity()).toBe(false);
+
+    rerender(<MultiRequiredForm value={["email"]} />);
+    expect(form.checkValidity()).toBe(true);
+  });
+});
+
 describe("legacyBehavior Combobox", () => {
   describe("Single Select", () => {
     it("combobox is accessible", async () => {

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -101,6 +101,11 @@ type RootSharedProps = {
   closeOnSelect?: boolean;
   clearable?: boolean;
   disabled?: boolean;
+  // Native form integration. Base UI renders a hidden form input for the
+  // selection: `required` enforces client-side required validation on submit
+  // (matching `<select required>`), and `name` submits the value under that key.
+  required?: boolean;
+  name?: string;
   // Disable the built-in text filtering of `Combobox.Option`s. Use this when the
   // consumer already narrows the option list itself (e.g. an async/server search
   // driven by `Combobox.Search`'s `onValueChange`): the options you render are
@@ -333,6 +338,8 @@ const RootImplementation = ({
   openOnInputClick: openOnInputClickProp,
   loopFocus: loopFocusProp,
   actionsRef,
+  required,
+  name,
   children,
 }: RootImplementationProps) => {
   const contentId = useId();
@@ -794,6 +801,9 @@ const RootImplementation = ({
           actionsRef={actionsRef}
           modal={modal}
           disabled={disabled}
+          // Native form integration; Base UI renders the hidden required input.
+          required={required}
+          name={name}
         >
           {children}
         </BaseAutocomplete.Root>
@@ -838,6 +848,9 @@ const RootImplementation = ({
           itemToStringLabel={itemToStringLabel}
           modal={modal}
           disabled={disabled}
+          // Native form integration; Base UI renders the hidden required input.
+          required={required}
+          name={name}
         >
           {children}
         </BaseCombobox.Root>

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -91,6 +91,11 @@ export type RootProps<
   closeOnSelect?: boolean;
   clearable?: boolean;
   disabled?: boolean;
+  // Native form integration. Base UI renders a hidden form input for the
+  // selection: `required` enforces client-side required validation on submit
+  // (matching `<select required>`), and `name` submits the value under that key.
+  required?: boolean;
+  name?: string;
   legacyBehavior?: LB;
   // Disable the built-in text filtering of `Combobox.Option`s. Use this when the
   // consumer already narrows the option list itself (e.g. an async/server search
@@ -272,6 +277,8 @@ const Root = <
   loopFocus: loopFocusProp,
   onItemHighlighted: onItemHighlightedProp,
   actionsRef,
+  required,
+  name,
   children,
 }: RootProps<O, LB>) => {
   const contentId = useId();
@@ -680,6 +687,9 @@ const Root = <
           actionsRef={actionsRef}
           modal={modal}
           disabled={disabled}
+          // Native form integration; Base UI renders the hidden required input.
+          required={required}
+          name={name}
         >
           {children}
         </BaseAutocomplete.Root>
@@ -719,6 +729,9 @@ const Root = <
           filteredItems={filteredItems}
           modal={modal}
           disabled={disabled}
+          // Native form integration; Base UI renders the hidden required input.
+          required={required}
+          name={name}
         >
           {children}
         </BaseCombobox.Root>

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -85,6 +85,9 @@ Telegraph infers this from whether `value` or `defaultValue` is an array.
 `triggerProps`, `contentProps`, and `optionsProps` continue to pass through to
 the underlying Combobox parts.
 
+Set `required` to use native form validation. An empty single- or multi-select
+blocks form submission. Set `name` to include the selected value in form data.
+
 Select does not depend on Radix directly.
 
 ## API Reference
@@ -100,6 +103,8 @@ The main select container component.
 | `size`          | `"0" \| "1" \| "2" \| "3"`            | `"1"`       | Size of the trigger button              |
 | `placeholder`   | `string`                              | `undefined` | Placeholder text when no value selected |
 | `disabled`      | `boolean`                             | `false`     | Whether the select is disabled          |
+| `required`      | `boolean`                             | `false`     | Require a selection before form submission |
+| `name`          | `string`                              | `undefined` | Submit the selected value with this field name |
 | `triggerProps`  | `ComboboxTriggerProps`                | `undefined` | Props passed to the trigger button      |
 | `contentProps`  | `ComboboxContentProps`                | `undefined` | Props passed to the dropdown content    |
 | `optionsProps`  | `ComboboxOptionsProps`                | `undefined` | Props passed to the options container   |

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -119,3 +119,44 @@ export const YearPickerWithScrollToValue: Story = {
     );
   },
 };
+
+// `required` enforces native client-side validation: submitting with no
+// selection is blocked by the browser (Base UI renders a hidden required input).
+export const RequiredInForm: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [value, setValue] = React.useState<string | undefined>(undefined);
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [submitted, setSubmitted] = React.useState<string | null>(null);
+    return (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          setSubmitted(value ?? "");
+        }}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+          alignItems: "flex-start",
+        }}
+      >
+        <Select.Root
+          placeholder="Select a channel"
+          value={value}
+          onValueChange={setValue}
+          size={args.size}
+          disabled={args.disabled}
+          required
+          name="channel"
+        >
+          <Select.Option value="email">Email</Select.Option>
+          <Select.Option value="sms">SMS</Select.Option>
+          <Select.Option value="push">Push</Select.Option>
+        </Select.Root>
+        <button type="submit">Submit</button>
+        {submitted !== null && <span>Submitted: {submitted || "(empty)"}</span>}
+      </form>
+    );
+  },
+};

--- a/packages/select/src/Select/Select.stories.tsx
+++ b/packages/select/src/Select/Select.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import React from "react";
+import { Button } from "@telegraph/button";
+import { Stack } from "@telegraph/layout";
+import { Text } from "@telegraph/typography";
+import { type FormEvent, useState } from "react";
 
-import { Select } from "./Select";
+import { Select, type RootProps } from "./Select";
 
 // Annotated rather than inferred: the inferred type reaches Combobox's
 // unexported `Option`/`DefinedOption`, which declaration emit cannot name
@@ -30,47 +33,54 @@ const meta: Meta<typeof Select.Root> = {
 };
 
 type Story = StoryObj<typeof meta>;
+type StoryProps = Pick<RootProps, "disabled" | "size">;
 
 export default meta;
 
+const SingleSelectExample = ({ size, disabled }: StoryProps) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  return (
+    <Select.Root
+      placeholder="Select an option"
+      value={value}
+      onValueChange={setValue}
+      size={size}
+      disabled={disabled}
+    >
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+    </Select.Root>
+  );
+};
+
 export const SingleSelect: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState<string | undefined>(undefined);
-    return (
-      <Select.Root
-        placeholder="Select an option"
-        value={value}
-        onValueChange={setValue}
-        size={args.size}
-        disabled={args.disabled}
-      >
-        <Select.Option value="1">Option 1</Select.Option>
-        <Select.Option value="2">Option 2</Select.Option>
-      </Select.Root>
-    );
-  },
+  render: (args) => (
+    <SingleSelectExample size={args.size} disabled={args.disabled} />
+  ),
+};
+
+const MultiSelectExample = ({ size, disabled }: StoryProps) => {
+  const [value, setValue] = useState<Array<string>>([]);
+  return (
+    <Select.Root
+      placeholder="Select an option"
+      value={value}
+      onValueChange={setValue}
+      size={size}
+      disabled={disabled}
+    >
+      <Select.Option value="1">Option 1</Select.Option>
+      <Select.Option value="2">Option 2</Select.Option>
+      <Select.Option value="3">Option 3</Select.Option>
+      <Select.Option value="4">Option 4</Select.Option>
+    </Select.Root>
+  );
 };
 
 export const MultiSelect: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState<Array<string>>([]);
-    return (
-      <Select.Root
-        placeholder="Select an option"
-        value={value}
-        onValueChange={setValue}
-        size={args.size}
-        disabled={args.disabled}
-      >
-        <Select.Option value="1">Option 1</Select.Option>
-        <Select.Option value="2">Option 2</Select.Option>
-        <Select.Option value="3">Option 3</Select.Option>
-        <Select.Option value="4">Option 4</Select.Option>
-      </Select.Root>
-    );
-  },
+  render: (args) => (
+    <MultiSelectExample size={args.size} disabled={args.disabled} />
+  ),
 };
 
 // Generate years from 1960 to 2060
@@ -96,67 +106,79 @@ export const YearPicker: Story = {
   },
 };
 
+const YearPickerWithScrollToValueExample = ({ size, disabled }: StoryProps) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  return (
+    <Select.Root
+      placeholder="Select a year"
+      value={value}
+      onValueChange={setValue}
+      defaultScrollToValue="2025"
+      size={size}
+      disabled={disabled}
+      optionsProps={{ maxHeight: "64" }}
+    >
+      {years.map((year) => (
+        <Select.Option key={year} value={year}>
+          {year}
+        </Select.Option>
+      ))}
+    </Select.Root>
+  );
+};
+
 export const YearPickerWithScrollToValue: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState<string | undefined>(undefined);
-    return (
-      <Select.Root
-        placeholder="Select a year"
-        value={value}
-        onValueChange={setValue}
-        defaultScrollToValue="2025"
-        size={args.size}
-        disabled={args.disabled}
-        optionsProps={{ maxHeight: "64" }}
-      >
-        {years.map((year) => (
-          <Select.Option key={year} value={year}>
-            {year}
-          </Select.Option>
-        ))}
-      </Select.Root>
-    );
-  },
+  render: (args) => (
+    <YearPickerWithScrollToValueExample
+      size={args.size}
+      disabled={args.disabled}
+    />
+  ),
 };
 
 // `required` enforces native client-side validation: submitting with no
 // selection is blocked by the browser (Base UI renders a hidden required input).
-export const RequiredInForm: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [value, setValue] = React.useState<string | undefined>(undefined);
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [submitted, setSubmitted] = React.useState<string | null>(null);
-    return (
-      <form
-        onSubmit={(event) => {
-          event.preventDefault();
-          setSubmitted(value ?? "");
-        }}
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: 12,
-          alignItems: "flex-start",
-        }}
+const RequiredInFormExample = ({ size, disabled }: StoryProps) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  const [submitted, setSubmitted] = useState<string | null>(null);
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitted(value ?? "");
+  };
+
+  return (
+    <Stack
+      as="form"
+      direction="column"
+      gap="3"
+      align="flex-start"
+      onSubmit={handleSubmit}
+    >
+      <Select.Root
+        placeholder="Select a channel"
+        value={value}
+        onValueChange={setValue}
+        size={size}
+        disabled={disabled}
+        required
+        name="channel"
       >
-        <Select.Root
-          placeholder="Select a channel"
-          value={value}
-          onValueChange={setValue}
-          size={args.size}
-          disabled={args.disabled}
-          required
-          name="channel"
-        >
-          <Select.Option value="email">Email</Select.Option>
-          <Select.Option value="sms">SMS</Select.Option>
-          <Select.Option value="push">Push</Select.Option>
-        </Select.Root>
-        <button type="submit">Submit</button>
-        {submitted !== null && <span>Submitted: {submitted || "(empty)"}</span>}
-      </form>
-    );
-  },
+        <Select.Option value="email">Email</Select.Option>
+        <Select.Option value="sms">SMS</Select.Option>
+        <Select.Option value="push">Push</Select.Option>
+      </Select.Root>
+      <Button type="submit">Submit</Button>
+      {submitted !== null && (
+        <Text as="span" aria-live="polite">
+          Submitted: {submitted || "(empty)"}
+        </Text>
+      )}
+    </Stack>
+  );
+};
+
+export const RequiredInForm: Story = {
+  render: (args) => (
+    <RequiredInFormExample size={args.size} disabled={args.disabled} />
+  ),
 };

--- a/packages/select/src/Select/Select.test.tsx
+++ b/packages/select/src/Select/Select.test.tsx
@@ -371,4 +371,28 @@ describe("Select", () => {
       expect(queryPortalElement("[data-tgph-combobox-empty]")).not.toBeNull(),
     );
   });
+
+  it("forwards `required` to enforce form validation", () => {
+    const RequiredForm = ({ value }: { value?: string }) => (
+      <form data-testid="form">
+        <Select.Root
+          value={value}
+          onValueChange={() => {}}
+          required
+          name="channel"
+        >
+          {renderSelectOptions()}
+        </Select.Root>
+      </form>
+    );
+
+    const { getByTestId, rerender } = render(<RequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // `required` reaches Base UI's hidden form input via the Combobox passthrough.
+    expect(form.checkValidity()).toBe(false);
+
+    rerender(<RequiredForm value="email" />);
+    expect(form.checkValidity()).toBe(true);
+  });
 });

--- a/packages/select/src/Select/Select.test.tsx
+++ b/packages/select/src/Select/Select.test.tsx
@@ -396,4 +396,28 @@ describe("Select", () => {
       expect(queryPortalElement("[data-tgph-combobox-empty]")).not.toBeNull(),
     );
   });
+
+  it("forwards `required` to enforce form validation", () => {
+    const RequiredForm = ({ value }: { value?: string }) => (
+      <form data-testid="form">
+        <Select.Root
+          value={value}
+          onValueChange={() => {}}
+          required
+          name="channel"
+        >
+          {renderSelectOptions()}
+        </Select.Root>
+      </form>
+    );
+
+    const { getByTestId, rerender } = render(<RequiredForm />);
+    const form = getByTestId("form") as HTMLFormElement;
+
+    // `required` reaches Base UI's hidden form input via the Combobox passthrough.
+    expect(form.checkValidity()).toBe(false);
+
+    rerender(<RequiredForm value="email" />);
+    expect(form.checkValidity()).toBe(true);
+  });
 });


### PR DESCRIPTION
### What changed?

- add `required` and `name` to `Combobox.Root` and forward them to Base UI's hidden form input
- expose the same form integration through `Select.Root`
- make an empty required single- or multi-select invalid until it has a selection
- submit the selected value under the supplied field name
- document both components and cover native validity and submission with tests and a Select story

### Why?

The Chakra-to-Telegraph migration replaced native required selects in provider settings with menu-backed controls that had no form field. The Base UI combobox engine now supplies that field, so these props restore browser validation and form submission without a separate hidden-input implementation.

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [x] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [ ] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [x] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?

### Screenshots or Loom

![Required Select native form validation demo](https://gist.githubusercontent.com/kylemcd/c23e7189e8f95283f4a1f1c2da218f34/raw/80ee67c4f96a839cc0142a320e382d6856a85608/pr-913-required-form-validation.gif)
