### PR TITLE
fix(select,icon,toggle,combobox,menu,segmented-control)!: let every component render as any element

### DIFF
--- a/.changeset/eager-falcons-agree.md
+++ b/.changeset/eager-falcons-agree.md
@@ -1,0 +1,18 @@
+---
+"@telegraph/button": minor
+"@telegraph/tabs": patch
+"@telegraph/menu": patch
+"@telegraph/segmented-control": patch
+---
+
+`Tabs.Tab` no longer reports a Base UI error when a disabled tab renders as another element:
+
+```tsx
+<Tabs.Tab value="docs" as="a" href="/docs" disabled>
+  Docs
+</Tabs.Tab>
+```
+
+`Button` always renders a real `<button>` when you disable it. It needs the native disabled state to block clicks, so it ignores `as`. `Tab` missed that and told Base UI the tag was not a button. Base UI logged the mismatch on every render.
+
+`@telegraph/button` now exports `rendersNativeButton(as, disabled)`. `Button.Root` uses it to pick its own tag. `Menu.Button`, `Menu.SubTrigger`, `SegmentedControl.Option`, and `Tabs.Tab` read it too. The five cannot diverge again.

--- a/.changeset/olive-hounds-travel.md
+++ b/.changeset/olive-hounds-travel.md
@@ -1,0 +1,15 @@
+---
+"@telegraph/menu": minor
+---
+
+`Menu.Button` accepts a component for `as`, so a menu item can navigate:
+
+```tsx
+<Menu.Button as={NextLink} href="/settings">
+  Settings
+</Menu.Button>
+```
+
+`as` was already declared, but it could never resolve to anything except `"button"`. `MenuButtonItemProps` read bare `MenuItemProps`, which is `MenuItemProps<"button">` and carries `as?: "button"`. Intersecting that with the `as?: T` beside it gave `as?: "button" & T`, so every other element failed to assign.
+
+`nativeButton` now follows the element that renders instead of defaulting to `true`. Base UI reports an error when the two disagree, and `Button.Root` renders a native button unless `as` says otherwise, forcing one back when `disabled`. Pass `nativeButton` explicitly for a component that resolves to a button.

--- a/.changeset/olive-hounds-travel.md
+++ b/.changeset/olive-hounds-travel.md
@@ -12,4 +12,8 @@
 
 `as` was already declared, but it could never resolve to anything except `"button"`. `MenuButtonItemProps` read bare `MenuItemProps`, which is `MenuItemProps<"button">` and carries `as?: "button"`. Intersecting that with the `as?: T` beside it gave `as?: "button" & T`, so every other element failed to assign.
 
-`nativeButton` now follows the element that renders instead of defaulting to `true`. Base UI reports an error when the two disagree, and `Button.Root` renders a native button unless `as` says otherwise, forcing one back when `disabled`. Pass `nativeButton` explicitly for a component that resolves to a button.
+`Menu.SubTrigger` had the same collapse through `MenuSubTriggerItemProps`, and takes a component for `as` now too.
+
+`nativeButton` on both now follows the element that renders instead of defaulting to `true`. Base UI reports an error when the two disagree, and `Button.Root` renders a native button unless `as` says otherwise, forcing one back when `disabled`. Pass `nativeButton` explicitly for a component that resolves to a button.
+
+**This changes keyboard behavior on an item that renders an anchor.** Base UI treated those items as native buttons before, so Space did nothing. Space now activates the item, matching Enter and the WAI-ARIA menu pattern. The invalid `type="button"` that Base UI stamped onto those anchors is gone as well.

--- a/.changeset/tidy-melons-shake.md
+++ b/.changeset/tidy-melons-shake.md
@@ -1,7 +1,10 @@
 ---
 "@telegraph/segmented-control": minor
-"@telegraph/combobox": patch
+"@telegraph/combobox": minor
 "@telegraph/tag": patch
+"@telegraph/select": minor
+"@telegraph/icon": minor
+"@telegraph/toggle": minor
 ---
 
 `SegmentedControl.Option` accepts a component for `as`, so an option can navigate:
@@ -16,6 +19,12 @@
 
 Only the public props type is generic. The internals stay at the default element, because carrying an unresolved element parameter through Base UI's `render` callback stacks mapped types over Button's icon union and takes package type-checking from seconds to minutes.
 
-`nativeButton` follows the element that renders, as it now does for `Menu.Button`.
+`nativeButton` follows the element that renders, as it now does for `Menu.Button`. It counts the root's `disabled` as well as the option's own, because `Root` passes `disabled` down through context and `Button` renders a native button whenever it is set. Reading only the option's own left a disabled option without its native `disabled` attribute, which Base UI replaced with `aria-disabled`.
 
-Several components took their element parameter without a default, so an absent `as` left it at the constraint rather than the documented default. The element passthrough then dropped native attributes, and `<Combobox.Option type="button" />` or `<Combobox.Empty id="x" />` did not compile. Fixed on `Combobox.Option`, `Combobox.Empty`, `Tag.Button` and the Combobox trigger primitives.
+Several components took their element parameter without a default, so an absent `as` left it at the constraint rather than the documented default. The element passthrough then dropped native attributes, and `<Combobox.Option type="button" />` or `<Combobox.Empty id="x" />` did not compile. Fixed on `Combobox.Option`, `Combobox.Empty`, `Combobox.Create`, `Tag.Button` and the Combobox trigger primitives.
+
+Three more components could not take a component for `as` at all:
+
+- `Select.Option` was not generic, and its props type read bare `ComboboxOptionProps`.
+- `Spinner` declared `Partial<IconBaseProps<T>>`, and a mapped type in front of `as?: T` stops the element resolving. Only `icon` is optional now, so the rendered element's own required props are enforced again.
+- `Toggle.Indicator` declared `"span"` but renders `Tag as={as || "label"}`, so it rejected props the rendered element accepts, such as `htmlFor`.

