### PR TITLE
chore(readme): update package READMEs for the prop-validation change

### DIFF
--- a/.changeset/plain-doors-tell.md
+++ b/.changeset/plain-doors-tell.md
@@ -14,7 +14,9 @@
 
 Update the READMEs for the prop-validation change.
 
-The `Popover.Content` and `Modal.Content` custom-animation examples passed `as={motion.div}`. Both components always render the animated element now, so the examples animate a child instead. Copying either one used to give a type error.
+The `Modal.Content` custom-animation example passed `as={motion.div}`. `Modal.Content` always renders the animated element now, so the example animates a child instead. Copying it used to give a type error.
+
+`Popover.Content` drops its custom-animation example. The props table and the `skipAnimation` example already cover turning the built-in animation off.
 
 `Modal.Body` no longer documents `flex`, and the Tabs root no longer documents `disabled`. Neither prop existed. The catch-all index signature hid that.
 

--- a/.changeset/plain-doors-tell.md
+++ b/.changeset/plain-doors-tell.md
@@ -1,0 +1,22 @@
+---
+"@telegraph/popover": patch
+"@telegraph/modal": patch
+"@telegraph/tabs": patch
+"@telegraph/menu": patch
+"@telegraph/segmented-control": patch
+"@telegraph/select": patch
+"@telegraph/tooltip": patch
+"@telegraph/input": patch
+"@telegraph/style-engine": patch
+"@telegraph/helpers": patch
+---
+
+Update the READMEs for the prop-validation change.
+
+The `Popover.Content` and `Modal.Content` custom-animation examples passed `as={motion.div}`. Both components always render the animated element now, so the examples animate a child instead. Copying either one used to give a type error.
+
+`Modal.Body` no longer documents `flex`, and the Tabs root no longer documents `disabled`. Neither prop existed. The catch-all index signature hid that.
+
+`Menu.Button` documents `as` and `nativeButton`. `SegmentedControl.Option` and `Select.Option` document `as`. `Select.Option` documents `label`.
+
+`@telegraph/helpers` gains a "Type checking" section covering the two cases that surprise people: a `data-*` key alone in a nested prop bag, and a `tgphRef` whose element type does not match. The README is the only prose that reaches an installed package, because no package publishes its changelog.

--- a/.changeset/plain-doors-tell.md
+++ b/.changeset/plain-doors-tell.md
@@ -9,6 +9,7 @@
 "@telegraph/input": patch
 "@telegraph/style-engine": patch
 "@telegraph/helpers": patch
+"@telegraph/textarea": patch
 ---
 
 Update the READMEs for the prop-validation change.
@@ -18,5 +19,7 @@ The `Popover.Content` and `Modal.Content` custom-animation examples passed `as={
 `Modal.Body` no longer documents `flex`, and the Tabs root no longer documents `disabled`. Neither prop existed. The catch-all index signature hid that.
 
 `Menu.Button` documents `as` and `nativeButton`. `SegmentedControl.Option` and `Select.Option` document `as`. `Select.Option` documents `label`.
+
+The `@telegraph/textarea` README documented seven props that do not exist: `autoResize`, `minRows`, `maxRows`, `showCharacterCount`, `state`, `errorMessage` and `helperText`. Roughly half its examples were built around them. It also gave `size` two values outside the scale, and the wrong default for `size` and `resize`. The README now documents the real component, and every example in it compiles.
 
 `@telegraph/helpers` gains a "Type checking" section covering the two cases that surprise people: a `data-*` key alone in a nested prop bag, and a `tgphRef` whose element type does not match. The README is the only prose that reaches an installed package, because no package publishes its changelog.

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -21,14 +21,14 @@ npm install @telegraph/helpers
 ```tsx
 import { Button } from "@telegraph/button";
 import {
-  callLegacyDismissHandlers,
-  getBaseUIMotionOffset,
   PolymorphicProps,
   RefToTgphRef,
   TgphElement,
   TgphSlot,
   VisuallyHidden,
+  callLegacyDismissHandlers,
   createTgphBaseUIRender,
+  getBaseUIMotionOffset,
   useControllableState,
   useDeterminateState,
 } from "@telegraph/helpers";
