### PR TITLE
docs(menu): deprecate the typeable-trigger recipe, keep the focus-bounce (KNO-14119)

### DIFF
--- a/.changeset/menu-button-without-root.md
+++ b/.changeset/menu-button-without-root.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/menu": patch
+---
+
+Allow `Menu.Button` to render as a standalone styled action when no `Menu.Root` is present, preserving compatibility for buttons placed inside combobox popups.

--- a/.changeset/menu-button-without-root.md
+++ b/.changeset/menu-button-without-root.md
@@ -2,4 +2,4 @@
 "@telegraph/menu": patch
 ---
 
-Allow `Menu.Button` to render as a standalone styled action when no `Menu.Root` is present, preserving compatibility for buttons placed inside combobox popups.
+Keep `Menu.Button` rendering as a standalone styled action when no `Menu.Root` is present as a deprecated compatibility fallback. This fallback will be removed in a future major release. Migrate popup action rows to `Combobox.Option` with `onSelect` or to plain buttons.

--- a/.changeset/menu-deprecate-typeable-trigger.md
+++ b/.changeset/menu-deprecate-typeable-trigger.md
@@ -1,0 +1,7 @@
+---
+"@telegraph/menu": patch
+---
+
+Deprecate the typeable-trigger recipe — composing a typeable input inside `Menu.Trigger` — in favor of the `@telegraph/combobox` input-as-trigger arrangement (`Combobox.Input`). This is a documentation-only change: the focus-bounce that keeps focus in place when a consumer prevents `onOpenAutoFocus` is **retained unchanged** as permanent Radix-compat behavior.
+
+A typeable menu trigger does not follow the WAI-ARIA menu-button pattern, and Base UI declined an `initialFocus` opt-out for menus, so new UI that needs a typeable trigger should use the combobox arrangement. The `Menu.Trigger` typeable composition (and its `TypeableTrigger` story) remain only as a reference for the retained focus-bounce.

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -140,6 +140,11 @@ Inherits all Button props for additional styling.
 If `disabled` coerces the item to `<button>`, native semantics take precedence
 over `nativeButton={false}` so Base UI matches the rendered element.
 
+For backwards compatibility, `Menu.Button` can render without a `Menu.Root` as
+a styled action. This standalone use is deprecated: it is not part of a menu's
+arrow-key navigation, including when placed inside a combobox popup. Prefer a
+component native to the surrounding interaction for new code.
+
 ### `<Menu.Sub>`
 
 Groups a `Menu.SubTrigger` with its `Menu.SubContent` to create a nested submenu

--- a/packages/menu/src/Menu/Menu.browser.test.tsx
+++ b/packages/menu/src/Menu/Menu.browser.test.tsx
@@ -6,13 +6,15 @@ import { page, userEvent } from "vitest/browser";
 import { Menu } from "./Menu";
 import { TypeableTriggerExample } from "./Menu.fixtures";
 
-// Reproduces KNO-14086 end-to-end: a typeable input composed inside
-// Menu.Trigger that prevents the legacy openAutoFocus. Base UI defers its
-// initial popup focus to a real animation frame, so this only reproduces in a
-// headed browser with real vsync — every headless environment (jsdom,
-// happy-dom, headless Chromium) fires that focus eagerly and hides the race.
-// The old setTimeout(0) restore lost the race here (focus landed in the popup);
-// the focusin bounce wins.
+// Regression coverage for the focus-bounce on a prevented `onOpenAutoFocus`
+// (KNO-14086), exercised through the legacy typeable-trigger composition — a
+// deprecated recipe kept only for this repro; new UI should use the
+// `@telegraph/combobox` input-as-trigger arrangement. Base UI defers its initial
+// popup focus to a real animation frame, so this only reproduces in a headed
+// browser with real vsync — every headless environment (jsdom, happy-dom,
+// headless Chromium) fires that focus eagerly and hides the race. The old
+// setTimeout(0) restore lost the race here (focus landed in the popup); the
+// focusin bounce wins.
 const TypeableTriggerMenu = () => {
   const [open, setOpen] = useState(false);
 
@@ -59,7 +61,7 @@ const waitFrames = (count: number) =>
     requestAnimationFrame(step);
   });
 
