### PR TITLE
perf(layout,button): stop repeating the element passthrough in prop types

### DIFF
--- a/.changeset/plain-spoons-tap.md
+++ b/.changeset/plain-spoons-tap.md
@@ -1,0 +1,8 @@
+---
+"@telegraph/layout": minor
+"@telegraph/button": minor
+---
+
+`StackProps` and `Button`'s `RootProps` no longer include the element passthrough more than once. `BoxProps<T>` already carries it, so `StackProps<T>` intersecting `PolymorphicProps<T>` with `Omit<BoxProps<T>, "as">` included it twice, and `Button.RootProps<T>` added a third copy. `as` and the button-shaped `tgphRef` were the only members those extra copies contributed, and both are now declared directly.
+
+The public prop surface is unchanged. The types are smaller: measured with `tsc --extendedDiagnostics`, `@telegraph/layout` drops 25% of its type instantiations and `@telegraph/button` 13%. Downstream, `@telegraph/combobox` drops 14% of its types and `@telegraph/modal` 20%.

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,4 +1,5 @@
 import {
+  type PolymorphicRootProps,
   RemappedOmit,
   type Required,
   type TgphComponentProps,
@@ -52,12 +53,9 @@ type ButtonOnClick = ButtonClickHandler | boolean;
 export type RootProps<T extends TgphElement = "button"> = Omit<
   StackProps<T>,
   "tgphRef" | "as" | "onClick"
-> & {
-  // `StackProps<T>` above already carries the element passthrough. Take only
-  // `as` and the button-shaped `tgphRef` from the polymorphic helper.
-  as?: T;
-  tgphRef?: React.Ref<HTMLButtonElement>;
-} & RootBaseProps & {
+> &
+  PolymorphicRootProps<T, HTMLButtonElement> &
+  RootBaseProps & {
     onClick?: ButtonClickHandler;
   };
 

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,5 +1,5 @@
 import {
-  type PolymorphicRootProps,
+  type AsAndTgphRefProps,
   RemappedOmit,
   type Required,
   type TgphComponentProps,
@@ -54,7 +54,7 @@ export type RootProps<T extends TgphElement = "button"> = Omit<
   StackProps<T>,
   "tgphRef" | "as" | "onClick"
 > &
-  PolymorphicRootProps<T, HTMLButtonElement> &
+  AsAndTgphRefProps<T, HTMLButtonElement> &
   RootBaseProps & {
     onClick?: ButtonClickHandler;
   };

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -1,5 +1,4 @@
 import {
-  type PolymorphicPropsWithTgphRef,
   RemappedOmit,
   type Required,
   type TgphComponentProps,
@@ -53,9 +52,12 @@ type ButtonOnClick = ButtonClickHandler | boolean;
 export type RootProps<T extends TgphElement = "button"> = Omit<
   StackProps<T>,
   "tgphRef" | "as" | "onClick"
-> &
-  Omit<PolymorphicPropsWithTgphRef<T, HTMLButtonElement>, "onClick"> &
-  RootBaseProps & {
+> & {
+  // `StackProps<T>` above already carries the element passthrough. Take only
+  // `as` and the button-shaped `tgphRef` from the polymorphic helper.
+  as?: T;
+  tgphRef?: React.Ref<HTMLButtonElement>;
+} & RootBaseProps & {
     onClick?: ButtonClickHandler;
   };
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -9,7 +9,7 @@ export type {
   TgphComponentProps,
   OptionalAsPropConfig,
   RemappedOmit,
-  PolymorphicRootProps,
+  AsAndTgphRefProps,
   CSSPropertiesWithVars,
 } from "./types/utility";
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -9,6 +9,7 @@ export type {
   TgphComponentProps,
   OptionalAsPropConfig,
   RemappedOmit,
+  PolymorphicRootProps,
   CSSPropertiesWithVars,
 } from "./types/utility";
 

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -82,6 +82,16 @@ export type PolymorphicPropsWithTgphRef<
   tgphRef?: React.Ref<R>;
 } & PolymorphicProps<E>;
 
+// The `as` and `tgphRef` pair a polymorphic component re-declares after
+// omitting them from an inherited props type, so the ref points at the element
+// it actually renders. Both stay at the top level of the intersection on
+// purpose: `as?: E` is the inference site for `E`, and a mapped type such as
+// `Omit` in front of it stops `<X as="a" />` resolving `E` to `"a"`.
+export type PolymorphicRootProps<
+  E extends React.ElementType,
+  R extends HTMLElement | React.ElementType,
+> = { as?: E; tgphRef?: React.Ref<R> };
+
 export type TgphComponentProps<T extends React.ElementType> =
   React.ComponentProps<T>;
 

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -87,7 +87,7 @@ export type PolymorphicPropsWithTgphRef<
 // it actually renders. Both stay at the top level of the intersection on
 // purpose: `as?: E` is the inference site for `E`, and a mapped type such as
 // `Omit` in front of it stops `<X as="a" />` resolving `E` to `"a"`.
-export type PolymorphicRootProps<
+export type AsAndTgphRefProps<
   E extends React.ElementType,
   R extends HTMLElement | React.ElementType,
 > = { as?: E; tgphRef?: React.Ref<R> };

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import type { TgphElement } from "@telegraph/helpers";
+import type { AsProp, TgphElement } from "@telegraph/helpers";
 import { useStyleEngine } from "@telegraph/style-engine";
 import clsx from "clsx";
 
@@ -11,7 +11,9 @@ import { StyleProps, cssVars } from "./Stack.constants";
 export type StackProps<T extends TgphElement = "div"> = Omit<
   BoxProps<T>,
   "as"
-> & { as?: T } & StyleProps;
+> &
+  AsProp<T> &
+  StyleProps;
 
 const Stack = <T extends TgphElement = "div">({
   className,

--- a/packages/layout/src/Stack/Stack.tsx
+++ b/packages/layout/src/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import type { PolymorphicProps, TgphElement } from "@telegraph/helpers";
+import type { TgphElement } from "@telegraph/helpers";
 import { useStyleEngine } from "@telegraph/style-engine";
 import clsx from "clsx";
 
@@ -6,9 +6,12 @@ import { Box, type BoxProps } from "../Box";
 
 import { StyleProps, cssVars } from "./Stack.constants";
 
-export type StackProps<T extends TgphElement = "div"> = PolymorphicProps<T> &
-  Omit<BoxProps<T>, "as"> &
-  StyleProps;
+// `BoxProps<T>` already carries the element passthrough. Do not intersect
+// `PolymorphicProps<T>` back in, because that repeats it.
+export type StackProps<T extends TgphElement = "div"> = Omit<
+  BoxProps<T>,
+  "as"
+> & { as?: T } & StyleProps;
 
 const Stack = <T extends TgphElement = "div">({
   className,


### PR DESCRIPTION
Stacked on #924. Third of five.

## The problem

`BoxProps<T>` carries the element passthrough. `StackProps<T>` included it a second time, and `Button.RootProps<T>` a third.

```ts
// Before: PolymorphicProps<T> repeats what Omit<BoxProps<T>, "as"> already has.
type StackProps<T> = PolymorphicProps<T> & Omit<BoxProps<T>, "as"> & StyleProps;
```

The repeats cost nothing while every prop type resolved to `any`. They cost real compile work now that #922 makes the types resolve.

## The solution

Keep one copy. `as` was the only member the second copy contributed, so re-declare that alone.

```ts
type StackProps<T> = Omit<BoxProps<T>, "as"> & { as?: T } & StyleProps;
```

The public prop surface does not change.

## What is in this one

- `StackProps` and `Button.RootProps` each drop their duplicate passthrough
- `AsAndTgphRefProps<E, R>` names the `as`/`tgphRef` pair a component re-declares after omitting both

## Impact

Instantiation counts are deterministic, unlike wall-clock time. Measured with `tsc --extendedDiagnostics`:

| Package | Types | Instantiations |
|---|---|---|
| `layout` | −5% | **−25%** |
| `button` | −5% | **−13%** |
| `combobox` | **−15%** | −11% |
| `modal` | **−20%** | −15% |

The downstream rows need the declarations rebuilt first. Without that step `combobox` and `modal` read the old emitted types and report no change.

This also clears both `TS2590` errors in control, which corrects a claim in #922. My earlier probe used `Button.Root as={motion.div}` directly, which still exceeds the limit. Control's two sites go through `Button` and a generic wrapper, and both come back under the limit.

## One trap

The obvious refactor does not work, and the helper says so. Folding the omit-and-re-declare into a mapped type compiles, then breaks `<Button.Root as="a" />`. `as?: E` is the inference site for `E`, and a mapped type in front of it stops TypeScript resolving `E`.

Resolves [KNO-14502](https://linear.app/knock/issue/KNO-14502/telegraph-two-prop-typing-limitations-shipped-with-the-polymorphic)