@@ -161,7 +161,13 @@ type BaseProps = AsProp<React.ElementType> & {
 
 #### `PolymorphicProps<E>`
 
-Complete props type for polymorphic components.
+Props type for polymorphic components. It declares `as`, `children`,
+`className` and `style`, and adds the props of the element `E` renders.
+
+The element props are dropped when `E` is unresolved. An unresolved `E` is the
+whole `React.ElementType` union, and `Omit<ComponentProps<ElementType>, "as">`
+is `{ [x: string]: any }`. That index signature turns off prop checking on
+every component that inherits it. See the "Type checking" section below.
 
 ```tsx
 import { PolymorphicProps, TgphElement } from "@telegraph/helpers";
@@ -725,6 +731,40 @@ type ConditionalProps<T extends TgphElement> = PolymorphicProps<T> &
 4. **Implement `useDeterminateState` for loading states**: Improves UX with minimum durations
 5. **Type polymorphic components properly**: Use appropriate helper types
 6. **Test type constraints**: Verify TypeScript catches errors correctly
+
+## Type checking
+
+Telegraph components reject props they do not declare. Two cases surprise
+people, so they are written out here.
+
+### A `data-*` key alone in a nested prop bag
+
+JSX exempts hyphenated **attributes** from excess-property checks, so setting
+one on a component always works. An object literal gets no such exemption, and
+several Telegraph components take nested prop bags such as `textProps`.
+
+Two different checks apply. A fresh object literal gets excess-property
+checking. A variable does not, but it hits weak-type detection when it shares
+no property with an all-optional target.
+
+```tsx
+const dataAttrs = { "data-testid": "x" };
+const bag = { size: "2" as const, "data-testid": "x" };
+
+<Input data-testid="x" />                                // fine, an attribute
+<Input textProps={{ size: "2", "data-testid": "x" }} />  // fails, fresh literal
+<Input textProps={{ size: "2", ...dataAttrs }} />        // fine, spreads are exempt
+<Input textProps={bag} />                                // fine, not fresh
+<Input textProps={{ ...dataAttrs }} />                   // fails, nothing in common
+```
+
+Any bag that carries one real prop passes either check.
+
+### `tgphRef` must match the element
+
+`tgphRef` is no longer typed as `any`. A ref whose element type does not match
+what the component renders is an error. `Combobox.Trigger` renders a `button`,
+so a `RefObject<HTMLDivElement>` on it now fails.
 
 ## References
 

--- a/packages/helpers/src/types/utility.ts
+++ b/packages/helpers/src/types/utility.ts
@@ -64,17 +64,17 @@ type PolymorphicPassthroughProps<E extends React.ElementType> =
 // The `PolymorphicProps` type is a utility type that allows you to create a
 // component that can be used as a button, link, or any other element via
 // the `as` prop. It takes a generic type `E` that extends `React.ElementType`.
-// It returns a type that includes the `as` prop and all the props of the
-// underlying element type `E`.
+// It returns a type that includes the `as` prop and the props of the underlying
+// element type `E`, minus the passthrough when `E` is unresolved.
 export type PolymorphicProps<E extends React.ElementType> =
   PolymorphicPassthroughProps<E> & PolymorphicBaseProps<E>;
 
 // The `PolymorphicPropsWithTgphRef` type is a utility type that allows you to create a
 // component that can be used as a button, link, or any other element via
 // the `as` prop. It takes a generic type `E` that extends `React.ElementType`.
-// It returns a type that includes the `as` prop and all the props of the
-// underlying element type `E`. It also includes a `tgpRef` prop that allows you to
-// pass a ref to the component.
+// It returns `PolymorphicProps<E>` plus a `tgphRef` prop that allows you to
+// pass a ref to the component. `R` is the element the ref points at, so a
+// mismatched ref type is an error.
 export type PolymorphicPropsWithTgphRef<
   E extends React.ElementType,
   R extends HTMLElement | React.ElementType,

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -86,7 +86,9 @@ Container component that wraps the input and slots.
 #### `<Input.Slot>`
 
 Wrapper for leading and trailing components. Props passed to `Input.Slot` are
-merged into its single child, and refs are forwarded to that child.
+merged into its single child, and refs are forwarded to that child. The slot
+accepts `span` attributes plus `position` and `size`. Set props that belong to
+the child on the child itself.
 
 | Prop       | Type                      | Default     | Description          |
 | ---------- | ------------------------- | ----------- | -------------------- |

--- a/packages/menu/README.md
+++ b/packages/menu/README.md
@@ -115,17 +115,19 @@ above modal overlays and other lower layering surfaces.
 
 Individual menu item that can be clicked or selected.
 
-| Prop                   | Type                          | Default     | Description                  |
-| ---------------------- | ----------------------------- | ----------- | ---------------------------- |
-| `children`             | `React.ReactNode`             | required    | Button label                 |
-| `leadingIcon` / `icon` | `IconProps`                   | `undefined` | Icon before text             |
-| `trailingIcon`         | `IconProps`                   | `undefined` | Icon after text              |
-| `leadingComponent`     | `React.ReactNode`             | `undefined` | Custom component before text |
-| `trailingComponent`    | `React.ReactNode`             | `undefined` | Custom component after text  |
-| `selected`             | `boolean`                     | `false`     | Whether item is selected     |
-| `disabled`             | `boolean`                     | `false`     | Whether item is disabled     |
-| `color`                | `"gray" \| "accent" \| "red"` | `"gray"`    | Button color theme           |
-| `onClick`              | `() => void`                  | `undefined` | Click handler                |
+| Prop                   | Type                          | Default      | Description                                   |
+| ---------------------- | ----------------------------- | ------------ | --------------------------------------------- |
+| `children`             | `React.ReactNode`             | required     | Button label                                  |
+| `leadingIcon` / `icon` | `IconProps`                   | `undefined`  | Icon before text                              |
+| `trailingIcon`         | `IconProps`                   | `undefined`  | Icon after text                               |
+| `leadingComponent`     | `React.ReactNode`             | `undefined`  | Custom component before text                  |
+| `trailingComponent`    | `React.ReactNode`             | `undefined`  | Custom component after text                   |
+| `selected`             | `boolean`                     | `false`      | Whether item is selected                      |
+| `disabled`             | `boolean`                     | `false`      | Whether item is disabled                      |
+| `color`                | `"gray" \| "accent" \| "red"` | `"gray"`     | Button color theme                            |
+| `onClick`              | `() => void`                  | `undefined`  | Click handler                                 |
+| `as`                   | `TgphElement`                 | `"button"`   | Element or component to render                |
+| `nativeButton`         | `boolean`                     | follows `as` | Tells Base UI whether a native button renders |
 
 Inherits all Button props for additional styling.
 

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -325,7 +325,7 @@ const FullScreenModal = ({ open, onClose, children }) => (
         <Modal.Close />
       </Modal.Header>
 
-      <Modal.Body flex="1">{children}</Modal.Body>
+      <Modal.Body>{children}</Modal.Body>
     </Modal.Content>
   </Modal.Root>
 );
@@ -516,22 +516,23 @@ const LoadingModal = ({ open, onClose }) => {
 import { Modal } from "@telegraph/modal";
 import { motion } from "motion/react";
 
+// `Modal.Content` always renders the animated element. Animate a child instead.
 const AnimatedModal = ({ open, onClose }) => (
   <Modal.Root open={open} onOpenChange={onClose} a11yTitle="Animated Modal">
-    <Modal.Content
-      as={motion.div}
-      initial={{ scale: 0.8, opacity: 0 }}
-      animate={{ scale: 1, opacity: 1 }}
-      exit={{ scale: 0.8, opacity: 0 }}
-      transition={{ duration: 0.2 }}
-    >
+    <Modal.Content>
       <Modal.Header>
         <Modal.Heading>Animated Modal</Modal.Heading>
         <Modal.Close />
       </Modal.Header>
 
       <Modal.Body>
-        <p>This modal has custom animations.</p>
+        <motion.div
+          initial={{ scale: 0.8, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.2 }}
+        >
+          <p>This modal has custom animations.</p>
+        </motion.div>
       </Modal.Body>
     </Modal.Content>
   </Modal.Root>

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -520,33 +520,6 @@ const OptimizedPopover = ({ data }) => {
 };
 ```
 
-### Popover with Custom Animation
-
-```tsx
-import { Button } from "@telegraph/button";
-import { Popover } from "@telegraph/popover";
-import { motion } from "motion/react";
-
-<Popover.Root>
-  <Popover.Trigger>
-    <Button>Custom Animation</Button>
-  </Popover.Trigger>
-
-  {/* `Popover.Content` always renders the animated element, so turn off the
-      built-in animation and animate a child instead. */}
-  <Popover.Content skipAnimation>
-    <motion.div
-      initial={{ opacity: 0, rotateX: -90 }}
-      animate={{ opacity: 1, rotateX: 0 }}
-      exit={{ opacity: 0, rotateX: -90 }}
-      transition={{ duration: 0.3 }}
-    >
-      <p>Custom animated content</p>
-    </motion.div>
-  </Popover.Content>
-</Popover.Root>;
-```
-
 ## Design Tokens & Styling
 
 The popover component uses Telegraph design tokens for consistent styling:

--- a/packages/popover/README.md
+++ b/packages/popover/README.md
@@ -532,15 +532,17 @@ import { motion } from "motion/react";
     <Button>Custom Animation</Button>
   </Popover.Trigger>
 
-  <Popover.Content
-    as={motion.div}
-    skipAnimation={true} // Skip built-in animation
-    initial={{ opacity: 0, rotateX: -90 }}
-    animate={{ opacity: 1, rotateX: 0 }}
-    exit={{ opacity: 0, rotateX: -90 }}
-    transition={{ duration: 0.3 }}
-  >
-    <p>Custom animated content</p>
+  {/* `Popover.Content` always renders the animated element, so turn off the
+      built-in animation and animate a child instead. */}
+  <Popover.Content skipAnimation>
+    <motion.div
+      initial={{ opacity: 0, rotateX: -90 }}
+      animate={{ opacity: 1, rotateX: 0 }}
+      exit={{ opacity: 0, rotateX: -90 }}
+      transition={{ duration: 0.3 }}
+    >
+      <p>Custom animated content</p>
+    </motion.div>
   </Popover.Content>
 </Popover.Root>;
 ```

--- a/packages/segmented-control/README.md
+++ b/packages/segmented-control/README.md
@@ -78,12 +78,13 @@ the same scroll-button behavior.
 
 Individual option button within the segmented control.
 
-| Prop       | Type                       | Default | Description                       |
-| ---------- | -------------------------- | ------- | --------------------------------- |
-| `value`    | `string`                   | -       | Unique identifier for this option |
-| `disabled` | `boolean`                  | `false` | Disable this specific option      |
-| `size`     | `"0" \| "1" \| "2" \| "3"` | `"1"`   | Button size                       |
-| `children` | `ReactNode`                | -       | Content of the option             |
+| Prop       | Type                       | Default    | Description                       |
+| ---------- | -------------------------- | ---------- | --------------------------------- |
+| `value`    | `string`                   | -          | Unique identifier for this option |
+| `disabled` | `boolean`                  | `false`    | Disable this specific option      |
+| `size`     | `"0" \| "1" \| "2" \| "3"` | `"1"`      | Button size                       |
+| `children` | `ReactNode`                | -          | Content of the option             |
+| `as`       | `TgphElement`              | `"button"` | Element or component to render    |
 
 ## Usage Patterns
 

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -75,10 +75,15 @@ Select is a lightweight wrapper around `@telegraph/combobox`. It inherits the
 migrated Combobox popup, portal, focus, and dismissal behavior, which is backed
 by Base UI through Telegraph primitives.
 
-The public Select API remains unchanged. Single-select usage closes after
-selection, while multi-select usage stays open; this behavior is inferred from
-whether `value` or `defaultValue` is an array. `triggerProps`, `contentProps`,
-and `optionsProps` continue to pass through to the underlying Combobox parts.
+`Select.Root` is generic over its value. `value` and `defaultValue` accept a
+string or an array of strings, which matches what `Select.Option` produces, and
+`onValueChange` narrows to the same type. `legacyBehavior` is no longer
+accepted. Use `Combobox` directly for option objects.
+
+Single-select usage closes after selection, while multi-select usage stays open.
+Telegraph infers this from whether `value` or `defaultValue` is an array.
+`triggerProps`, `contentProps`, and `optionsProps` continue to pass through to
+the underlying Combobox parts.
 
 Select does not depend on Radix directly.
 
@@ -103,11 +108,13 @@ The main select container component.
 
 Individual option within the select dropdown.
 
-| Prop       | Type        | Default | Description                         |
-| ---------- | ----------- | ------- | ----------------------------------- |
-| `value`    | `string`    | -       | Unique value for this option        |
-| `disabled` | `boolean`   | `false` | Whether this option is disabled     |
-| `children` | `ReactNode` | -       | Display text/content for the option |
+| Prop       | Type          | Default    | Description                                      |
+| ---------- | ------------- | ---------- | ------------------------------------------------ |
+| `value`    | `string`      | -          | Unique value for this option                     |
+| `disabled` | `boolean`     | `false`    | Whether this option is disabled                  |
+| `children` | `ReactNode`   | -          | Display text/content for the option              |
+| `label`    | `string`      | `children` | Plain-text label used for search and the trigger |
+| `as`       | `TgphElement` | `"button"` | Element or component to render                   |
 
 ## Usage Patterns
 

--- a/packages/style-engine/README.md
+++ b/packages/style-engine/README.md
@@ -100,7 +100,7 @@ Core function that processes style props and returns CSS variables.
 
 ```tsx
 {
-  styleProp: Record<string, string>; // CSS custom properties (including pseudo-class vars)
+  styleProp: CSSPropertiesWithVars & Partial<Record<string, string>>; // CSS custom properties (including pseudo-class vars)
   otherProps: Record<string, unknown>; // Non-style props (including unmatched pseudo sub-props)
   interactive: boolean; // Whether pseudo-class props were resolved (for scoping CSS rules)
 }

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -84,14 +84,13 @@ current/default value no longer matches a rendered tab.
 
 The root container component that provides tab state management and context.
 
-| Prop            | Type                              | Default        | Description                                   |
-| --------------- | --------------------------------- | -------------- | --------------------------------------------- |
-| `defaultValue`  | `string`                          | `undefined`    | ID of the initially active tab (uncontrolled) |
-| `value`         | `string`                          | `undefined`    | Currently active tab ID (controlled)          |
-| `onValueChange` | `(value: string) => void`         | `undefined`    | Called when the active tab changes            |
-| `disabled`      | `boolean`                         | `false`        | Disables all tabs when true                   |
-| `orientation`   | `"horizontal" \| "vertical"`      | `"horizontal"` | Layout orientation                            |
-| `dir`           | `"ltr" \| "rtl"`                  | `"ltr"`        | Text direction                                |
+| Prop            | Type                         | Default        | Description                                   |
+| --------------- | ---------------------------- | -------------- | --------------------------------------------- |
+| `defaultValue`  | `string`                     | `undefined`    | ID of the initially active tab (uncontrolled) |
+| `value`         | `string`                     | `undefined`    | Currently active tab ID (controlled)          |
+| `onValueChange` | `(value: string) => void`    | `undefined`    | Called when the active tab changes            |
+| `orientation`   | `"horizontal" \| "vertical"` | `"horizontal"` | Layout orientation                            |
+| `dir`           | `"ltr" \| "rtl"`             | `"ltr"`        | Text direction                                |
 
 ### `<Tabs.List>`
 

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -1,6 +1,6 @@
 # 📝 TextArea
 
-> Multi-line text input component with auto-resize, character counting, and form integration capabilities.
+> Multi-line text input component built on Telegraph's `Text` primitive.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -44,11 +44,10 @@ export const CommentBox = () => {
   return (
     <TextArea
       value={comment}
-      onChange={(e) => setComment(e.target.value)}
+      onChange={(event) => setComment(event.target.value)}
       placeholder="Share your thoughts..."
       maxLength={500}
-      showCharacterCount
-      autoResize
+      rows={4}
     />
   );
 };
