### PR TITLE
fix(toggle): keep the track color, dimmed, when a Toggle is disabled

### DIFF
--- a/.changeset/wild-hounds-taste.md
+++ b/.changeset/wild-hounds-taste.md
@@ -1,0 +1,12 @@
+---
+"@telegraph/toggle": patch
+---
+
+fix(toggle): keep the track color, dimmed, when a Toggle is disabled
+
+A disabled Toggle inherited Button's blanket disabled background, so on and off
+rendered the identical `--tgph-gray-3` and thumb position was the only cue. A
+disabled track now keeps its own color — the `color` token when on, `--tgph-gray-7`
+when off — at 50% opacity, so a locked toggle still reads as on or off. This
+changes the appearance of the disabled off state as well, from a flat
+`--tgph-gray-3` to the dimmed unchecked gray.

--- a/packages/toggle/package.json
+++ b/packages/toggle/package.json
@@ -45,6 +45,7 @@
     "@knocklabs/typescript-config": "^0.0.2",
     "@telegraph/postcss-config": "workspace:^",
     "@telegraph/prettier-config": "workspace:^",
+    "@telegraph/tokens": "workspace:^",
     "@telegraph/vite-config": "workspace:^",
     "@types/react": "^19.2.17",
     "eslint": "^10.4.0",

--- a/packages/toggle/src/Toggle/Toggle.browser.test.css
+++ b/packages/toggle/src/Toggle/Toggle.browser.test.css
@@ -1,0 +1,19 @@
+/* Stylesheets for Toggle.browser.test.tsx, in a CSS file because the load order
+   below is itself part of the assertion and prettier sorts side-effect imports
+   in .tsx alphabetically.
+
+   Toggle's sheet is loaded FIRST so it loses every source-order tie. Its
+   disabled-track rule and Button's blanket `--tgph-gray-3` rule have identical
+   specificity (0,3,0), so from here only `!important` can win — which is what
+   production needs, where each package ships its own stylesheet and the
+   consuming app picks the order.
+
+   Toggle's rules come from src (the file under test); its dependencies come from
+   their built CSS, which is both what a consumer actually loads and the only
+   form in which the `@telegraph interactive(...)` at-rule has been expanded into
+   the real `.tgph-box--interactive:disabled` rule. That means these tests need
+   `yarn build:packages` first — CI builds before the browser job. */
+@import "./Toggle.styles.css";
+@import "@telegraph/layout/default.css";
+@import "@telegraph/button/default.css";
+@import "@telegraph/tokens/default";

--- a/packages/toggle/src/Toggle/Toggle.browser.test.tsx
+++ b/packages/toggle/src/Toggle/Toggle.browser.test.tsx
@@ -1,0 +1,106 @@
+// Real cascade only. Which color a disabled track ends up with is decided by
+// three stylesheets competing: Box declares `background-color:
+// var(--background-color)`, Button flattens every disabled track to
+// `--tgph-gray-3` with an equally specific rule, and Toggle wins it back with
+// `!important`. jsdom does not resolve `var()` at all, so it cannot say which
+// declaration won — only a real browser can. Toggle.browser.test.css loads the
+// competing sheets, in the order that makes the `!important` load-bearing.
+import { describe, expect, it } from "vitest";
+import { render } from "vitest-browser-react";
+import { page } from "vitest/browser";
+
+import { Toggle } from "./Toggle";
+import "./Toggle.browser.test.css";
+
+// From @telegraph/tokens, light appearance.
+const BLUE_9 = "rgb(74, 130, 255)";
+const GRAY_7 = "rgb(203, 207, 213)";
+const GRAY_3 = "rgb(239, 240, 243)";
+
+// The track is a Button.Root with no accessible identity of its own — it is
+// labelled by the same text as the checkbox it controls, so `getByLabelText`
+// would match both and trip the strict-locator rule. Reach it through the
+// toggle root instead.
+const trackOf = async (testId: string) => {
+  const root = page.getByTestId(testId);
+  await expect.element(root).toBeInTheDocument();
+  const track = (root.element() as HTMLElement).querySelector(
+    "[data-tgph-toggle-switch]",
+  );
+  return getComputedStyle(track as HTMLElement);
+};
+
+describe("Toggle disabled track (real browser)", () => {
+  it("distinguishes a disabled toggle that is on from one that is off", async () => {
+    await render(
+      <>
+        <Toggle.Default
+          data-testid="on-locked"
+          label="On, locked"
+          defaultValue
+          disabled
+        />
+        <Toggle.Default
+          data-testid="off-locked"
+          label="Off, locked"
+          defaultValue={false}
+          disabled
+        />
+      </>,
+    );
+
+    const on = await trackOf("on-locked");
+    const off = await trackOf("off-locked");
+
+    // The regression this file exists for: Button's blanket disabled rule
+    // painted both tracks `--tgph-gray-3`, leaving thumb position as the only
+    // cue that the toggle was on.
+    expect(on.backgroundColor).not.toBe(off.backgroundColor);
+    expect(on.backgroundColor).not.toBe(GRAY_3);
+    expect(off.backgroundColor).not.toBe(GRAY_3);
+
+    // On keeps its color token, off keeps the unchecked gray, and both read as
+    // locked because they are dimmed.
+    expect(on.backgroundColor).toBe(BLUE_9);
+    expect(off.backgroundColor).toBe(GRAY_7);
+    expect(on.opacity).toBe("0.5");
+    expect(off.opacity).toBe("0.5");
+  });
+
+  it("leaves an enabled toggle at full strength", async () => {
+    await render(
+      <>
+        <Toggle.Default data-testid="on" label="On" defaultValue />
+        <Toggle.Default data-testid="off" label="Off" defaultValue={false} />
+      </>,
+    );
+
+    const on = await trackOf("on");
+    const off = await trackOf("off");
+
+    // Same colors as the disabled pair above — dimming is the only difference,
+    // so a disabled toggle reads as "on, but locked" rather than as a new state.
+    expect(on.backgroundColor).toBe(BLUE_9);
+    expect(off.backgroundColor).toBe(GRAY_7);
+    expect(on.opacity).toBe("1");
+    expect(off.opacity).toBe("1");
+  });
+
+  it("dims the color the consumer asked for, not just blue", async () => {
+    await render(
+      <Toggle.Default
+        data-testid="green-locked"
+        label="On, locked"
+        color="green"
+        defaultValue
+        disabled
+      />,
+    );
+
+    // --tgph-green-9. The fix reuses whatever token Button already resolved, so
+    // every color survives being disabled, not just the default.
+    expect((await trackOf("green-locked")).backgroundColor).toBe(
+      "rgb(0, 170, 114)",
+    );
+  });
+});

