### PR TITLE
fix(popover,tooltip,modal,combobox)!: stop `as` replacing the animated element

### DIFF
--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -11,4 +11,6 @@
 
 `Modal.Root` needed one more change to keep that promise. The cast that let the body destructure `as` sat on the parameter. That put `as` straight back into the public type, so `<Modal.Root as="div">` compiled and did nothing. The cast now sits in the body.
 
+`Tooltip` also drops `asChild`. It declared the prop and never read it. Tooltip always merges its props onto its child, so `asChild` had no meaning. Passing it is now a type error, and you can remove it.
+
 `Combobox.Primitives.TriggerIndicator` also drops `alt`. The body discards it, because `Button.Icon` rejects `alt` and `aria-hidden` together. Leaving `alt` in the type promised an accessible name that never rendered.

--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -8,3 +8,7 @@
 `as` no longer replaces the animated element on `Popover.Content`, `Tooltip`'s popup label, `Modal.Root`, and Combobox's trigger indicator and trigger tag. Each renders a `framer-motion` element and then spread the caller's rest props after it, so a caller-supplied `as` won that spread. The animation stopped running, motion props reached a plain DOM node, and for `Popover.Content` the popup could stay mounted after close, because `onAnimationComplete` never fired on a non-motion element.
 
 `as` is now dropped from each props type and discarded at runtime. Passing it is a type error, and a spread cannot smuggle it through.
+
+`Modal.Root` needed one more change to keep that promise. The cast that let the body destructure `as` sat on the parameter. That put `as` straight back into the public type, so `<Modal.Root as="div">` compiled and did nothing. The cast now sits in the body.
+
+`Combobox.Primitives.TriggerIndicator` also drops `alt`. The body discards it, because `Button.Icon` rejects `alt` and `aria-hidden` together. Leaving `alt` in the type promised an accessible name that never rendered.

--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -5,6 +5,6 @@
 "@telegraph/combobox": minor
 ---
 
-`as` no longer replaces the animated element on `Popover.Content`, `Tooltip`'s popup label, `Modal.Root` and Combobox's trigger indicator. Each renders a `framer-motion` element and then spread the caller's rest props after it, so a caller-supplied `as` won that spread. The animation stopped running, motion props reached a plain DOM node, and for `Popover.Content` the popup could stay mounted after close, because `onAnimationComplete` never fired on a non-motion element.
+`as` no longer replaces the animated element on `Popover.Content`, `Tooltip`'s popup label, `Modal.Root`, and Combobox's trigger indicator and trigger tag. Each renders a `framer-motion` element and then spread the caller's rest props after it, so a caller-supplied `as` won that spread. The animation stopped running, motion props reached a plain DOM node, and for `Popover.Content` the popup could stay mounted after close, because `onAnimationComplete` never fired on a non-motion element.
 
 `as` is now dropped from each props type and discarded at runtime. Passing it is a type error, and a spread cannot smuggle it through.

--- a/.changeset/quiet-hounds-listen.md
+++ b/.changeset/quiet-hounds-listen.md
@@ -1,0 +1,10 @@
+---
+"@telegraph/popover": minor
+"@telegraph/tooltip": minor
+"@telegraph/modal": minor
+"@telegraph/combobox": minor
+---
+
+`as` no longer replaces the animated element on `Popover.Content`, `Tooltip`'s popup label, `Modal.Root` and Combobox's trigger indicator. Each renders a `framer-motion` element and then spread the caller's rest props after it, so a caller-supplied `as` won that spread. The animation stopped running, motion props reached a plain DOM node, and for `Popover.Content` the popup could stay mounted after close, because `onAnimationComplete` never fired on a non-motion element.
+
+`as` is now dropped from each props type and discarded at runtime. Passing it is a type error, and a spread cannot smuggle it through.

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -28,8 +28,10 @@ import type {
   SingleSelect,
 } from "./Combobox.types";
 