--- a/.changeset/tidy-melons-shake.md
+++ b/.changeset/tidy-melons-shake.md
@@ -1,0 +1,21 @@
+---
+"@telegraph/segmented-control": minor
+"@telegraph/combobox": patch
+"@telegraph/tag": patch
+---
+
+`SegmentedControl.Option` accepts a component for `as`, so an option can navigate:
+
+```tsx
+<SegmentedControl.Option value="docs" as={NextLink} href="/docs">
+  Docs
+</SegmentedControl.Option>
+```
+
+`OptionProps` read bare `ButtonProps`, which is `ButtonProps<"button">` and carries `as?: "button"`. Intersecting that with the `as?: T` beside it pinned the element.
+
+Only the public props type is generic. The internals stay at the default element, because carrying an unresolved element parameter through Base UI's `render` callback stacks mapped types over Button's icon union and takes package type-checking from seconds to minutes.
+
+`nativeButton` follows the element that renders, as it now does for `Menu.Button`.
+
+Several components took their element parameter without a default, so an absent `as` left it at the constraint rather than the documented default. The element passthrough then dropped native attributes, and `<Combobox.Option type="button" />` or `<Combobox.Empty id="x" />` did not compile. Fixed on `Combobox.Option`, `Combobox.Empty`, `Tag.Button` and the Combobox trigger primitives.

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -86,6 +86,13 @@ const deriveState = (params: DeriveStateParams): InternalProps["state"] => {
   return params.state;
 };
 