--- a/packages/toggle/src/Toggle/Toggle.stories.tsx
+++ b/packages/toggle/src/Toggle/Toggle.stories.tsx
@@ -79,3 +79,29 @@ export const ToggleWithLabelAndIndicator: Story = {
     w: "80",
   },
 };
+
+// A locked toggle still has to say which way it is locked, so these two must
+// not render the same track.
+export const DisabledOn: Story = {
+  args: {
+    label: "Enable notifications",
+    indicator: true,
+    color: "blue",
+    defaultValue: true,
+    size: "1",
+    disabled: true,
+    w: "80",
+  },
+};
+
+export const DisabledOff: Story = {
+  args: {
+    label: "Enable notifications",
+    indicator: true,
+    color: "blue",
+    defaultValue: false,
+    size: "1",
+    disabled: true,
+    w: "80",
+  },
+};

--- a/packages/toggle/src/Toggle/Toggle.styles.css
+++ b/packages/toggle/src/Toggle/Toggle.styles.css
@@ -34,8 +34,19 @@
 }
 
 /* Override the background color of the gray button to match the design spec. */
-[data-tgph-toggle-switch][data-tgph-toggle-checked="false"]:not(
-    [data-tgph-button-state="disabled"]
-  ) {
+[data-tgph-toggle-switch][data-tgph-toggle-checked="false"] {
   background-color: var(--tgph-gray-7) !important;
+}
+
+/* Button flattens every disabled track to `--tgph-gray-3`, which renders a
+   locked toggle identically whether it is on or off — thumb position and a gray
+   icon become the only cue. Keep the track's own color token (Button still sets
+   `--background-color` to it when disabled) and dim the switch instead, so a
+   locked toggle still reads as "on, but locked". */
+[data-tgph-toggle-switch][data-tgph-toggle-checked="true"][data-tgph-button-state="disabled"] {
+  background-color: var(--background-color) !important;
+}
+
+[data-tgph-toggle-switch][data-tgph-button-state="disabled"] {
+  opacity: 0.5;
 }

--- a/packages/toggle/tsconfig.json
+++ b/packages/toggle/tsconfig.json
@@ -19,6 +19,8 @@
     "src/**/*"
   ],
   "exclude": [
+    "src/**/*.test.tsx",
+    "src/**/*.test.ts",
     "dist",
     "node_modules"
   ]

--- a/packages/toggle/vitest.config.mts
+++ b/packages/toggle/vitest.config.mts
@@ -1,10 +1,13 @@
-import { defineProject } from "vitest/config";
+import { defineProject, mergeConfig } from "vitest/config";
 
-export default defineProject({
-  test: {
-    name: "toggle",
-    globals: true,
-    setupFiles: ["../../vitest/setup"],
-    environment: "jsdom",
-  },
-});
+import { sharedConfig } from "../../vitest/config.mts";
+
+export default mergeConfig(
+  { ...sharedConfig },
+  defineProject({
+    test: {
+      name: "toggle",
+      environment: "jsdom",
+    },
+  }),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4101,6 +4101,7 @@ __metadata:
     "@telegraph/postcss-config": "workspace:^"
     "@telegraph/prettier-config": "workspace:^"
     "@telegraph/tag": "workspace:^"
+    "@telegraph/tokens": "workspace:^"
     "@telegraph/typography": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^19.2.17"


### PR DESCRIPTION
## What Changed?

- disabled track keeps its own color at 50% opacity — the `color` token when on, `--tgph-gray-7` when off
- dropped the `:not([data-tgph-button-state="disabled"])` guard from the unchecked-track rule
- `DisabledOn` / `DisabledOff` stories
- browser test for the four checked × disabled combos. `Toggle.browser.test.css` just pins stylesheet load order so the `!important` actually matters there
- `vitest.config.mts` merges `sharedConfig` (keeps `*.browser.test.tsx` out of the jsdom run), `tsconfig.json` excludes test files like menu/modal/truncate

## Why?

`Toggle.Switch` renders its track as a `Button.Root`, and button paints every disabled solid track `--tgph-gray-3`. toggle's own rule skipped the disabled case, so disabled+on and disabled+off came out identical — thumb position was the only cue. button still sets `--background-color` to the real token when disabled, it was just losing to that blanket rule, so we read it back rather than duplicate `BUTTON_COLOR_MAP`.

## Screenshots

same story and viewport, top row (enabled) unchanged.

before: disabled on/off are identical:

<img width="1004" height="216" alt="toggle before" src="https://github.com/user-attachments/assets/bc886876-8261-4488-b6b0-13462d0a7d60" />

after: the track keeps its color, dimmed:

<img width="1004" height="216" alt="toggle after" src="https://github.com/user-attachments/assets/e521614f-660a-43b6-94d6-2c9c359dd624" />