@@ -58,414 +57,173 @@ export const CommentBox = () => {
 
 ### `<TextArea>`
 
-The main textarea component with enhanced features for multi-line text input.
+Renders a `textarea` through Telegraph's `Text` component, so it takes the
+typography and layout style props as well.
 
-| Prop                 | Type                                             | Default      | Description                                      |
-| -------------------- | ------------------------------------------------ | ------------ | ------------------------------------------------ |
-| `size`               | `"0" \| "1" \| "2" \| "3" \| "4"`                | `"1"`        | Size of the textarea                             |
-| `variant`            | `"ghost" \| "outline"`                           | `"outline"`  | Visual style variant                             |
-| `autoResize`         | `boolean`                                        | `false`      | Automatically adjust height based on content     |
-| `minRows`            | `number`                                         | `3`          | Minimum number of visible rows                   |
-| `maxRows`            | `number`                                         | `undefined`  | Maximum number of visible rows (for auto-resize) |
-| `showCharacterCount` | `boolean`                                        | `false`      | Display character count indicator                |
-| `maxLength`          | `number`                                         | `undefined`  | Maximum allowed characters                       |
-| `resize`             | `"none" \| "vertical" \| "horizontal" \| "both"` | `"vertical"` | CSS resize behavior                              |
-| `state`              | `"default" \| "error" \| "success"`              | `"default"`  | Validation state                                 |
-| `errorMessage`       | `string`                                         | `undefined`  | Error message to display                         |
-| `helperText`         | `string`                                         | `undefined`  | Helper text to display                           |
+| Prop        | Type                                             | Default     | Description                             |
+| ----------- | ------------------------------------------------ | ----------- | --------------------------------------- |
+| `size`      | `"1" \| "2" \| "3"`                              | `"2"`       | Padding, font size and corner radius    |
+| `variant`   | `"outline" \| "ghost"`                           | `"outline"` | Visual style                            |
+| `resize`    | `"both" \| "vertical" \| "horizontal" \| "none"` | `"both"`    | CSS resize behavior                     |
+| `errored`   | `boolean`                                        | `false`     | Applies the error styling               |
+| `disabled`  | `boolean`                                        | `false`     | Disables the textarea                   |
+| `textProps` | `TextProps<"textarea">`                          | `undefined` | Props merged onto the underlying `Text` |
+| `tgphRef`   | `Ref<HTMLTextAreaElement>`                       | `undefined` | Ref to the textarea element             |
 
-All standard HTML textarea attributes are also supported (value, onChange, placeholder, disabled, etc.).
+It also accepts every `textarea` attribute (`value`, `onChange`, `placeholder`,
+`rows`, `maxLength`, `name`, `required`, `readOnly`) and every `Text` style prop
+(`w`, `p`, `bg`, `rounded`, and the rest).
+
+`TextArea` does not resize itself, count characters, or render helper and error
+text. Compose those around it.
 
 ## Usage Patterns
 
-### Basic Textarea
+### Sizes
 
 ```tsx
 import { TextArea } from "@telegraph/textarea";
 
-export const BasicExample = () => (
-  <TextArea placeholder="Enter your message..." rows={4} />
+export const Sizes = () => (
+  <>
+    <TextArea size="1" placeholder="Size 1" />
+    <TextArea size="2" placeholder="Size 2" />
+    <TextArea size="3" placeholder="Size 3" />
+  </>
 );
 ```
 
-### Different Sizes
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-
-export const SizedTextAreas = () => (
-  <div>
-    <TextArea size="0" placeholder="Small textarea" />
-    <TextArea size="1" placeholder="Medium textarea" />
-    <TextArea size="2" placeholder="Large textarea" />
-  </div>
-);
-```
-
-### With Character Limit
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-import { useState } from "react";
-
-export const CharacterLimit = () => {
-  const [value, setValue] = useState("");
-
-  return (
-    <TextArea
-      value={value}
-      onChange={(e) => setValue(e.target.value)}
-      placeholder="Write a tweet..."
-      maxLength={280}
-      showCharacterCount
-    />
-  );
-};
-```
-
-### Auto-resize
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-
-export const AutoResizeExample = () => (
-  <TextArea
-    autoResize
-    minRows={2}
-    maxRows={10}
-    placeholder="This textarea will grow as you type..."
-  />
-);
-```
-
-### Validation States
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-
-export const ValidationStates = () => (
-  <div>
-    <TextArea
-      state="error"
-      errorMessage="This field is required"
-      placeholder="Error state"
-    />
-
-    <TextArea
-      state="success"
-      helperText="Looks good!"
-      placeholder="Success state"
-    />
-  </div>
-);
-```
-
-### Different Variants
+### Variants
 
 ```tsx
 import { TextArea } from "@telegraph/textarea";
 
 export const Variants = () => (
-  <div>
+  <>
     <TextArea variant="outline" placeholder="Outline variant" />
     <TextArea variant="ghost" placeholder="Ghost variant" />
-  </div>
+  </>
 );
 ```
 
-## Advanced Usage
+### Disabled and errored
 
-### Form Integration
+```tsx
+import { TextArea } from "@telegraph/textarea";
+
+export const States = () => (
+  <>
+    <TextArea placeholder="Default state" />
+    <TextArea placeholder="Disabled state" disabled />
+    <TextArea placeholder="Error state" errored />
+  </>
+);
+```
+
+`errored` styles the control. It does not render a message. Render your own
+message next to the textarea and link it with `aria-describedby`.
+
+### Resize behavior
+
+```tsx
+import { TextArea } from "@telegraph/textarea";
+
+export const Resize = () => (
+  <>
+    <TextArea resize="vertical" placeholder="Vertical only" />
+    <TextArea resize="none" placeholder="Fixed size" rows={6} />
+  </>
+);
+```
+
+### Style props
+
+```tsx
+import { TextArea } from "@telegraph/textarea";
+
+export const Styled = () => (
+  <TextArea w="full" p="3" rounded="3" placeholder="Full width" />
+);
+```
+
+### `textProps`
+
+Use `textProps` to reach the underlying `Text` when a prop would otherwise
+collide with one of TextArea's own.
+
+```tsx
+import { TextArea } from "@telegraph/textarea";
+
+export const WithTextProps = () => (
+  <TextArea textProps={{ placeholder: "Set through the bag", color: "gray" }} />
+);
+```
+
+A `data-*` key inside `textProps` is an object literal, so it fails
+excess-property checking. Set it on the component instead.
+
+### Form integration
 
 ```tsx
 import { TextArea } from "@telegraph/textarea";
 import { Controller, useForm } from "react-hook-form";
 
-type FormData = {
-  description: string;
-  notes: string;
-};
+type FormData = { description: string };
 
 export const FormExample = () => {
-  const {
-    control,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<FormData>();
+  const { control, handleSubmit } = useForm<FormData>();
 
   return (
     <form onSubmit={handleSubmit(console.log)}>
-      <div>
-        <label htmlFor="description">Description</label>
-        <Controller
-          name="description"
-          control={control}
-          rules={{
-            required: "Description is required",
-            minLength: { value: 10, message: "Minimum 10 characters" },
-          }}
-          render={({ field, fieldState }) => (
+      <label htmlFor="description">Description</label>
+      <Controller
+        name="description"
+        control={control}
+        rules={{ required: "Description is required" }}
+        render={({ field, fieldState }) => (
+          <>
             <TextArea
               {...field}
-              state={fieldState.error ? "error" : "default"}
-              errorMessage={fieldState.error?.message}
+              id="description"
+              errored={Boolean(fieldState.error)}
+              aria-describedby={
+                fieldState.error ? "description-error" : undefined
+              }
               placeholder="Describe your project..."
               maxLength={1000}
-              showCharacterCount
-              autoResize
             />
-          )}
-        />
-      </div>
-
-      <div>
-        <label htmlFor="notes">Additional Notes</label>
-        <Controller
-          name="notes"
-          control={control}
-          render={({ field }) => (
-            <TextArea
-              {...field}
-              placeholder="Any additional notes (optional)"
-              variant="ghost"
-              maxLength={500}
-              showCharacterCount
-            />
-          )}
-        />
-      </div>
-
+            {fieldState.error && (
+              <span id="description-error">{fieldState.error.message}</span>
+            )}
+          </>
+        )}
+      />
       <button type="submit">Submit</button>
     </form>
   );
 };
 ```
 
+## Data attributes
+
+`TextArea` sets these for styling and for tests.
+
+| Attribute                    | Values                                         |
+| ---------------------------- | ---------------------------------------------- |
+| `data-tgph-textarea`         | present                                        |
+| `data-tgph-textarea-state`   | `default` \| `disabled` \| `error`             |
+| `data-tgph-textarea-variant` | `outline` \| `ghost`                           |
+| `data-tgph-textarea-size`    | `1` \| `2` \| `3`                              |
+| `data-tgph-textarea-resize`  | `both` \| `vertical` \| `horizontal` \| `none` |
+
 ## Accessibility
 
-- ✅ **Keyboard Navigation**: Full keyboard support for text input and navigation
-- ✅ **Screen Reader Support**: Proper labeling and error announcement
-- ✅ **Focus Management**: Clear focus indicators and logical tab order
-- ✅ **High Contrast**: Compatible with high contrast modes
-- ✅ **Error Handling**: Clear error states and validation messages
+`TextArea` renders a native `textarea`, so keyboard behavior, screen reader
+support and focus order come from the browser.
 
-### Keyboard Shortcuts
+Label it, because the component does not label itself. Use a `label` with
+`htmlFor`, or `aria-label`.
 
-| Key            | Action                          |
-| -------------- | ------------------------------- |
-| `Tab`          | Move focus to/from the textarea |
-| `Enter`        | Insert new line                 |
-| `Ctrl/Cmd + A` | Select all text                 |
-| `Ctrl/Cmd + Z` | Undo last action                |
-| `Ctrl/Cmd + Y` | Redo last action                |
-
-### ARIA Attributes
-
-- `aria-label` or `aria-labelledby` - Associates labels with textarea
-- `aria-describedby` - Links help text and error messages
-- `aria-invalid` - Indicates validation state
-- `role="textbox"` - Explicitly identifies as text input
-- `aria-multiline="true"` - Indicates multi-line input
-
-### Best Practices
-
-1. **Provide Clear Labels**: Always include accessible labels for textareas
-2. **Error Messaging**: Use clear, specific error messages
-3. **Helper Text**: Provide helpful guidance about expected input
-4. **Character Limits**: Clearly communicate length restrictions
-5. **Auto-resize Limits**: Set reasonable min/max bounds for auto-resize
-
-## Examples
-
-### Basic Example
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-
-export const FeedbackForm = () => (
-  <div>
-    <label htmlFor="feedback">Your Feedback</label>
-    <TextArea
-      id="feedback"
-      placeholder="Tell us what you think..."
-      rows={4}
-      maxLength={1000}
-      showCharacterCount
-    />
-  </div>
-);
-```
-
-### Advanced Example
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-import { useState } from "react";
-
-export const BlogPostEditor = () => {
-  const [content, setContent] = useState("");
-  const [isDraft, setIsDraft] = useState(true);
-
-  const handleSave = () => {
-    // Save logic here
-    console.log("Saving:", content);
-  };
-
-  const handlePublish = () => {
-    setIsDraft(false);
-    // Publish logic here
-    console.log("Publishing:", content);
-  };
-
-  return (
-    <div className="blog-editor">
-      <div className="editor-header">
-        <h2>Write your blog post</h2>
-        <div className="status">Status: {isDraft ? "Draft" : "Published"}</div>
-      </div>
-
-      <TextArea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="Start writing your blog post..."
-        autoResize
-        minRows={10}
-        maxRows={30}
-        showCharacterCount
-        helperText="Write in markdown format. Use **bold** and *italic* for formatting."
-      />
-
-      <div className="editor-actions">
-        <button onClick={handleSave} disabled={!content}>
-          Save Draft
-        </button>
-        <button
-          onClick={handlePublish}
-          disabled={!content || content.length < 100}
-          className="primary"
-        >
-          Publish Post
-        </button>
-      </div>
-    </div>
-  );
-};
-```
-
-### Real-world Example
-
-```tsx
-import { TextArea } from "@telegraph/textarea";
-import { useEffect, useState } from "react";
-
-export const CustomerSupportTicket = () => {
-  const [ticket, setTicket] = useState({
-    subject: "",
-    description: "",
-    priority: "medium",
-  });
-  const [attachments, setAttachments] = useState([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-
-    try {
-      // Submit ticket logic
-      await submitTicket({ ...ticket, attachments });
-      alert("Ticket submitted successfully!");
-    } catch (error) {
-      alert("Failed to submit ticket. Please try again.");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="support-ticket">
-      <h2>Submit a Support Ticket</h2>
-
-      <div className="form-group">
-        <label htmlFor="subject">Subject</label>
-        <input
-          id="subject"
-          type="text"
-          value={ticket.subject}
-          onChange={(e) => setTicket({ ...ticket, subject: e.target.value })}
-          required
-        />
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="priority">Priority</label>
-        <select
-          id="priority"
-          value={ticket.priority}
-          onChange={(e) => setTicket({ ...ticket, priority: e.target.value })}
-        >
-          <option value="low">Low</option>
-          <option value="medium">Medium</option>
-          <option value="high">High</option>
-          <option value="urgent">Urgent</option>
-        </select>
-      </div>
-
-      <div className="form-group">
-        <label htmlFor="description">Description</label>
-        <TextArea
-          id="description"
-          value={ticket.description}
-          onChange={(e) =>
-            setTicket({ ...ticket, description: e.target.value })
-          }
-          placeholder="Please describe your issue in detail. Include any error messages, steps to reproduce, and screenshots if applicable."
-          autoResize
-          minRows={6}
-          maxRows={15}
-          maxLength={5000}
-          showCharacterCount
-          state={ticket.description.length < 50 ? "default" : "success"}
-          helperText="Please provide at least 50 characters for a detailed description."
-          required
-        />
-      </div>
-
-      <div className="form-group">
-        <label>Attachments</label>
-        <FileUpload
-          onFilesChange={setAttachments}
-          maxFiles={5}
-          acceptedTypes={[".png", ".jpg", ".pdf", ".txt"]}
-        />
-      </div>
-
-      <div className="form-actions">
-        <button
-          type="submit"
-          disabled={
-            isSubmitting || !ticket.subject || ticket.description.length < 50
-          }
-          className="primary"
-        >
-          {isSubmitting ? "Submitting..." : "Submit Ticket"}
-        </button>
-      </div>
-    </form>
-  );
-};
-```
-
-## References
-
-- [Storybook Demo](https://storybook.telegraph.dev/?path=/docs/textarea)
-- [Input Component](../input/README.md) - Related single-line input component
-- [Typography Component](../typography/README.md) - For text styling
-
-## Contributing
-
-See our [Contributing Guide](../../CONTRIBUTING.md) for more details.
-
-## License
-
-MIT License - see [LICENSE](../../LICENSE) for details.
+`errored` sets `data-tgph-textarea-state="error"` and styles the control. It
+does not set `aria-invalid` or announce anything. Set `aria-invalid` yourself,
+and link your message with `aria-describedby`.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -68,24 +68,24 @@ export const TooltipExample = () => (
 
 The main tooltip component that wraps content and provides contextual information on hover or focus.
 
-| Prop                      | Type                                     | Default     | Description                                                  |
-| ------------------------- | ---------------------------------------- | ----------- | ------------------------------------------------------------ |
-| `label`                   | `string \| ReactNode`                    | `undefined` | Content to display in the tooltip                            |
-| `labelProps`              | `TgphComponentProps<typeof Stack>`       | `undefined` | Props to pass to the rendered tooltip content                |
-| `enabled`                 | `boolean`                                | `true`      | Whether the tooltip can open                                 |
-| `side`                    | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`  | Preferred placement side                                     |
-| `align`                   | `"start" \| "center" \| "end"`           | `"center"`  | Alignment relative to the trigger                            |
-| `sideOffset`              | `number`                                 | `4`         | Distance from the trigger element                            |
-| `alignOffset`             | `number`                                 | `0`         | Offset along the alignment axis                              |
-| `delayDuration`           | `number`                                 | `400`       | Delay before showing tooltip (ms)                            |
-| `skipDelayDuration`       | `number`                                 | -           | Skip delay if another tooltip was recently shown             |
-| `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content |
-| `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip      |
-| `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                          |
-| `triggerRef`              | `RefObject<HTMLElement \| null>`         | `undefined` | Ref forwarded to the rendered trigger element                |
-| `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges           |
-| `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                               |
-| `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                     |
+| Prop                      | Type                                     | Default     | Description                                                                                                                |
+| ------------------------- | ---------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `label`                   | `string \| ReactNode`                    | `undefined` | Content to display in the tooltip                                                                                          |
+| `labelProps`              | `Omit<StackProps, "as">`                 | `undefined` | Props to pass to the rendered tooltip content. `as` is not accepted, because the label always renders the animated element |
+| `enabled`                 | `boolean`                                | `true`      | Whether the tooltip can open                                                                                               |
+| `side`                    | `"top" \| "right" \| "bottom" \| "left"` | `"bottom"`  | Preferred placement side                                                                                                   |
+| `align`                   | `"start" \| "center" \| "end"`           | `"center"`  | Alignment relative to the trigger                                                                                          |
+| `sideOffset`              | `number`                                 | `4`         | Distance from the trigger element                                                                                          |
+| `alignOffset`             | `number`                                 | `0`         | Offset along the alignment axis                                                                                            |
+| `delayDuration`           | `number`                                 | `400`       | Delay before showing tooltip (ms)                                                                                          |
+| `skipDelayDuration`       | `number`                                 | -           | Skip delay if another tooltip was recently shown                                                                           |
+| `disableHoverableContent` | `boolean`                                | `false`     | Prevent tooltip from staying open when hovering over content                                                               |
+| `disableFocusOpen`        | `boolean`                                | `false`     | Prevent focus events from instantly opening the tooltip                                                                    |
+| `skipAnimation`           | `boolean`                                | `false`     | Disable the tooltip entry animation                                                                                        |
+| `triggerRef`              | `RefObject<HTMLElement \| null>`         | `undefined` | Ref forwarded to the rendered trigger element                                                                              |
+| `avoidCollisions`         | `boolean`                                | `true`      | Automatically flip tooltip to avoid viewport edges                                                                         |
+| `sticky`                  | `"partial" \| "always"`                  | `"partial"` | How tooltip follows the cursor                                                                                             |
+| `hideWhenDetached`        | `boolean`                                | `false`     | Hide tooltip when trigger is not visible                                                                                   |
 
 ## Usage Patterns
 


### PR DESCRIPTION
Stacked on #928. Last of five. Documentation only.

## The problem

The stack changes behavior that package READMEs document, so several READMEs are now wrong. Two of their examples no longer compile, and two document props that never existed.

The catch-all index signature hid the second kind. A reader could copy `flex` onto `Modal.Body` from our own README and get nothing.

## The solution

Compile the examples. I extracted the `tsx` blocks from every changed README and checked them against the branch.

## What is in this one

- `Modal.Content` animates a child instead of passing `as={motion.div}`, which #924 makes a type error. `Popover.Content` drops its equivalent example.
- `flex` on `Modal.Body` and `disabled` on the Tabs root are gone. Neither existed.
- `Menu.Button` documents `as` and `nativeButton`. `SegmentedControl.Option` documents `as`. `Select.Option` documents `as` and `label`.
- `@telegraph/helpers` gains a "Type checking" section.

## Why the helpers section matters

Every package sets `files: ["dist", "README.md"]`, and no package publishes `CHANGELOG.md`. So the changeset prose explains this breaking change to anyone reading the repo, and to nobody reading the installed package. A consumer who hits a new type error has the README and nothing else.

## `@telegraph/textarea`, rewritten

Pre-existing rot rather than fallout from the stack. It is here because the PR already touches ten READMEs.

Seven documented props were never implemented: `autoResize`, `minRows`, `maxRows`, `showCharacterCount`, `state`, `errorMessage` and `helperText`. About half the examples used them. The `size` scale, the `size` default and the `resize` default were all wrong. The file went from 471 lines to 227.

## Impact

None. Documentation only, no code changes.

Still out of scope. `tokens` documents a token shape that does not match the export. `kbd` and `filter` document stylesheets their packages do not ship. That work needs its own ticket.

Resolves [KNO-14533](https://linear.app/knock/issue/KNO-14533/telegraph-update-package-readmes-for-the-prop-validation-stack)