+// Whether `Button.Root` renders a real `<button>` for this `as`/`disabled`
+// pair. Base UI components that render a Button need it: they log an error
+// when their `nativeButton` prop disagrees with the tag that renders, and
+// they swap native `disabled` for `aria-disabled` when it is false.
+const rendersNativeButton = (as?: TgphElement, disabled?: boolean) =>
+  !!disabled || !as || as === "button";
+
 const Root = <T extends TgphElement = "button">(rootProps: RootProps<T>) => {
   const {
     as,
@@ -123,7 +130,7 @@ const Root = <T extends TgphElement = "button">(rootProps: RootProps<T>) => {
   // disabled. We do this so we can use the native button element's disabled
   // state to prevent clicks.
   // We also want to trivially pass in "button" if no "as" prop is provided
-  const derivedAs = disabled || !as ? "button" : as;
+  const derivedAs = rendersNativeButton(as, disabled) ? "button" : as;
 
   const layout = React.useMemo<InternalProps["layout"]>(() => {
     const childrenArray = React.Children.toArray(children);
@@ -341,4 +348,4 @@ const Button = Default as typeof Default & {
   Text: typeof Text;
 };
 
-export { Button };
+export { Button, rendersNativeButton };

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -326,7 +326,7 @@ const Default = <T extends TgphElement = "button">({
   const rootProps = props as RootProps<T>;
 
   return (
-    <Root<T> {...rootProps} {...(typeof onClick === "function" && { onClick })}>
+    <Root {...rootProps} {...(typeof onClick === "function" && { onClick })}>
       {combinedLeadingIcon && (
         <Icon {...combinedLeadingIcon} internal_iconType="leading" />
       )}

--- a/packages/button/src/Button/index.ts
+++ b/packages/button/src/Button/index.ts
@@ -1,4 +1,4 @@
-export { Button } from "./Button";
+export { Button, rendersNativeButton } from "./Button";
 export type {
   RootProps as ButtonRootProps,
   TextProps as ButtonTextProps,

--- a/packages/button/src/index.ts
+++ b/packages/button/src/index.ts
@@ -1,4 +1,4 @@
-export { Button } from "./Button";
+export { Button, rendersNativeButton } from "./Button";
 export type {
   ButtonRootProps,
   ButtonTextProps,

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -36,7 +36,7 @@ type TriggerIndicatorProps<T extends TgphElement> = Omit<
   "as" | "alt"
 >;
 
-const TriggerIndicator = <T extends TgphElement>(
+const TriggerIndicator = <T extends TgphElement = "span">(
   triggerIndicatorProps: TriggerIndicatorProps<T>,
 ) => {
   const {
@@ -73,7 +73,7 @@ type TriggerClearProps<T extends TgphElement> = TgphComponentProps<
   tooltipProps?: TooltipProps;
 };
 
-const TriggerClear = <T extends TgphElement>(
+const TriggerClear = <T extends TgphElement = "button">(
   triggerClearProps: TriggerClearProps<T>,
 ) => {
   const { tooltipProps, ...props } =
@@ -153,7 +153,7 @@ type TriggerTextProps<T extends TgphElement> = TgphComponentProps<
   typeof Button.Text<T>
 >;
 
-const TriggerText = <T extends TgphElement>(
+const TriggerText = <T extends TgphElement = "span">(
   triggerTextProps: TriggerTextProps<T>,
 ) => {
   const { children, ...props } = triggerTextProps as TriggerTextProps<"span">;
@@ -206,7 +206,7 @@ type TriggerPlaceholderProps<T extends TgphElement> = TgphComponentProps<
   typeof Button.Text<T>
 >;
 
-const TriggerPlaceholder = <T extends TgphElement>(
+const TriggerPlaceholder = <T extends TgphElement = "span">(
   triggerPlaceholderProps: TriggerPlaceholderProps<T>,
 ) => {
   const { children, ...props } =
@@ -306,7 +306,7 @@ type TriggerTagRootProps<T extends TgphElement> = {
   value: string;
 } & Omit<TgphComponentProps<typeof Tag.Root<T>>, "as">;
 
-const TriggerTagRoot = <T extends TgphElement>(
+const TriggerTagRoot = <T extends TgphElement = "span">(
   triggerTagRootProps: TriggerTagRootProps<T>,
 ) => {
   const {
@@ -344,7 +344,7 @@ type TriggerTagTextProps<T extends TgphElement> = TgphComponentProps<
   typeof Tag.Text<T>
 >;
 
-const TriggerTagText = <T extends TgphElement>(
+const TriggerTagText = <T extends TgphElement = "span">(
   triggerTagTextProps: TriggerTagTextProps<T>,
 ) => {
   const { children, ...props } =
@@ -397,7 +397,7 @@ type TriggerTagButtonProps<T extends TgphElement> = TgphComponentProps<
   typeof Tag.Button<T>
 >;
 
-const TriggerTagButton = <T extends TgphElement>(
+const TriggerTagButton = <T extends TgphElement = "button">(
   triggerTagButtonProps: TriggerTagButtonProps<T>,
 ) => {
   const { children, ...props } =
@@ -448,7 +448,7 @@ type TriggerTagDefaultProps<T extends TgphElement> = TgphComponentProps<
   typeof TriggerTagRoot<T>
 >;
 
-const TriggerTagDefault = <T extends TgphElement>(
+const TriggerTagDefault = <T extends TgphElement = "span">(
   triggerTagDefaultProps: TriggerTagDefaultProps<T>,
 ) => {
   const { value, children, ...props } =

--- a/packages/combobox/src/Combobox/Combobox.test-d.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test-d.tsx
@@ -379,4 +379,12 @@ describe("Combobox types", () => {
     <Combobox.Primitives.TriggerTag.Button />;
     <Combobox.Primitives.TriggerTag.Default value="a" />;
   });
+
+  it("resolves Create at its default element", () => {
+    // The component took no default for its element parameter, so with no `as`
+    // it fell back to the constraint and the passthrough dropped native
+    // attributes. It renders a button.
+    <Combobox.Create type="submit" />;
+    <Combobox.Create as="a" href="/new" />;
+  });
 });

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -695,7 +695,12 @@ export type OptionProps<T extends TgphElement = "button"> = Omit<
   selected?: boolean | null;
 };
 
-const Option = <T extends TgphElement>(optionProps: OptionProps<T>) => {
+// `= "button"` matters: without a default, an absent `as` gives `T` no
+// inference candidate, so it falls back to the constraint. The element
+// passthrough then drops native attributes such as `type`.
+const Option = <T extends TgphElement = "button">(
+  optionProps: OptionProps<T>,
+) => {
   const {
     value,
     label,
@@ -1019,7 +1024,7 @@ export type EmptyProps<T extends TgphElement = "div"> = TgphComponentProps<
   message?: string | null;
 };
 
-const Empty = <T extends TgphElement>({
+const Empty = <T extends TgphElement = "div">({
   icon = { icon: SearchIcon, alt: "Search Icon" },
   message = "No results found",
   children,

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -1087,7 +1087,7 @@ export type CreateProps<
         legacyBehavior?: false;
       });
 
-const Create = <T extends TgphElement, LB extends boolean>({
+const Create = <T extends TgphElement = "button", LB extends boolean = false>({
   leadingText = "Create",
   values,
   onCreate,

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -695,9 +695,8 @@ export type OptionProps<T extends TgphElement = "button"> = Omit<
   selected?: boolean | null;
 };
 
-// `= "button"` matters: without a default, an absent `as` gives `T` no
-// inference candidate, so it falls back to the constraint. The element
-// passthrough then drops native attributes such as `type`.
+// Do not drop `= "button"`. Without it an absent `as` silently loses the
+// element's own attributes, so `type` stops type checking.
 const Option = <T extends TgphElement = "button">(
   optionProps: OptionProps<T>,
 ) => {

--- a/packages/icon/src/Spinner/Spinner.test-d.tsx
+++ b/packages/icon/src/Spinner/Spinner.test-d.tsx
@@ -1,7 +1,15 @@
 import { Spinner } from ".";
 import type { SpinnerProps } from ".";
 import { LoaderCircle } from "lucide-react";
+import { forwardRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
+
+// Stands in for `next/link`: takes `href` and renders an anchor.
+const RouterLink = forwardRef<
+  HTMLAnchorElement,
+  { href: string; children?: React.ReactNode }
+>(({ href, ...props }, ref) => <a href={href} ref={ref} {...props} />);
+RouterLink.displayName = "RouterLink";
 
 describe("Spinner types", () => {
   it("has no catch-all index signature", () => {
@@ -68,10 +76,17 @@ describe("Spinner types", () => {
     <Spinner />;
     <Spinner size="4" variant="secondary" color="accent" animation="spin" />;
     <Spinner icon={LoaderCircle} alt="Loading..." p="2" mt="4" bg="gray-2" />;
-    // `as` does not infer T (it sits behind `Partial<...>`), so it stays
-    // pinned to the "span" default rather than widening like Icon's does.
     <Spinner rounded="2" w="4" as="span" />;
     <Spinner className="c" style={{ opacity: 0.5 }} aria-label="loading" />;
     <Spinner data-testid="spinner" onClick={() => {}} />;
+  });
+
+  it("renders as another element", () => {
+    // `as` used to sit behind `Partial<...>`, a mapped type, so it could never
+    // infer `T` and stayed pinned to the "span" default.
+    <Spinner as="div" />;
+    <Spinner as={RouterLink} href="/loading" />;
+    // @ts-expect-error RouterLink requires href
+    <Spinner as={RouterLink} />;
   });
 });

--- a/packages/icon/src/Spinner/Spinner.tsx
+++ b/packages/icon/src/Spinner/Spinner.tsx
@@ -1,23 +1,31 @@
 import { type TgphElement } from "@telegraph/helpers";
-import { LoaderCircle } from "lucide-react";
+import { LoaderCircle, type LucideIcon } from "lucide-react";
 
 import { Icon, type IconBaseProps } from "../Icon";
 
-// `IconBaseProps`, not `IconProps`: Spinner supplies its own `alt`.
-type SpinnerProps<T extends TgphElement = "span"> = Partial<
-  IconBaseProps<T>
+// `IconBaseProps`, not `IconProps`: Spinner supplies its own `alt`. Only `icon`
+// is relaxed — a blanket `Partial` also made the rendered element's own
+// required props optional. `as` stays out of the `Omit` so `as={Component}`
+// can still resolve `T`.
+type SpinnerProps<T extends TgphElement = "span"> = Omit<
+  IconBaseProps<T>,
+  "as" | "icon"
 > & {
+  as?: T;
+  icon?: LucideIcon;
   alt?: string;
 };
 
-const Spinner = <T extends TgphElement = "span">(props: SpinnerProps<T>) => {
+const Spinner = <T extends TgphElement = "span">(
+  spinnerProps: SpinnerProps<T>,
+) => {
   const {
     color = "gray",
     icon = LoaderCircle,
     animation = "spin",
     alt = "Loading...",
     ...rest
-  } = props as SpinnerProps<"span">;
+  } = spinnerProps as SpinnerProps<"span">;
   return (
     <Icon
       color={color}

--- a/packages/input/src/Input/Input.tsx
+++ b/packages/input/src/Input/Input.tsx
@@ -164,7 +164,7 @@ const Default = <T extends TgphElement = "input">({
   const rootProps = props as RootProps<T>;
 
   return (
-    <Root<T> {...rootProps}>
+    <Root {...rootProps}>
       {LeadingComponent && <Slot position="leading">{LeadingComponent}</Slot>}
       {TrailingComponent && (
         <Slot position="trailing">{TrailingComponent}</Slot>

--- a/packages/menu/src/Menu/Menu.test-d.tsx
+++ b/packages/menu/src/Menu/Menu.test-d.tsx
@@ -163,15 +163,23 @@ describe("Menu types", () => {
   });
 
   it("renders a menu item as a link", () => {
-    // KNO-14480 Part 5. `MenuButtonItemProps` used bare `MenuItemProps`, whose
+    // KNO-14480. `MenuButtonItemProps` used bare `MenuItemProps`, whose
     // `as?: "button"` collapsed the element parameter to `"button"`.
     <Menu.Button as="a" href="/x" label="Docs" />;
     <Menu.Button as={RouterLink} href="/settings" label="Settings" />;
     <Menu.Button as="a" href="/x" target="_blank" rel="noreferrer" />;
   });
 
+  it("renders a submenu trigger as a link", () => {
+    // Same collapse as `Menu.Button` above, through `MenuSubTriggerItemProps`.
+    <Menu.SubTrigger as="a" href="/x" label="Docs" />;
+    <Menu.SubTrigger as={RouterLink} href="/settings" label="Settings" />;
+  });
+
   it("enforces the element's own required props", () => {
     // @ts-expect-error RouterLink requires href
     <Menu.Button as={RouterLink} label="Missing href" />;
+    // @ts-expect-error RouterLink requires href
+    <Menu.SubTrigger as={RouterLink} label="Missing href" />;
   });
 });

--- a/packages/menu/src/Menu/Menu.test-d.tsx
+++ b/packages/menu/src/Menu/Menu.test-d.tsx
@@ -8,7 +8,16 @@ import type {
   MenuSubProps,
   MenuSubTriggerProps,
 } from ".";
+import { forwardRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
+
+// Stands in for `next/link`: a component that takes `href` and renders an
+// anchor, which is the shape callers reach for on a menu item that navigates.
+const RouterLink = forwardRef<
+  HTMLAnchorElement,
+  { href: string; children?: React.ReactNode }
+>(({ href, ...props }, ref) => <a href={href} ref={ref} {...props} />);
+RouterLink.displayName = "RouterLink";
 
 describe("Menu types", () => {
   it("has no catch-all index signature", () => {
@@ -151,5 +160,18 @@ describe("Menu types", () => {
     </Menu.Root>;
     <Menu.Content as="section" forceMount skipAnimation />;
     <Menu.Divider as="div" my="2" data-testid="divider" />;
+  });
+
+  it("renders a menu item as a link", () => {
+    // KNO-14480 Part 5. `MenuButtonItemProps` used bare `MenuItemProps`, whose
+    // `as?: "button"` collapsed the element parameter to `"button"`.
+    <Menu.Button as="a" href="/x" label="Docs" />;
+    <Menu.Button as={RouterLink} href="/settings" label="Settings" />;
+    <Menu.Button as="a" href="/x" target="_blank" rel="noreferrer" />;
+  });
+
+  it("enforces the element's own required props", () => {
+    // @ts-expect-error RouterLink requires href
+    <Menu.Button as={RouterLink} label="Missing href" />;
   });
 });

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -113,6 +113,45 @@ describe("Menu", () => {
         spy.mockRestore();
       }
     });
+
+    it("renders a submenu trigger as an anchor without a Base UI nativeButton warning", async () => {
+      const errors: Array<unknown> = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation((...args) => errors.push(args[0]));
+
+      try {
+        render(
+          <Menu.Root defaultOpen>
+            <Menu.Trigger>
+              <button>Open</button>
+            </Menu.Trigger>
+            <Menu.Content>
+              <Menu.Sub>
+                <Menu.SubTrigger as="a" href="/share">
+                  Share
+                </Menu.SubTrigger>
+                <Menu.SubContent>
+                  <Menu.Button label="Copy link" />
+                </Menu.SubContent>
+              </Menu.Sub>
+            </Menu.Content>
+          </Menu.Root>,
+        );
+
+        const menu = await screen.findByRole("menu");
+        const anchor = menu.querySelector('a[href="/share"]');
+
+        expect(anchor).not.toBeNull();
+        expect(anchor).toHaveTextContent("Share");
+        expect(menu.querySelector("button")).toBeNull();
+        expect(
+          errors.filter((e) => String(e).includes("nativeButton")),
+        ).toHaveLength(0);
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe("type inheritance", () => {

--- a/packages/menu/src/Menu/Menu.test.tsx
+++ b/packages/menu/src/Menu/Menu.test.tsx
@@ -77,6 +77,44 @@ afterEach(() => {
 });
 
 describe("Menu", () => {
+  describe("as a link", () => {
+    it("renders the item as an anchor without a Base UI nativeButton warning", async () => {
+      const errors: Array<unknown> = [];
+      const spy = vi
+        .spyOn(console, "error")
+        .mockImplementation((...args) => errors.push(args[0]));
+
+      try {
+        render(
+          <Menu.Root defaultOpen>
+            <Menu.Trigger>
+              <button>Open</button>
+            </Menu.Trigger>
+            <Menu.Content>
+              <Menu.Button as="a" href="/docs">
+                Docs
+              </Menu.Button>
+            </Menu.Content>
+          </Menu.Root>,
+        );
+
+        const menu = await screen.findByRole("menu");
+        const anchor = menu.querySelector('a[href="/docs"]');
+
+        expect(anchor).not.toBeNull();
+        expect(anchor).toHaveTextContent("Docs");
+        expect(menu.querySelector("button")).toBeNull();
+
+        // Base UI reports an error when `nativeButton` disagrees with the tag.
+        expect(
+          errors.filter((e) => String(e).includes("nativeButton")),
+        ).toHaveLength(0);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
   describe("type inheritance", () => {
     it("accepts valid content-specific props", () => {
       const validProps: MenuContentProps = {

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -856,7 +856,7 @@ const Button = <T extends TgphElement = "button">({
       label={label}
       nativeButton={isNativeButton}
       render={createTgphBaseUIRender(
-        <MenuItem<T>
+        <MenuItem
           as={as}
           {...menuItemProps}
           onClick={handleClick as MenuItemProps<T>["onClick"]}
@@ -979,7 +979,7 @@ const SubTrigger = <T extends TgphElement = "button">({
       nativeButton={isNativeButton}
       openOnHover={openOnHover}
       render={createTgphBaseUIRender((state: MenuSubTriggerRenderState) => (
-        <MenuItem<T>
+        <MenuItem
           as={as}
           {...menuItemProps}
           onClick={handleClick as MenuItemProps<T>["onClick"]}

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -1,4 +1,5 @@
 import { Menu as BaseMenu } from "@base-ui/react/menu";
+import { rendersNativeButton } from "@telegraph/button";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type LegacyDismissEventHandler,
@@ -704,11 +705,8 @@ const Button = <T extends TgphElement = "button">({
   const combinedLeadingIcon = leadingIcon || icon;
   const itemRef = useRef<HTMLElement>(null);
   const menuItemProps = props as MenuItemProps<T>;
-  // Base UI reports an error when `nativeButton` disagrees with the tag that
-  // renders, so follow `Button.Root`, which renders a native button unless `as`
-  // says otherwise and forces one back when disabled. A caller rendering a
-  // component that resolves to a button can still say so explicitly.
-  const isNativeButton = nativeButton ?? (!!disabled || !as || as === "button");
+  // A caller rendering a component that resolves to a button can say so.
+  const isNativeButton = nativeButton ?? rendersNativeButton(as, disabled);
   // Keyboard selection can arrive through React keydown, native keyup/click, or
   // Base UI internals; these refs dedupe those paths while preserving cancel.
   const ignoreNextKeyboardClickRef = useRef(false);
@@ -962,8 +960,7 @@ const SubTrigger = <T extends TgphElement = "button">({
 }: SubTriggerProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
   const menuItemProps = props as MenuItemProps<T>;
-  // Follows the rendered tag, the way `Menu.Button` does.
-  const isNativeButton = nativeButton ?? (!!disabled || !as || as === "button");
+  const isNativeButton = nativeButton ?? rendersNativeButton(as, disabled);
   const combinedTrailingIcon: typeof trailingIcon =
     trailingIcon === undefined && trailingComponent === undefined
       ? { icon: ChevronRight, "aria-hidden": true }

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -923,7 +923,12 @@ const Sub = ({ children, onOpenChange, ...props }: SubProps) => {
   );
 };
 
-type MenuSubTriggerItemProps = Omit<MenuItemProps, "onClick" | "tgphRef">;
+// `MenuItemProps<T>` and omitting `as`, for the reason given on
+// `MenuButtonItemProps` above.
+type MenuSubTriggerItemProps<T extends TgphElement = "button"> = Omit<
+  MenuItemProps<T>,
+  "onClick" | "tgphRef" | "as"
+>;
 
 export type SubTriggerProps<T extends TgphElement = "button"> = Partial<
   Omit<
@@ -931,13 +936,14 @@ export type SubTriggerProps<T extends TgphElement = "button"> = Partial<
     "children" | "className" | "onClick" | "render" | "style"
   >
 > &
-  MenuSubTriggerItemProps & {
+  MenuSubTriggerItemProps<T> & {
     as?: T;
     onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
     tgphRef?: Ref<HTMLElement>;
   };
 
 const SubTrigger = <T extends TgphElement = "button">({
+  as,
   closeDelay,
   delay,
   disabled,
@@ -951,11 +957,13 @@ const SubTrigger = <T extends TgphElement = "button">({
   openOnHover,
   tgphRef,
   onClick,
-  nativeButton = true,
+  nativeButton,
   ...props
 }: SubTriggerProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
   const menuItemProps = props as MenuItemProps<T>;
+  // Follows the rendered tag, the way `Menu.Button` does.
+  const isNativeButton = nativeButton ?? (!!disabled || !as || as === "button");
   const combinedTrailingIcon: typeof trailingIcon =
     trailingIcon === undefined && trailingComponent === undefined
       ? { icon: ChevronRight, "aria-hidden": true }
@@ -971,10 +979,11 @@ const SubTrigger = <T extends TgphElement = "button">({
       delay={delay}
       disabled={disabled}
       label={label}
-      nativeButton={nativeButton}
+      nativeButton={isNativeButton}
       openOnHover={openOnHover}
       render={createTgphBaseUIRender((state: MenuSubTriggerRenderState) => (
         <MenuItem<T>
+          as={as}
           {...menuItemProps}
           onClick={handleClick as MenuItemProps<T>["onClick"]}
           leadingIcon={combinedLeadingIcon}

--- a/packages/menu/src/Menu/Menu.tsx
+++ b/packages/menu/src/Menu/Menu.tsx
@@ -654,9 +654,12 @@ const Content = <T extends TgphElement = "div">({
   );
 };
 
-type MenuButtonItemProps = Omit<
-  MenuItemProps,
-  "onClick" | "onKeyDown" | "tgphRef"
+// `MenuItemProps<T>`, not the bare form: bare `MenuItemProps` is
+// `MenuItemProps<"button">`, whose `as?: "button"` intersects the `as?: T`
+// below and collapses `T` to `"button"`, so `as={NextLink}` could never resolve.
+type MenuButtonItemProps<T extends TgphElement = "button"> = Omit<
+  MenuItemProps<T>,
+  "onClick" | "onKeyDown" | "tgphRef" | "as"
 >;
 
 export type ButtonProps<T extends TgphElement = "button"> = Partial<
@@ -671,7 +674,7 @@ export type ButtonProps<T extends TgphElement = "button"> = Partial<
     | "style"
   >
 > &
-  MenuButtonItemProps & {
+  MenuButtonItemProps<T> & {
     as?: T;
     onClick?: (event: ReactMouseEvent<HTMLElement>) => void;
     onKeyDown?: (event: MenuButtonKeyDownEvent) => void;
@@ -680,6 +683,7 @@ export type ButtonProps<T extends TgphElement = "button"> = Partial<
   };
 
 const Button = <T extends TgphElement = "button">({
+  as,
   closeOnClick,
   disabled,
   mx = "1",
@@ -694,12 +698,17 @@ const Button = <T extends TgphElement = "button">({
   onClick,
   onKeyDown,
   onSelect,
-  nativeButton = true,
+  nativeButton,
   ...props
 }: ButtonProps<T>) => {
   const combinedLeadingIcon = leadingIcon || icon;
   const itemRef = useRef<HTMLElement>(null);
   const menuItemProps = props as MenuItemProps<T>;
+  // Base UI reports an error when `nativeButton` disagrees with the tag that
+  // renders, so follow `Button.Root`, which renders a native button unless `as`
+  // says otherwise and forces one back when disabled. A caller rendering a
+  // component that resolves to a button can still say so explicitly.
+  const isNativeButton = nativeButton ?? (!!disabled || !as || as === "button");
   // Keyboard selection can arrive through React keydown, native keyup/click, or
   // Base UI internals; these refs dedupe those paths while preserving cancel.
   const ignoreNextKeyboardClickRef = useRef(false);
@@ -847,9 +856,10 @@ const Button = <T extends TgphElement = "button">({
       closeOnClick={closeOnClick}
       disabled={disabled}
       label={label}
-      nativeButton={nativeButton}
+      nativeButton={isNativeButton}
       render={createTgphBaseUIRender(
         <MenuItem<T>
+          as={as}
           {...menuItemProps}
           onClick={handleClick as MenuItemProps<T>["onClick"]}
           // `MenuItemProps<"button">`: `onKeyDown` reaches MenuItem only through

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test-d.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test-d.tsx
@@ -1,7 +1,15 @@
 import { SegmentedControl } from ".";
 import type { SegmentedControlOptionProps, SegmentedControlRootProps } from ".";
 import { AlignLeft } from "lucide-react";
+import { forwardRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
+
+// Stands in for `next/link`: takes `href` and renders an anchor.
+const RouterLink = forwardRef<
+  HTMLAnchorElement,
+  { href: string; children?: React.ReactNode }
+>(({ href, ...props }, ref) => <a href={href} ref={ref} {...props} />);
+RouterLink.displayName = "RouterLink";
 
 describe("SegmentedControl types", () => {
   it("has no catch-all index signature", () => {
@@ -125,5 +133,23 @@ describe("SegmentedControl types", () => {
     >
       <SegmentedControl.Option value="left">Left</SegmentedControl.Option>
     </SegmentedControl.Root>;
+  });
+
+  it("renders an option as a link", () => {
+    // KNO-14527. `OptionProps` read bare `ButtonProps`, whose `as?: "button"`
+    // collapsed the element parameter.
+    <SegmentedControl.Root>
+      <SegmentedControl.Option value="a" as="a" href="/x">
+        Docs
+      </SegmentedControl.Option>
+      <SegmentedControl.Option value="b" as={RouterLink} href="/y">
+        Settings
+      </SegmentedControl.Option>
+    </SegmentedControl.Root>;
+  });
+
+  it("enforces the element's own required props", () => {
+    // @ts-expect-error RouterLink requires href
+    <SegmentedControl.Option value="a" as={RouterLink} />;
   });
 });

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
@@ -28,6 +28,10 @@ const SegmentedControlFixture = ({
 };
 
 describe("SegmentedControl", () => {
+  beforeAll(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
   it("renders an option as an anchor without a Base UI nativeButton warning", () => {
     const errors: Array<unknown> = [];
     const spy = vi
@@ -58,8 +62,35 @@ describe("SegmentedControl", () => {
     }
   });
 
-  beforeAll(() => {
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  it("keeps a disabled option natively disabled when the root is disabled", () => {
+    const errors: Array<unknown> = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args) => errors.push(args[0]));
+
+    try {
+      // `Root`'s `disabled` makes `Button` render a native button whatever `as`
+      // says, so `nativeButton` has to account for it.
+      const { container } = render(
+        <SegmentedControl.Root defaultValue="docs" disabled>
+          <SegmentedControl.Option value="docs" as="a" href="/docs">
+            Docs
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>,
+      );
+
+      const button = container.querySelector("button");
+
+      expect(button).not.toBeNull();
+      // Base UI drops the native attribute when it is told the tag is not a
+      // button, which leaves `aria-disabled` as the only signal.
+      expect(button).toHaveAttribute("disabled");
+      expect(
+        errors.filter((e) => String(e).includes("nativeButton")),
+      ).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   afterAll(() => {

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.test.tsx
@@ -28,6 +28,36 @@ const SegmentedControlFixture = ({
 };
 
 describe("SegmentedControl", () => {
+  it("renders an option as an anchor without a Base UI nativeButton warning", () => {
+    const errors: Array<unknown> = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args) => errors.push(args[0]));
+
+    try {
+      const { container } = render(
+        <SegmentedControl.Root defaultValue="docs">
+          <SegmentedControl.Option value="docs" as="a" href="/docs">
+            Docs
+          </SegmentedControl.Option>
+        </SegmentedControl.Root>,
+      );
+
+      const anchor = container.querySelector('a[href="/docs"]');
+
+      expect(anchor).not.toBeNull();
+      expect(anchor).toHaveTextContent("Docs");
+      expect(container.querySelector("button")).toBeNull();
+
+      // Base UI reports an error when `nativeButton` disagrees with the tag.
+      expect(
+        errors.filter((e) => String(e).includes("nativeButton")),
+      ).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   beforeAll(() => {
     vi.stubGlobal("ResizeObserver", ResizeObserverMock);
   });

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -12,6 +12,7 @@ import {
 import { useComposedRefs } from "@telegraph/compose-refs";
 import {
   type RemappedOmit,
+  type TgphElement,
   createTgphBaseUIRender,
   useControllableState,
 } from "@telegraph/helpers";
@@ -458,16 +459,27 @@ const ButtonStyleProps: Record<SegmentedControlOptionStatus, ButtonRootProps> =
     },
   };
 
-export type OptionProps = Omit<ButtonProps, "value"> & {
+// `ButtonProps<T>`, not the bare form: bare `ButtonProps` is
+// `ButtonProps<"button">`, whose `as?: "button"` would pin the element and stop
+// `as={NextLink}` resolving.
+export type OptionProps<T extends TgphElement = "button"> = Omit<
+  ButtonProps<T>,
+  "value"
+> & {
   value: string;
 };
 
-type OptionButtonProps = Omit<OptionProps, "value"> & {
+// Pinned to the default element on purpose. Carrying an unresolved `T` through
+// the internals stacks mapped types over Button's icon union inside Base UI's
+// `render` callback, which takes package type-checking from seconds to minutes.
+// `Button.Root` reads its own props the same way.
+type OptionButtonProps = Omit<OptionProps<"button">, "value"> & {
   buttonRef: RefObject<HTMLButtonElement | null>;
   status: SegmentedControlOptionStatus;
 };
 
 const OptionButton = ({
+  as,
   buttonRef,
   disabled,
   size = "1",
@@ -494,6 +506,7 @@ const OptionButton = ({
 
   return (
     <Button
+      as={as}
       size={derivedSize}
       disabled={derivedDisabled}
       {...ButtonStyleProps[status]}
@@ -507,8 +520,8 @@ const OptionButton = ({
       // `RemappedOmit` distributes over Button's `icon`/`leadingIcon` union;
       // `Omit` would collapse it into one object where both sides look present.
       {...(props as RemappedOmit<
-        ButtonProps,
-        "size" | "disabled" | "style" | "tgphRef"
+        ButtonProps<"button">,
+        "as" | "size" | "disabled" | "style" | "tgphRef"
       >)}
       // Base UI's Toggle marks each option with `aria-pressed`, which reads as an
       // independent toggle. For single-select, present each option as a radio
@@ -528,15 +541,24 @@ const OptionButton = ({
   );
 };
 
-const Option = ({ value, disabled, ...props }: OptionProps) => {
+const Option = <T extends TgphElement = "button">(
+  optionProps: OptionProps<T>,
+) => {
+  const { as, value, disabled, ...props } =
+    optionProps as OptionProps<"button">;
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   return (
     <BaseToggle
       value={getBaseToggleValue(value)}
       disabled={disabled}
+      // Base UI reports an error when this disagrees with the tag that renders.
+      // `Button` renders a native button unless `as` says otherwise, and forces
+      // one back when disabled.
+      nativeButton={!!disabled || !as || as === "button"}
       render={createTgphBaseUIRender((state) => (
         <OptionButton
+          as={as}
           buttonRef={buttonRef}
           disabled={state.disabled || disabled}
           status={state.pressed ? "active" : "inactive"}

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   type ButtonProps,
   type ButtonRootProps,
+  rendersNativeButton,
 } from "@telegraph/button";
 import { useComposedRefs } from "@telegraph/compose-refs";
 import {
@@ -556,10 +557,7 @@ const Option = <T extends TgphElement = "button">(
     <BaseToggle
       value={getBaseToggleValue(value)}
       disabled={disabled}
-      // Base UI reports an error when this disagrees with the tag that renders.
-      // `Button` renders a native button unless `as` says otherwise, and forces
-      // one back when disabled.
-      nativeButton={isDisabled || !as || as === "button"}
+      nativeButton={rendersNativeButton(as, isDisabled)}
       render={createTgphBaseUIRender((state) => (
         <OptionButton
           as={as}

--- a/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/segmented-control/src/SegmentedControl/SegmentedControl.tsx
@@ -547,6 +547,10 @@ const Option = <T extends TgphElement = "button">(
   const { as, value, disabled, ...props } =
     optionProps as OptionProps<"button">;
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const { disabled: groupDisabled } = useContext(SegmentedControlContextState);
+  // `Root`'s `disabled` reaches `Button` through context, so it decides the
+  // rendered tag just as the option's own does.
+  const isDisabled = Boolean(groupDisabled || disabled);
 
   return (
     <BaseToggle
@@ -555,7 +559,7 @@ const Option = <T extends TgphElement = "button">(
       // Base UI reports an error when this disagrees with the tag that renders.
       // `Button` renders a native button unless `as` says otherwise, and forces
       // one back when disabled.
-      nativeButton={!!disabled || !as || as === "button"}
+      nativeButton={isDisabled || !as || as === "button"}
       render={createTgphBaseUIRender((state) => (
         <OptionButton
           as={as}

--- a/packages/select/src/Select/Select.test-d.tsx
+++ b/packages/select/src/Select/Select.test-d.tsx
@@ -1,7 +1,15 @@
 import { Select } from ".";
 import type { Option, OptionProps, SelectProps } from ".";
 import type { Dispatch, SetStateAction } from "react";
+import { forwardRef } from "react";
 import { describe, expectTypeOf, it } from "vitest";
+
+// Stands in for `next/link`: takes `href` and renders an anchor.
+const RouterLink = forwardRef<
+  HTMLAnchorElement,
+  { href: string; children?: React.ReactNode }
+>(({ href, ...props }, ref) => <a href={href} ref={ref} {...props} />);
+RouterLink.displayName = "RouterLink";
 
 // Declared at module scope: an initialized `const` would be narrowed by
 // control flow to the value it holds, which is not what a consumer's state
@@ -164,5 +172,14 @@ describe("Select types", () => {
     <Select.Option value="1" label="Option 1">
       <b>Option 1</b>
     </Select.Option>;
+  });
+
+  it("renders an option as another element", () => {
+    // `OptionProps` was the bare `ComboboxOptionProps`, which pins `as` to
+    // `"button"`, on a component that took no element parameter at all.
+    <Select.Option value="1" as="a" href="/one" />;
+    <Select.Option value="1" as={RouterLink} href="/one" />;
+    // @ts-expect-error RouterLink requires href
+    <Select.Option value="1" as={RouterLink} />;
   });
 });

--- a/packages/select/src/Select/Select.tsx
+++ b/packages/select/src/Select/Select.tsx
@@ -6,6 +6,7 @@ import {
   type ComboboxRootProps,
   type ComboboxTriggerProps,
 } from "@telegraph/combobox";
+import type { TgphElement } from "@telegraph/helpers";
 
 // `Select.Option` takes a string `value`, so a Select selects over a single
 // string or an array of them.
@@ -63,13 +64,20 @@ const Root = <V extends SelectValue = string>(rootProps: RootProps<V>) => {
   );
 };
 
-type OptionProps = ComboboxOptionProps;
+// Generic, so `as={NextLink}` resolves. The bare form is
+// `ComboboxOptionProps<"button">`, which pins `as` to `"button"`.
+type OptionProps<T extends TgphElement = "button"> = ComboboxOptionProps<T>;
 
 // `label` defaults to `children` but stays overridable, which is what Combobox
 // already does at runtime: it renders `label || children` and searches on the
 // same. Taking it explicitly rather than through the rest spread also stops an
 // explicit `label={undefined}` erasing the fallback.
-const Option = ({ value, label, children, ...props }: OptionProps) => {
+const Option = <T extends TgphElement = "button">(
+  optionProps: OptionProps<T>,
+) => {
+  const { value, label, children, ...props } =
+    optionProps as OptionProps<"button">;
+
   return <Combobox.Option value={value} label={label ?? children} {...props} />;
 };
 

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -64,7 +64,7 @@ const Tab = <T extends TgphElement = "button">(tabProps: TabProps<T>) => {
       nativeButton={nativeButton}
       render={createTgphBaseUIRender<BaseTabRenderProps, BaseTabState>(
         (state) => (
-          <MenuItem<T>
+          <MenuItem
             leadingIcon={combinedLeadingIcon}
             trailingIcon={combinedTrailingIcon}
             disabled={disabled}

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -1,4 +1,5 @@
 import { Tabs as BaseTabs } from "@base-ui/react/tabs";
+import { rendersNativeButton } from "@telegraph/button";
 import {
   type TgphComponentProps,
   type TgphElement,
@@ -53,9 +54,7 @@ const Tab = <T extends TgphElement = "button">(tabProps: TabProps<T>) => {
     ? ({ ...defaultIconProps, ...trailingIcon } as const)
     : undefined;
   const menuItemProps = props as TgphComponentProps<typeof MenuItem<T>>;
-  // Base UI renders a native button by default; only opt out when Telegraph's
-  // polymorphic `as` prop means MenuItem owns the element type.
-  const nativeButton = !props.as || props.as === "button";
+  const nativeButton = rendersNativeButton(props.as, disabled);
 
   return (
     <BaseTabs.Tab

--- a/packages/tabs/src/Tabs/Tabs.test.tsx
+++ b/packages/tabs/src/Tabs/Tabs.test.tsx
@@ -190,6 +190,40 @@ describe("Tabs", () => {
     expect(screen.getByRole("tabpanel")).toHaveTextContent("First panel");
   });
 
+  it("renders a disabled anchor tab without a Base UI nativeButton error", () => {
+    const errors: Array<unknown> = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((...args) => errors.push(args[0]));
+
+    try {
+      // `disabled` makes `Button` render a native button whatever `as` says, so
+      // `nativeButton` has to account for it or Base UI reports the mismatch.
+      const { container } = render(
+        <Tabs defaultValue="docs">
+          <Tabs.List>
+            <Tabs.Tab value="docs" as="a" href="/docs" disabled>
+              Docs
+            </Tabs.Tab>
+          </Tabs.List>
+        </Tabs>,
+      );
+
+      const tab = container.querySelector("[data-tgph-tab]");
+
+      expect(tab?.tagName).toBe("BUTTON");
+      // A tab stays focusable while disabled so arrow keys can still reach it,
+      // so Base UI marks it with `aria-disabled` rather than the native
+      // attribute. The mismatch only shows up in the console.
+      expect(tab).toHaveAttribute("aria-disabled", "true");
+      expect(
+        errors.filter((e) => String(e).includes("nativeButton")),
+      ).toHaveLength(0);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("activates tabs with arrow-key focus by default", async () => {
     const user = userEvent.setup();
 

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -192,7 +192,9 @@ const CopyButton = ({ onClick, textToCopy, ...props }: CopyButtonProps) => {
   );
 };
 
-const Button = <T extends TgphElement>({ ...props }: ButtonProps<T>) => {
+const Button = <T extends TgphElement = "button">({
+  ...props
+}: ButtonProps<T>) => {
   const context = useContext(TagContext);
   return (
     <TelegraphButton

--- a/packages/toggle/src/Toggle/Toggle.test-d.tsx
+++ b/packages/toggle/src/Toggle/Toggle.test-d.tsx
@@ -144,4 +144,10 @@ describe("Toggle types", () => {
     <Toggle.Default disabled required name="toggle" />;
     <Toggle.Switch className="c" style={{ opacity: 0.5 }} />;
   });
+
+  it("types the indicator at the element it renders", () => {
+    // It renders `Tag as={as || "label"}`, so the default element has to be
+    // `"label"` or props the rendered element accepts are rejected.
+    <Toggle.Indicator htmlFor="switch-id" />;
+  });
 });

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -268,14 +268,15 @@ const Label = <T extends TgphElement = "label">(labelProps: LabelProps<T>) => {
   );
 };
 
-export type IndicatorProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof Tag<T>
-> & {
-  enabledContent?: ReactNode;
-  disabledContent?: ReactNode;
-};
+// `= "label"`, matching the element it renders below. `"span"` rejected
+// props the rendered element accepts, such as `htmlFor`.
+export type IndicatorProps<T extends TgphElement = "label"> =
+  TgphComponentProps<typeof Tag<T>> & {
+    enabledContent?: ReactNode;
+    disabledContent?: ReactNode;
+  };
 
-const Indicator = <T extends TgphElement = "span">(
+const Indicator = <T extends TgphElement = "label">(
   indicatorProps: IndicatorProps<T>,
 ) => {
   const {
@@ -317,7 +318,7 @@ export type DefaultProps<T extends TgphElement = "div"> = RootProps<T> & {
   label?: ReactNode;
   labelProps?: Omit<LabelProps<"label">, "as">;
   indicator?: boolean;
-  indicatorProps?: Omit<IndicatorProps<"span">, "as">;
+  indicatorProps?: Omit<IndicatorProps<"label">, "as">;
 };
 
 const Default = <T extends TgphElement = "div">({
@@ -340,7 +341,7 @@ const Default = <T extends TgphElement = "div">({
         {indicator && (
           // `Omit` flattens Tag's discriminated `onRemove`/`onCopy` union, so
           // restore the original shape for the child.
-          <Indicator {...(indicatorProps as IndicatorProps<"span">)} />
+          <Indicator {...(indicatorProps as IndicatorProps<"label">)} />
         )}
         <Switch />
       </Stack>

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -331,7 +331,7 @@ const Default = <T extends TgphElement = "div">({
   const rootProps = props as RootProps<T>;
 
   return (
-    <Root<T> {...rootProps}>
+    <Root {...rootProps}>
       {label && (
         <Label as="label" {...labelProps}>
           {label}


### PR DESCRIPTION
Stacked on #925. Fourth of five.

## The problem

Seven polymorphic components rejected a component for `as`, so they could not render a router link.

```tsx
<Menu.Button as={NextLink} href="/settings">Settings</Menu.Button>
// Type 'ForwardRefExoticComponent<…>' is not assignable to type '"button"'.
```

Two causes. The element parameter collapsed: a bare `MenuItemProps` is `MenuItemProps<"button">`, and intersecting that with `as?: T` gives `as?: "button" & T`. Or the element default was absent or wrong, which left `T` at its constraint and dropped the element's native attributes.

A non-generic intermediate alias hides both from a pattern scan. I found them by compiling `<X as={RouterLink} href="/x" />` against every component instead.

## The solution

Give each one a real element parameter and a correct default.

Rendering a non-button then made a second defect visible. Base UI reports an error when its `nativeButton` prop disagrees with the tag that renders. Four wrappers derived that answer independently, and one had drifted.

## What is in this one

- `Menu.Button`, `Menu.SubTrigger`, `SegmentedControl.Option`, `Select.Option`, `Spinner`, `Combobox.Create` and `Toggle.Indicator` take a component for `as`
- `@telegraph/button` exports `rendersNativeButton(as, disabled)`, and `Button.Root`, `Menu.Button`, `Menu.SubTrigger`, `SegmentedControl.Option` and `Tabs.Tab` all read it
- `Tabs.Tab` stops reporting the wrong tag to Base UI when disabled, which was pre-existing
- `Spinner` enforces the rendered element's required props again

## Impact

**One behavior change.** Base UI treated anchor menu items as native buttons before, so Space did nothing. Space activates them now, which matches Enter and the WAI-ARIA menu pattern. The invalid `type="button"` on those anchors is gone. Control has 23 `Menu.Button as={Link}` call sites and all of their tests pass.

Only the public type is generic. Threading the element parameter through the internals as well type checks, and makes `segmented-control` take over 7 minutes to check.

Control sits at 342 errors against this build, with a baseline of 0 confirmed either side. I diff error sets rather than counts, because a count hid a relocated error twice on this work.

Resolves [KNO-14527](https://linear.app/knock/issue/KNO-14527/telegraph-menubutton-pins-its-element-to-button-so-asnextlink-cannot)
