### PR TITLE
fix(helpers)!: close polymorphic prop passthrough so invalid props error

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,6 @@
+---
+"@telegraph/helpers": patch
+"@telegraph/style-engine": patch
+---
+
+Close polymorphic prop inheritance so invalid props are type errors again. Extracting props from a generic component (`TgphComponentProps<typeof Stack>`) instantiated the element type parameter at its constraint, making `React.ComponentProps<React.ElementType>` resolve to `any` and leaving a `{ [x: string]: any }` index signature on every inheriting component. That disabled excess-property checking *and* widened declared props to `any`, so `<Button fontSize={16}>` and `<Button variant="nonsense">` both compiled. `PolymorphicProps` now drops the element passthrough when the element type is unresolved, and declares `as`/`children`/`className`/`style` explicitly. **Breaking for type consumers** that were passing props which never belonged to a component.

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -31,21 +31,39 @@ export type OptionalAsPropConfig<E extends React.ElementType> =
 // This allows you to create a component that can be used as a button, link,
 // or any other element, and pass all the props of the underlying element type.
 export type PropsWithAs<C extends React.ElementType, P> = AsProp<C> &
-  Omit<React.ComponentProps<C>, keyof AsProp<C>> &
+  (React.ElementType extends C
+    ? unknown
+    : Omit<React.ComponentProps<C>, keyof AsProp<C>>) &
   P;
+
+// Props every polymorphic component supports regardless of which element it
+// renders as. Declared explicitly so they survive when the element passthrough
+// below resolves to nothing.
+type PolymorphicBaseProps<E extends React.ElementType> = {
+  as?: E;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+// The props of the underlying element `E`, or nothing when `E` is unresolved.
+// Extracting props from a *generic* component (`TgphComponentProps<typeof
+// Stack>`) instantiates its type parameter at the constraint, so `E` arrives
+// here as the whole `React.ElementType` union. `ComponentProps<ElementType>`
+// is `any`, and `Omit<any, "as">` is `{ [x: string]: any }` — an index
+// signature that disables excess-property checking and widens every declared
+// prop to `any` on anything that inherits it. Dropping the passthrough in that
+// case keeps inherited prop sets closed.
+type PolymorphicPassthroughProps<E extends React.ElementType> =
+  React.ElementType extends E ? unknown : Omit<React.ComponentProps<E>, "as">;
 
 // The `PolymorphicProps` type is a utility type that allows you to create a
 // component that can be used as a button, link, or any other element via
 // the `as` prop. It takes a generic type `E` that extends `React.ElementType`.
 // It returns a type that includes the `as` prop and all the props of the
 // underlying element type `E`.
-export type PolymorphicProps<E extends React.ElementType> = Omit<
-  React.ComponentProps<E>,
-  "as"
-> & {
-  as?: E;
-  children?: React.ReactNode;
-};
+export type PolymorphicProps<E extends React.ElementType> =
+  PolymorphicPassthroughProps<E> & PolymorphicBaseProps<E>;
 
 // The `PolymorphicPropsWithTgphRef` type is a utility type that allows you to create a
 // component that can be used as a button, link, or any other element via

--- a/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
+++ b/packages/style-engine/src/helpers/getStyleProp/getStyleProp.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from "react";
+
 type Direction =
   | "x"
   | "y"
@@ -255,7 +257,7 @@ type StyleProp<CssVars extends CssVarsPropObject<CssVars>> =
   | object;
 
 type GetStylePropParams<CssVars, Props> = {
-  props: Props & { style?: Record<string, string> };
+  props: Props & { style?: Record<string, string> | CSSProperties };
   cssVars: CssVars;
 };
 


### PR DESCRIPTION
## What changed

`PolymorphicProps` no longer splices in the underlying element's props when the element type is unresolved, and declares `as` / `children` / `className` / `style` explicitly so they survive that case. `PropsWithAs` carried the same defect and gets the same guard. The style-engine `style` param widens to accept `CSSProperties`.

## Why

Invalid props on most Telegraph components were not type errors:

```tsx
<Button fontSize={16} fontWeight={500}>Save</Button>  // compiled
<Button p={12345}>Save</Button>                       // compiled
<Button variant="nonsense">Save</Button>              // compiled
```

Components inherit props via `TgphComponentProps<typeof Stack>`. Because `Stack` is generic, `React.ComponentProps` instantiates its type parameter at the **constraint** (`React.ElementType`), not the default. `React.ComponentProps<React.ElementType>` resolves to `any`, so `Omit<any, "as">` became a `{ [x: string]: any }` index signature on every inheriting component — which disabled excess-property checking *and* widened every declared prop to `any`.

54 bare `TgphComponentProps<typeof X>` sites are affected (27× `Stack`, 6× `Box`, plus Tooltip, MenuItem, Input, Kbd, Combobox…). `Stack` itself was poisoned through its own bare `TgphComponentProps<typeof Box>`. The instantiation-expression form `TgphComponentProps<typeof Box<T>>` pins `T` first and was never affected, which is why `Button.Text` already rejected unknown props while `Button.Root` did not.

Not a TypeScript regression — reproduces identically under 5.9.3 and 6.0.2.

## Why this is a draft

The fix is validated but **incomplete**. It surfaces roughly **117 implementation errors and 125 test/story errors across 21 packages** that the `any` was hiding. None of it is visible to CI today: there's no type-check job, and `vite-plugin-dts` doesn't fail on diagnostics — so this PR's checks will go green while the errors are still there. It should not merge until the fallout is fixed.

Fallout is mechanical, in three shapes:
1. Implementations destructuring passthrough props that are no longer visible on an unresolved `T` (Button's `type`/`disabled`, Icon's `alt`/`aria-hidden`) — best fixed by declaring them, which documents the API better anyway.
2. Internal `<Stack as={derivedAs}>` spreads with unresolved generics — need a cast.
3. Indexed access like `DefaultProps<T>["state"]` — should reference the base type instead.

## Notes

- Verified with a throwaway probe: 9 invalid cases now error (unknown props and bad token values on `Button`, `Button.Root`, `Stack`, `Box`); 8 positive controls stay clean (`as="a" href`, `disabled type="submit"`, `aria-*`/`data-*`, `tgphRef`, `style`, style tokens). No false positives.
- helpers, style-engine and layout type-check clean; all 107 unit tests in the affected packages pass.
- One of PR #688's dormant type tests fires again (`<Button invalidProp="invalid">`). The rest stay dormant for two separate reasons worth fixing: #837 removed the `ButtonProps`/`ButtonRootProps`/`ButtonTextProps` exports they import, and several `@ts-expect-error` directives sit on the opening line of a multi-line JSX expression rather than the line carrying the error.
- Changeset is `patch` for both packages, matching the precedent set by the breaking `refactor(layout)!` in #909, but it is breaking for type consumers relying on the leak.

Resolves [KNO-14474](https://linear.app/knock/issue/KNO-14474/telegraph-polymorphic-prop-inheritance-collapses-to-any-components)