-describe("Menu typeable trigger (real browser)", () => {
+describe("Menu focus-bounce on prevented onOpenAutoFocus (real browser)", () => {
   it("keeps focus on the trigger input across Base UI's initial focus", async () => {
     render(<TypeableTriggerMenu />);
     const inputLocator = page.getByRole("textbox", { name: "Filter" });
@@ -87,9 +89,10 @@ describe("Menu typeable trigger (real browser)", () => {
   });
 });
 
-// Drives the exact composition the Storybook `TypeableTrigger` story ships, the
-// way a user would (real click + typing), so a broken demo can't slip through.
-describe("Menu typeable trigger story (real browser)", () => {
+// Drives the exact composition the Storybook `TypeableTrigger` story ships (now
+// the deprecated focus-bounce reference), the way a user would (real click +
+// typing), so a broken demo can't slip through.
+describe("Menu focus-bounce story fixture (real browser)", () => {
   it("opens on click and keeps focus in the input while typing to filter", async () => {
     render(<TypeableTriggerExample />);
     const inputLocator = page.getByRole("textbox", {

--- a/packages/menu/src/Menu/Menu.browser.test.tsx
+++ b/packages/menu/src/Menu/Menu.browser.test.tsx
@@ -6,13 +6,15 @@ import { page, userEvent } from "vitest/browser";
 import { Menu } from "./Menu";
 import { TypeableTriggerExample } from "./Menu.fixtures";
 
-// Reproduces KNO-14086 end-to-end: a typeable input composed inside
-// Menu.Trigger that prevents the legacy openAutoFocus. Base UI defers its
-// initial popup focus to a real animation frame, so this only reproduces in a
-// headed browser with real vsync — every headless environment (jsdom,
-// happy-dom, headless Chromium) fires that focus eagerly and hides the race.
-// The old setTimeout(0) restore lost the race here (focus landed in the popup);
-// the focusin bounce wins.
+// Regression coverage for the focus-bounce on a prevented `onOpenAutoFocus`
+// (KNO-14086), exercised through the legacy typeable-trigger composition — a
+// deprecated recipe kept only for this repro; new UI should use the
+// `@telegraph/combobox` input-as-trigger arrangement. Base UI defers its initial
+// popup focus to a real animation frame, so this only reproduces in a headed
+// browser with real vsync — every headless environment (jsdom, happy-dom,
+// headless Chromium) fires that focus eagerly and hides the race. The old
+// setTimeout(0) restore lost the race here (focus landed in the popup); the
+// focusin bounce wins.
 const TypeableTriggerMenu = () => {
   const [open, setOpen] = useState(false);
 
@@ -45,7 +47,7 @@ const waitFrames = (count: number) =>
     requestAnimationFrame(step);
   });
 
-describe("Menu typeable trigger (real browser)", () => {
+describe("Menu focus-bounce on prevented onOpenAutoFocus (real browser)", () => {
   it("keeps focus on the trigger input across Base UI's initial focus", async () => {
     render(<TypeableTriggerMenu />);
     const inputLocator = page.getByRole("textbox", { name: "Filter" });
@@ -73,9 +75,10 @@ describe("Menu typeable trigger (real browser)", () => {
   });
 });
 
-// Drives the exact composition the Storybook `TypeableTrigger` story ships, the
-// way a user would (real click + typing), so a broken demo can't slip through.
-describe("Menu typeable trigger story (real browser)", () => {
+// Drives the exact composition the Storybook `TypeableTrigger` story ships (now
+// the deprecated focus-bounce reference), the way a user would (real click +
+// typing), so a broken demo can't slip through.
+describe("Menu focus-bounce story fixture (real browser)", () => {
   it("opens on click and keeps focus in the input while typing to filter", async () => {
     render(<TypeableTriggerExample />);
     const inputLocator = page.getByRole("textbox", {

--- a/packages/menu/src/Menu/Menu.fixtures.tsx
+++ b/packages/menu/src/Menu/Menu.fixtures.tsx
@@ -13,15 +13,24 @@ const PROPERTIES = [
 ];
 
 /**
- * A typeable input composed inside `Menu.Trigger`, as PropertySelectorField and
- * the block editor suggestion menus do. Shared between the Storybook story and
- * the headed browser test so both exercise the exact same composition.
+ * @deprecated Legacy typeable-trigger composition, kept only as regression
+ * coverage for the focus-bounce — not a supported pattern for new UI. Composing
+ * a typeable input inside `Menu.Trigger` does not follow the WAI-ARIA
+ * menu-button pattern; new UI that needs a typeable trigger should use
+ * `@telegraph/combobox`'s input-as-trigger arrangement (Storybook:
+ * `components-combobox--input-as-trigger`). This fixture exists purely to
+ * exercise the prevented-`openAutoFocus` focus-bounce regression path, and is
+ * shared between the Storybook story and the headed browser test so both drive
+ * the exact same composition.
  *
  * The input stays a real text field: `nativeButton={false}` + a wrapping `div`
  * put Base UI's button semantics on the div, not the input, and passing
  * `onClick` to the trigger suppresses Base UI's own open-on-press so it doesn't
  * fight the input's focus/typing. Opening is driven by focus/typing; the popup
- * prevents the legacy `openAutoFocus` so keystrokes keep feeding the input.
+ * prevents the legacy `openAutoFocus` so keystrokes keep feeding the input. On
+ * `@base-ui/react` >= 1.6.0 the open menu's trigger typeahead consumes printable
+ * keys, so the `onKeyDown` below must stop propagation for everything except
+ * navigation/selection keys.
  */
 export const TypeableTriggerExample = (
   args: Partial<TgphComponentProps<typeof Menu.Root>> = {},

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -155,5 +155,13 @@ export const WithSubmenu: Story = {
 // while ArrowDown still moves into the list.
 export const TypeableTrigger: Story = {
   name: "Typeable Trigger (deprecated)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Deprecated.** A typeable input inside `Menu.Trigger` does not follow the WAI-ARIA menu-button pattern. Use [Combobox's Input As Trigger story](?path=/story/components-combobox--input-as-trigger) for new UI. This legacy example remains only as a reference for the retained focus-bounce behavior.",
+      },
+    },
+  },
   render: (args) => <TypeableTriggerExample {...args} />,
 };

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -146,9 +146,14 @@ export const WithSubmenu: Story = {
   },
 };
 
-// A typeable input composed inside the trigger (PropertySelectorField, block
-// editor suggestion menus). Click or type to open; keystrokes keep landing in
-// the input — not the menu's typeahead — and ArrowDown moves into the list.
+// @deprecated Composing a typeable input inside `Menu.Trigger` is a legacy
+// pattern, retained here only as a reference for the retained focus-bounce
+// behavior. It does not follow the WAI-ARIA menu-button pattern, so new UI that
+// needs a typeable trigger should use the `@telegraph/combobox` input-as-trigger
+// arrangement instead (see the "Components/Combobox › Input As Trigger" story).
+// This demo keeps focus in the input across open (a prevented `onOpenAutoFocus`)
+// while ArrowDown still moves into the list.
 export const TypeableTrigger: Story = {
+  name: "Typeable Trigger (deprecated)",
   render: (args) => <TypeableTriggerExample {...args} />,
 };

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -125,6 +125,33 @@ describe("Menu", () => {
     }
   });
 
+  it("renders a clickable styled button without Menu.Root", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    render(
+      <>
+        <Menu.Button
+          data-testid="standalone-menu-button"
+          data-tgph-combobox-option
+          onClick={onClick}
+        >
+          Switch account
+        </Menu.Button>
+        <Menu.Divider data-testid="standalone-menu-divider" />
+      </>,
+    );
+
+    const button = screen.getByTestId("standalone-menu-button");
+    expect(button).toHaveAttribute("data-tgph-menu-button");
+    expect(button).toHaveAttribute("data-tgph-combobox-option");
+    expect(screen.getByTestId("standalone-menu-divider")).toBeInTheDocument();
+
+    await user.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
   describe("as a link", () => {
     it("keeps disabled item coercion native over an explicit override", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1111,7 +1111,7 @@ describe("Menu", () => {
     expect(submenu).toHaveAttribute("data-align", "start");
   });
 
-  describe("typeable trigger open autofocus", () => {
+  describe("focus-bounce on prevented onOpenAutoFocus (Radix-compat)", () => {
     // Long enough to clear a couple of jsdom animation frames (~16ms each).
     const PENDING_FRAME_DRAIN_MS = 32;
 
@@ -1126,9 +1126,12 @@ describe("Menu", () => {
       });
     });
 
-    // Reproduces the surfaces (PropertySelectorField, block editor suggestion
-    // menus) that compose a typeable input inside Menu.Trigger and prevent the
-    // legacy openAutoFocus so keystrokes keep feeding the input, not the menu.
+    // Behavior contract under test: when a consumer prevents the legacy
+    // `openAutoFocus`, focus bounces back once (staying where it was) and later
+    // intentional navigation into the menu is still allowed. Exercised through
+    // the legacy typeable-trigger composition (a deprecated recipe — new UI
+    // should use the `@telegraph/combobox` input-as-trigger arrangement) purely
+    // because it is the composition that first surfaced the race (KNO-14086).
     const TypeableTriggerMenu = ({
       onOpenAutoFocus,
       preventOpenAutoFocus = true,

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -1223,7 +1223,7 @@ describe("Menu", () => {
     expect(submenu).toHaveAttribute("data-align", "start");
   });
 
-  describe("typeable trigger open autofocus", () => {
+  describe("focus-bounce on prevented onOpenAutoFocus (Radix-compat)", () => {
     // Long enough to clear a couple of jsdom animation frames (~16ms each).
     const PENDING_FRAME_DRAIN_MS = 32;
 
@@ -1238,9 +1238,12 @@ describe("Menu", () => {
       });
     });
 
-    // Reproduces the surfaces (PropertySelectorField, block editor suggestion
-    // menus) that compose a typeable input inside Menu.Trigger and prevent the
-    // legacy openAutoFocus so keystrokes keep feeding the input, not the menu.
+    // Behavior contract under test: when a consumer prevents the legacy
+    // `openAutoFocus`, focus bounces back once (staying where it was) and later
+    // intentional navigation into the menu is still allowed. Exercised through
+    // the legacy typeable-trigger composition (a deprecated recipe — new UI
+    // should use the `@telegraph/combobox` input-as-trigger arrangement) purely
+    // because it is the composition that first surfaced the race (KNO-14086).
     const TypeableTriggerMenu = ({
       onOpenAutoFocus,
       preventOpenAutoFocus = true,

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -714,6 +714,14 @@ export type ButtonProps<T extends TgphElement = "button"> = Partial<
     tgphRef?: Ref<HTMLElement>;
   };
 
+/**
+ * Renders a Base UI menu item when nested in `Menu.Root`.
+ *
+ * Rendering `Menu.Button` without `Menu.Root` is supported for backwards
+ * compatibility, but deprecated. In that arrangement it is only a styled
+ * action, so menu arrow-key navigation (including from a combobox popup) will
+ * not reach it.
+ */
 const Button = <T extends TgphElement = "button">({
   as,
   closeOnClick,
@@ -733,6 +741,7 @@ const Button = <T extends TgphElement = "button">({
   nativeButton,
   ...props
 }: ButtonProps<T>) => {
+  const compatibilityContext = useContext(MenuCompatibilityContext);
   const combinedLeadingIcon = leadingIcon || icon;
   const itemRef = useRef<HTMLElement>(null);
   const menuItemProps = props as MenuItemProps<T>;
@@ -884,37 +893,43 @@ const Button = <T extends TgphElement = "button">({
     preventBaseUIHandlerWhenDefaultPrevented(event);
   };
 
+  const renderedItem = (
+    <MenuItem
+      as={as}
+      {...menuItemProps}
+      onClick={handleClick as MenuItemProps<T>["onClick"]}
+      // `MenuItemProps<"button">`: `onKeyDown` reaches MenuItem only through
+      // the element passthrough, which is a deferred conditional while `T`
+      // is unresolved and therefore not indexable.
+      onKeyDown={handleKeyDown as MenuItemProps<"button">["onKeyDown"]}
+      selected={selected}
+      leadingIcon={combinedLeadingIcon}
+      trailingIcon={trailingIcon}
+      leadingComponent={leadingComponent}
+      trailingComponent={trailingComponent}
+      data-tgph-menu-button
+      disabled={disabled}
+      mx={mx}
+      style={{
+        outline: "none",
+        flexShrink: 0,
+        ...menuItemProps.style,
+      }}
+      tgphRef={composedTgphRef as MenuItemProps<T>["tgphRef"]}
+    />
+  );
+
+  if (!compatibilityContext) {
+    return renderedItem;
+  }
+
   return (
     <BaseMenu.Item
       closeOnClick={closeOnClick}
       disabled={disabled}
       label={label}
       nativeButton={isNativeButton}
-      render={createTgphBaseUIRender(
-        <MenuItem
-          as={as}
-          {...menuItemProps}
-          onClick={handleClick as MenuItemProps<T>["onClick"]}
-          // `MenuItemProps<"button">`: `onKeyDown` reaches MenuItem only through
-          // the element passthrough, which is a deferred conditional while `T`
-          // is unresolved and therefore not indexable.
-          onKeyDown={handleKeyDown as MenuItemProps<"button">["onKeyDown"]}
-          selected={selected}
-          leadingIcon={combinedLeadingIcon}
-          trailingIcon={trailingIcon}
-          leadingComponent={leadingComponent}
-          trailingComponent={trailingComponent}
-          data-tgph-menu-button
-          disabled={disabled}
-          mx={mx}
-          style={{
-            outline: "none",
-            flexShrink: 0,
-            ...menuItemProps.style,
-          }}
-          tgphRef={composedTgphRef as MenuItemProps<T>["tgphRef"]}
-        />,
-      )}
+      render={createTgphBaseUIRender(renderedItem)}
     />
   );
 };

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -349,15 +349,21 @@ const MenuPopupContent = ({
       return;
     }
 
-    // Base UI's MenuPopup hardcodes initial focus into the popup and exposes no
-    // way to opt out (only Popover/Dialog surface `initialFocus`). Its focus
-    // manager queues that move to the next animation frame, so the previous
-    // setTimeout(0) restore fired first and then lost the race, letting the
-    // popup steal focus from a typeable trigger input. Instead, bounce focus
-    // back the instant Base UI's initial focus lands: focusing an element inside
-    // the popup dispatches `focusin` here synchronously during Base UI's own
-    // `.focus()` call, so re-asserting the intended target from that event wins
-    // with no dependence on timer ordering.
+    // Permanent Radix-compat behavior. This implements the prevented-
+    // `onOpenAutoFocus` contract consumers carried over from Radix: when the
+    // handler calls `preventDefault()`, focus stays where it was instead of
+    // moving into the popup. Base UI's MenuPopup hardcodes initial focus into the
+    // popup and does not expose an `initialFocus` opt-out for menus — upstream
+    // declined to add one because a typeable menu trigger is not the endorsed
+    // pattern (the Autocomplete/Combobox engine is). New UI wanting a typeable
+    // trigger should use `@telegraph/combobox`'s input-as-trigger arrangement;
+    // this bounce is not a temporary shim, it stays as the Radix-compat contract.
+    // Base UI's focus manager queues its move to the next animation frame, which
+    // a `setTimeout(0)` restore loses the race to. Instead, bounce focus back the
+    // instant Base UI's initial focus lands: focusing an element inside the popup
+    // dispatches `focusin` here synchronously during Base UI's own `.focus()`
+    // call, so re-asserting the intended target from that event wins with no
+    // dependence on timer ordering.
     const abortController = new AbortController();
     openAutoFocusAbortRef.current = abortController;
     const { signal } = abortController;

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -894,34 +894,32 @@ const Button = <T extends TgphElement = "button">({
     preventBaseUIHandlerWhenDefaultPrevented(event);
   };
 
-  const renderedItem = (
-    <MenuItem
-      as={as}
-      {...menuItemProps}
-      onClick={handleClick as MenuItemProps<T>["onClick"]}
-      // `MenuItemProps<"button">`: `onKeyDown` reaches MenuItem only through
-      // the element passthrough, which is a deferred conditional while `T`
-      // is unresolved and therefore not indexable.
-      onKeyDown={handleKeyDown as MenuItemProps<"button">["onKeyDown"]}
-      selected={selected}
-      leadingIcon={combinedLeadingIcon}
-      trailingIcon={trailingIcon}
-      leadingComponent={leadingComponent}
-      trailingComponent={trailingComponent}
-      data-tgph-menu-button
-      disabled={disabled}
-      mx={mx}
-      style={{
-        outline: "none",
-        flexShrink: 0,
-        ...menuItemProps.style,
-      }}
-      tgphRef={composedTgphRef as MenuItemProps<T>["tgphRef"]}
-    />
-  );
+  // `MenuItemProps<"button">`: `onKeyDown` reaches MenuItem only through the
+  // element passthrough, which is a deferred conditional while `T` is
+  // unresolved and therefore not indexable.
+  const resolvedMenuItemProps = {
+    as,
+    ...menuItemProps,
+    onClick: handleClick as MenuItemProps<T>["onClick"],
+    onKeyDown: handleKeyDown as MenuItemProps<"button">["onKeyDown"],
+    selected,
+    leadingIcon: combinedLeadingIcon,
+    trailingIcon,
+    leadingComponent,
+    trailingComponent,
+    "data-tgph-menu-button": true,
+    disabled,
+    mx,
+    style: {
+      outline: "none",
+      flexShrink: 0,
+      ...menuItemProps.style,
+    },
+    tgphRef: composedTgphRef as MenuItemProps<T>["tgphRef"],
+  } satisfies MenuItemProps<T>;
 
   if (!compatibilityContext) {
-    return renderedItem;
+    return <MenuItem {...resolvedMenuItemProps} />;
   }
 
   return (
@@ -930,7 +928,7 @@ const Button = <T extends TgphElement = "button">({
       disabled={disabled}
       label={label}
       nativeButton={isNativeButton}
-      render={createTgphBaseUIRender(renderedItem)}
+      render={createTgphBaseUIRender(<MenuItem {...resolvedMenuItemProps} />)}
     />
   );
 };

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -374,15 +374,21 @@ const MenuPopupContent = ({
       return;
     }
 
-    // Base UI's MenuPopup hardcodes initial focus into the popup and exposes no
-    // way to opt out (only Popover/Dialog surface `initialFocus`). Its focus
-    // manager queues that move to the next animation frame, so the previous
-    // setTimeout(0) restore fired first and then lost the race, letting the
-    // popup steal focus from a typeable trigger input. Instead, bounce focus
-    // back the instant Base UI's initial focus lands: focusing an element inside
-    // the popup dispatches `focusin` here synchronously during Base UI's own
-    // `.focus()` call, so re-asserting the intended target from that event wins
-    // with no dependence on timer ordering.
+    // Permanent Radix-compat behavior. This implements the prevented-
+    // `onOpenAutoFocus` contract consumers carried over from Radix: when the
+    // handler calls `preventDefault()`, focus stays where it was instead of
+    // moving into the popup. Base UI's MenuPopup hardcodes initial focus into the
+    // popup and does not expose an `initialFocus` opt-out for menus — upstream
+    // declined to add one because a typeable menu trigger is not the endorsed
+    // pattern (the Autocomplete/Combobox engine is). New UI wanting a typeable
+    // trigger should use `@telegraph/combobox`'s input-as-trigger arrangement;
+    // this bounce is not a temporary shim, it stays as the Radix-compat contract.
+    // Base UI's focus manager queues its move to the next animation frame, which
+    // a `setTimeout(0)` restore loses the race to. Instead, bounce focus back the
+    // instant Base UI's initial focus lands: focusing an element inside the popup
+    // dispatches `focusin` here synchronously during Base UI's own `.focus()`
+    // call, so re-asserting the intended target from that event wins with no
+    // dependence on timer ordering.
     const abortController = new AbortController();
     openAutoFocusAbortRef.current = abortController;
     const { signal } = abortController;

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -718,9 +718,10 @@ export type ButtonProps<T extends TgphElement = "button"> = Partial<
  * Renders a Base UI menu item when nested in `Menu.Root`.
  *
  * Rendering `Menu.Button` without `Menu.Root` is supported for backwards
- * compatibility, but deprecated. In that arrangement it is only a styled
- * action, so menu arrow-key navigation (including from a combobox popup) will
- * not reach it.
+ * compatibility, but deprecated and scheduled for removal in a future major
+ * release. In that arrangement it is only a styled action, so menu arrow-key
+ * navigation (including from a combobox popup) will not reach it. Migrate popup
+ * action rows to `Combobox.Option` with `onSelect` or to plain buttons.
  */
 const Button = <T extends TgphElement = "button">({
   as,


### PR DESCRIPTION
### What changed?

- keep rootless `Menu.Button` components working as styled actions
- retain Base UI menu behavior for buttons inside `Menu.Root`
- mark the rootless fallback as deprecated and scheduled for removal in a future major release
- direct combobox popup actions to `Combobox.Option` with `onSelect` or to plain buttons
- deprecate the typeable-input-inside-`Menu.Trigger` recipe and direct new interfaces to `Combobox.Input`
- retain prevented-`onOpenAutoFocus` focus restoration as the permanent Radix compatibility contract
- update the README, stories, tests, JSDoc, and patch changesets for both compatibility paths

### Why?

Some dashboard combobox popups still render `Menu.Button` and `Menu.Divider`, but the new combobox engine no longer provides an implicit `Menu.Root`. The fallback prevents those actions from crashing while consumers migrate. It does not add menu arrow-key navigation outside a root.

### Screenshots or Loom

![Rootless popup action before and after](https://gist.githubusercontent.com/kylemcd/c23e7189e8f95283f4a1f1c2da218f34/raw/0e38b804355104f9536675b9f9fe18c3a62e3113/pr-917-rootless-menu-button-before-after.gif)

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [x] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [ ] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [x] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?