-type TriggerIndicatorProps<T extends TgphElement> = Partial<
-  TgphComponentProps<typeof Button.Icon<T>>
+// Drop `as`: this always renders `motion.span` (KNO-14501).
+type TriggerIndicatorProps<T extends TgphElement> = Omit<
+  Partial<TgphComponentProps<typeof Button.Icon<T>>>,
+  "as"
 >;
 
 const TriggerIndicator = <T extends TgphElement>(
@@ -38,8 +40,15 @@ const TriggerIndicator = <T extends TgphElement>(
   const {
     icon = ChevronsUpDown,
     "aria-hidden": ariaHidden = true,
+    // Destructure `alt` for the same reason the cast omits it: Button.Icon
+    // rejects `alt` and `aria-hidden` arriving together.
+    as: _as,
+    alt: _alt,
     ...props
-  } = triggerIndicatorProps as TriggerIndicatorProps<"span">;
+  } = triggerIndicatorProps as TriggerIndicatorProps<"span"> & {
+    as?: TgphElement;
+    alt?: string;
+  };
   const context = React.useContext(ComboboxContext);
   return (
     <Button.Icon

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -28,10 +28,12 @@ import type {
   SingleSelect,
 } from "./Combobox.types";
 
-// Drop `as`: this always renders `motion.span` (KNO-14501).
+// Drop `as`: this always renders `motion.span` (KNO-14501). Drop `alt` too:
+// the body discards it, so leaving it in the type promised an accessible name
+// this never renders.
 type TriggerIndicatorProps<T extends TgphElement> = Omit<
   Partial<TgphComponentProps<typeof Button.Icon<T>>>,
-  "as"
+  "as" | "alt"
 >;
 
 const TriggerIndicator = <T extends TgphElement>(

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -299,15 +299,22 @@ const TriggerTagContext = React.createContext<{
   value: "",
 });
 
+// Drop `as`: this always renders `motion.span` (KNO-14501).
 type TriggerTagRootProps<T extends TgphElement> = {
   value: string;
-} & TgphComponentProps<typeof Tag.Root<T>>;
+} & Omit<TgphComponentProps<typeof Tag.Root<T>>, "as">;
 
 const TriggerTagRoot = <T extends TgphElement>(
   triggerTagRootProps: TriggerTagRootProps<T>,
 ) => {
-  const { value, children, ...props } =
-    triggerTagRootProps as TriggerTagRootProps<"span">;
+  const {
+    value,
+    children,
+    as: _as,
+    ...props
+  } = triggerTagRootProps as TriggerTagRootProps<"span"> & {
+    as?: TgphElement;
+  };
   return (
     <TriggerTagContext.Provider value={{ value }}>
       <Tag.Root

--- a/packages/combobox/src/Combobox/Combobox.test-d.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test-d.tsx
@@ -186,6 +186,19 @@ describe("Combobox types", () => {
     />;
   });
 
+  it("rejects `as` on animated trigger primitives", () => {
+    // KNO-14501.
+    <Combobox.Primitives.TriggerIndicator
+      // @ts-expect-error as is not a TriggerIndicator prop
+      as="section"
+    />;
+    <Combobox.Primitives.TriggerTag.Root
+      value="a"
+      // @ts-expect-error as is not a TriggerTag.Root prop
+      as="section"
+    />;
+  });
+
   it("rejects invalid values for declared props", () => {
     <Combobox.Root
       // @ts-expect-error modal is a boolean

--- a/packages/combobox/src/Combobox/Combobox.test-d.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test-d.tsx
@@ -192,6 +192,11 @@ describe("Combobox types", () => {
       // @ts-expect-error as is not a TriggerIndicator prop
       as="section"
     />;
+    // The body discards `alt`, so the type must not promise it.
+    <Combobox.Primitives.TriggerIndicator
+      // @ts-expect-error alt is not a TriggerIndicator prop
+      alt="Open"
+    />;
     <Combobox.Primitives.TriggerTag.Root
       value="a"
       // @ts-expect-error as is not a TriggerTag.Root prop

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -126,6 +126,18 @@ const ControlledOpenCombobox = ({
 };
 
 describe("Combobox", () => {
+  it("keeps the animated trigger tag when a spread supplies `as`", () => {
+    const smuggled = { as: "b" } as Record<string, unknown>;
+    const { container } = render(
+      <Combobox.Root>
+        <Combobox.Primitives.TriggerTag.Root value="a" {...smuggled} />
+      </Combobox.Root>,
+    );
+
+    expect(container.querySelector("b")).toBeNull();
+    expect(container.querySelector("span")).not.toBeNull();
+  });
+
   it("keeps the animated trigger indicator when a spread supplies `as`", () => {
     // A spread is the only route left: `as` is gone from the props type.
     const smuggled = { as: "b" } as Record<string, unknown>;

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -126,6 +126,19 @@ const ControlledOpenCombobox = ({
 };
 
 describe("Combobox", () => {
+  it("keeps the animated trigger indicator when a spread supplies `as`", () => {
+    // A spread is the only route left: `as` is gone from the props type.
+    const smuggled = { as: "b" } as Record<string, unknown>;
+    const { container } = render(
+      <Combobox.Root>
+        <Combobox.Primitives.TriggerIndicator {...smuggled} />
+      </Combobox.Root>,
+    );
+
+    expect(container.querySelector("b")).toBeNull();
+    expect(container.querySelector("span")).not.toBeNull();
+  });
+
   describe("Single Select", () => {
     it("combobox is accessible", async () => {
       const user = userEvent.setup();

--- a/packages/modal/src/Modal/Modal.test-d.tsx
+++ b/packages/modal/src/Modal/Modal.test-d.tsx
@@ -110,6 +110,17 @@ describe("Modal types", () => {
     />;
   });
 
+  it("rejects `as` on Root", () => {
+    // KNO-14501. `Root` renders the animated containers and discards `as`, so
+    // the type has to reject it. It accepted it while the cast sat on the
+    // parameter rather than in the body.
+    <Modal.Root
+      a11yTitle="Settings"
+      // @ts-expect-error as is not a Modal.Root prop
+      as="div"
+    />;
+  });
+
   it("accepts valid props", () => {
     <Modal.Root
       a11yTitle="Settings"

--- a/packages/modal/src/Modal/Modal.test.tsx
+++ b/packages/modal/src/Modal/Modal.test.tsx
@@ -51,6 +51,21 @@ const TestModal = ({
 };
 
 describe("Modal", () => {
+  it("keeps the animated element when a spread supplies `as`", async () => {
+    // A spread is the only route left: `as` is gone from the props type.
+    const smuggled = { as: "section" } as Record<string, unknown>;
+    render(
+      <Modal.Root open a11yTitle="Settings" {...smuggled}>
+        <Modal.Content>
+          <Modal.Body>Modal body</Modal.Body>
+        </Modal.Content>
+      </Modal.Root>,
+    );
+
+    await waitFor(() => expect(screen.getByText("Modal body")).toBeTruthy());
+    expect(document.querySelector("section")).toBeNull();
+  });
+
   it("renders an accessible dialog with hidden title and description", async () => {
     render(<TestModal />);
 

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -128,9 +128,10 @@ const useBodyScrollLock = (layerId: string, enabled: boolean) => {
   }, [enabled, layerId]);
 };
 
+// Drop `as`: the content always renders `motion.div` (KNO-14501).
 export type RootProps = RootDialogProps &
   LegacyFocusScopeProps &
-  StackProps & {
+  Omit<StackProps, "as"> & {
     a11yTitle: string;
     a11yDescription?: string;
     layer?: number;
@@ -140,8 +141,11 @@ const Root = ({
   defaultOpen: defaultOpenProp,
   open: openProp,
   onOpenChange: onOpenChangeProp,
+  // Discarded as well as dropped from the type, because a spread can still
+  // carry it.
+  as: _as,
   ...props
-}: RootProps) => {
+}: RootProps & { as?: TgphElement }) => {
   const [open, onOpenChange] = useControllableState({
     prop: openProp,
     onChange: onOpenChangeProp,

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -137,15 +137,18 @@ export type RootProps = RootDialogProps &
     layer?: number;
   };
 
-const Root = ({
-  defaultOpen: defaultOpenProp,
-  open: openProp,
-  onOpenChange: onOpenChangeProp,
-  // Discarded as well as dropped from the type, because a spread can still
-  // carry it.
-  as: _as,
-  ...props
-}: RootProps & { as?: TgphElement }) => {
+const Root = (rootProps: RootProps) => {
+  const {
+    defaultOpen: defaultOpenProp,
+    open: openProp,
+    onOpenChange: onOpenChangeProp,
+    // Discarded as well as dropped from the type, because a spread can still
+    // carry it. The cast stays in the body: on the parameter it puts `as` back
+    // into the public type, so `<Modal.Root as="div">` compiled and did nothing.
+    as: _as,
+    ...props
+  } = rootProps as RootProps & { as?: TgphElement };
+
   const [open, onOpenChange] = useControllableState({
     prop: openProp,
     onChange: onOpenChangeProp,

--- a/packages/popover/src/Popover/Popover.test-d.tsx
+++ b/packages/popover/src/Popover/Popover.test-d.tsx
@@ -99,7 +99,15 @@ describe("Popover types", () => {
         Content
       </Popover.Content>
     </Popover.Root>;
-    <Popover.Content as="section" forceMount skipAnimation />;
+    <Popover.Content forceMount skipAnimation />;
     <Popover.Trigger disabled className="trigger" />;
+  });
+
+  it("rejects `as` on animated content", () => {
+    // KNO-14501.
+    <Popover.Content
+      // @ts-expect-error as is not a Popover.Content prop
+      as="section"
+    />;
   });
 });

--- a/packages/popover/src/Popover/Popover.test.tsx
+++ b/packages/popover/src/Popover/Popover.test.tsx
@@ -37,6 +37,28 @@ afterEach(() => {
 });
 
 describe("Popover", () => {
+  it("keeps the animated element when a spread supplies `as`", async () => {
+    const user = userEvent.setup();
+    // A spread is the only route left: `as` is gone from the props type.
+    const smuggled = { as: "section" } as Record<string, unknown>;
+    render(
+      <Popover.Root>
+        <Popover.Trigger>
+          <TestButton>Open</TestButton>
+        </Popover.Trigger>
+        <Popover.Content {...smuggled} data-testid="content">
+          Body
+        </Popover.Content>
+      </Popover.Root>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open" }));
+
+    const content = await screen.findByTestId("content");
+    expect(content.tagName).toBe("DIV");
+    expect(document.querySelector("section")).toBeNull();
+  });
+
   describe("type inheritance", () => {
     it("accepts valid content-specific props", () => {
       const validProps: PopoverContentProps = {

--- a/packages/popover/src/Popover/Popover.tsx
+++ b/packages/popover/src/Popover/Popover.tsx
@@ -166,17 +166,8 @@ export type ContentProps<T extends TgphElement = "div"> = Omit<
   "children" | "className" | "render"
 > &
   Omit<BasePopoverPopupProps, "children" | "className" | "render" | "style"> &
-  // Source the polymorphic element props from `PolymorphicProps<T>` and the
-  // Stack style props from the *non-generic* Stack. Wrapping the generic
-  // `typeof Stack<T>` in `Omit<…, "align">` produces a deferred mapped type,
-  // and TypeScript then fails to compute a contextual type for the sibling
-  // dismiss-handler callbacks below — their `event` param silently widens to
-  // `any` at the JSX call site. That is exactly what let a stale Radix-shaped
-  // handler reading `event.detail.originalEvent` compile and crash at runtime
-  // (KNO-14309). Keeping the `Omit` off the generic makes each handler's
-  // `event` resolve to its concrete `Event` type, so `.detail`/`.originalEvent`
-  // access fails to compile.
-  PolymorphicProps<T> &
+  // Drop `as`: the content always renders `motion.div` (KNO-14501).
+  Omit<PolymorphicProps<T>, "as"> &
   Omit<StackProps, "align" | "as"> & {
     avoidCollisions?: boolean;
     contentStackRef?: Ref<HTMLDivElement>;
@@ -229,8 +220,11 @@ const Content = <T extends TgphElement = "div">(
     bg = "surface-1",
     tgphRef,
     style,
+    // Discarded as well as dropped from the type, because a spread can still
+    // carry it.
+    as: _as,
     ...props
-  } = contentProps as ContentProps<"div">;
+  } = contentProps as ContentProps<"div"> & { as?: TgphElement };
   const compatibilityContext = useContext(PopoverCompatibilityContext);
   const contentRef = useComposedRefs<HTMLElement>(
     tgphRef as Ref<HTMLElement>,
@@ -399,9 +393,8 @@ const Content = <T extends TgphElement = "div">(
               tgphRef={contentRef}
               zIndex="popover"
               key="tgph-popover-content"
-              // `as` is omitted from the cast so the rest props do not add a
-              // second candidate to Stack's element inference, which would
-              // widen `T` to a union and hide the motion props used here.
+              // Keep the `as` omission. It stops the rest props adding a second
+              // candidate to Stack's element inference.
               {...(stackProps as Omit<
                 StackProps<typeof motion.div>,
                 "as" | "children" | "onAnimationComplete"

--- a/packages/tooltip/src/Tooltip/Tooltip.test-d.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test-d.tsx
@@ -12,7 +12,6 @@ describe("Tooltip types", () => {
     expectTypeOf<TooltipProps["label"]>().not.toBeAny();
     expectTypeOf<TooltipProps["labelProps"]>().not.toBeAny();
     expectTypeOf<TooltipProps["enabled"]>().not.toBeAny();
-    expectTypeOf<TooltipProps["asChild"]>().not.toBeAny();
     expectTypeOf<TooltipProps["disableFocusOpen"]>().not.toBeAny();
     expectTypeOf<TooltipProps["skipAnimation"]>().not.toBeAny();
     expectTypeOf<TooltipProps["triggerRef"]>().not.toBeAny();
@@ -45,6 +44,14 @@ describe("Tooltip types", () => {
       label="hi"
       // @ts-expect-error unknown prop
       fontSize={16}
+    >
+      <button>trigger</button>
+    </Tooltip>;
+    <Tooltip
+      label="hi"
+      // Tooltip always merges onto its child, so `asChild` never did anything.
+      // @ts-expect-error asChild is not a Tooltip prop
+      asChild
     >
       <button>trigger</button>
     </Tooltip>;

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -70,7 +70,6 @@ describe("Tooltip", () => {
     it("accepts legacy wrapper passthrough props", () => {
       const validProps: TooltipProps = {
         label: "Tooltip text",
-        asChild: true,
         style: { zIndex: 9999 },
         children: null,
       };

--- a/packages/tooltip/src/Tooltip/Tooltip.test.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test.tsx
@@ -31,6 +31,22 @@ afterEach(() => {
 });
 
 describe("Tooltip", () => {
+  it("keeps the animated label element when a spread supplies `as`", async () => {
+    const user = userEvent.setup();
+    // A spread is the only route left: `as` is gone from `labelProps`.
+    const smuggled = { as: "section" } as Record<string, unknown>;
+    render(
+      <Tooltip label="Helpful context" delayDuration={0} labelProps={smuggled}>
+        <TestButton>Hover target</TestButton>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByRole("button", { name: "Hover target" }));
+    await screen.findByRole("tooltip");
+
+    expect(document.querySelector("section")).toBeNull();
+  });
+
   describe("type inheritance", () => {
     it("accepts valid tooltip-specific props", () => {
       const validProps: TooltipProps = {

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -108,7 +108,6 @@ export type TooltipBaseProps<T extends TgphElement = "div"> = {
   // Drop `as`: the popup label always renders `motion.div` (KNO-14501).
   labelProps?: Omit<TgphComponentProps<typeof Stack<T>>, "as">;
   enabled?: boolean;
-  asChild?: boolean;
   // When true, prevents focus events from instantly opening the tooltip. This
   // preserves delayed hover behavior when Select/Combobox move DOM focus on hover.
   disableFocusOpen?: boolean;

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -105,7 +105,8 @@ type LegacyTooltipPopupProps = Partial<
 export type TooltipBaseProps<T extends TgphElement = "div"> = {
   children?: ReactNode;
   label?: ReactNode;
-  labelProps?: TgphComponentProps<typeof Stack<T>>;
+  // Drop `as`: the popup label always renders `motion.div` (KNO-14501).
+  labelProps?: Omit<TgphComponentProps<typeof Stack<T>>, "as">;
   enabled?: boolean;
   asChild?: boolean;
   // When true, prevents focus events from instantly opening the tooltip. This
@@ -199,8 +200,15 @@ const Tooltip = <T extends TgphElement = "div">({
   const resolvedCollisionAvoidance =
     collisionAvoidance ??
     (avoidCollisions === false ? NO_COLLISION_AVOIDANCE : undefined);
-  const popupLabelProps = labelProps as StackProps | undefined;
-  const { style: labelStyle, ...popupLabelRestProps } = popupLabelProps ?? {};
+  const popupLabelProps = labelProps as
+    | (StackProps & { as?: TgphElement })
+    | undefined;
+  // `as` is discarded so a spread cannot replace the animated element.
+  const {
+    style: labelStyle,
+    as: _labelAs,
+    ...popupLabelRestProps
+  } = popupLabelProps ?? {};
   const popupStyle = {
     transformOrigin: "var(--transform-origin)",
     ...style,


### PR DESCRIPTION
Stacked on #922. Second of five.

## The problem

Five components render a `framer-motion` element, then spread the caller's rest props after it. A caller-supplied `as` won that spread and replaced the animated element.

```tsx
<Popover.Content as={motion.div} initial={{ opacity: 0 }} />
// the animation stops running, and motion props reach a plain DOM node
```

`Popover.Content` could also stay mounted after close, because `onAnimationComplete` never fired on a non-motion element.

## The solution

Drop `as` from each props type, and discard it at runtime so a spread cannot smuggle it through.

Closing that surfaced three more props with the same shape. Each one type checked and did nothing.

## What is in this one

- `as` leaves the props type on `Popover.Content`, `Tooltip`'s popup label, `Modal.Root`, and Combobox's trigger indicator and trigger tag
- `Modal.Root` moves its cast into the body, which had put `as` straight back into the public type
- `Combobox.Primitives.TriggerIndicator` drops `alt`, which the body discarded
- `Tooltip` drops `asChild`, which it declared and never read

## Impact

Breaking, but type-only. None of these props did anything at runtime, so deleting them from a call site changes nothing.

One control error, at `AiFetchStep/CreditInfo.tsx:37`. Control has 57 `asChild` call sites and this is the only one that breaks. `Popover.Trigger`, `Menu.Trigger` and `VisuallyHidden` all still support it.

Resolves [KNO-14501](https://linear.app/knock/issue/KNO-14501/telegraph-as-on-animated-content-silently-replaces-motiondiv)
