### PR TITLE
docs(repo): add a code-review skill for prop-type regressions

### DIFF
--- a/.agents/skills/code-review/SKILL.md
+++ b/.agents/skills/code-review/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: code-review
+description: Review a Telegraph change before it ships. Use when reviewing a diff, a PR, or your own work in this repo, and whenever a change touches a component's props type, destructures props, adds an `as` prop, or wraps a Base UI component.
+---
+
+# Reviewing a Telegraph change
+
+Telegraph is a component library. Every prop type in `packages/*/src` is a
+public API that a consuming app type-checks against. A prop type that is wrong
+does not fail here. It fails in the consumer, one release later, in a codebase
+nobody in this repo can see.
+
+That is the whole reason this skill exists. Most review checklists look for
+bugs that break the build. The failures below all compile.
+
+## The failure shape
+
+Three prop-validation releases (#922, #924, #925, #928, #931) fixed one family
+of defect. In every case the type and the component disagreed, and nothing
+reported it:
+
+| The type says            | The component does           | What the consumer sees                           |
+| ------------------------ | ---------------------------- | ------------------------------------------------ |
+| any prop is accepted     | ignores the typo             | `<Text fontSize={16} />` compiles, does nothing  |
+| `as` is accepted         | renders a fixed element      | `as={motion.div}` compiles, animation never runs |
+| `as` accepts any element | `as` collapsed to `"button"` | `as={NextLink}` is not assignable                |
+| this prop exists         | never reads it               | prop is accepted and silently dropped            |
+| this prop exists         | never destructures it        | prop reaches the DOM as an attribute             |
+
+None of these produce a type error, a lint warning, or a failing test on their
+own. Reviewing by reading is not enough: six review passes over that stack
+missed three of these, and a mechanical sweep found them in seconds.
+
+**So do both.** Read for intent, then run the sweeps. When the two disagree,
+the sweep is right.
+
+## Rules
+
+Read the rule file that matches what the diff touches. Read all three if the
+diff adds a component.
+
+| The diff...                                                             | Read                         |
+| ----------------------------------------------------------------------- | ---------------------------- |
+| changes a props type, adds a generic, adds or omits `as`                | `rules/polymorphic-types.md` |
+| destructures props, adds a prop, spreads onto an element, wraps Base UI | `rules/prop-plumbing.md`     |
+| adds or changes any public prop                                         | `rules/type-tests.md`        |
+
+## Procedure
+
+1. **Sweep first, then read.** Run the check below before forming an opinion.
+   It takes a second and it is not fooled by a plausible-looking diff.
+
+   ```bash
+   node .agents/skills/code-review/scripts/check-prop-plumbing.cjs
+   ```
+
+   Sweep A and C need your verdict. Sweep B is always a defect. Compare the
+   output against `main` rather than reading it cold: a finding that predates
+   the diff is not this PR's problem, and a finding that appears in it is.
+
+2. **Build before you trust a type result.** Cross-package types resolve
+   through `dist`. A stale build makes the type-test suite report the previous
+   release's API, and the failure it produces looks like a bad assertion rather
+   than a regression. Run `yarn build:packages` first. `rules/type-tests.md`
+   has the symptom to recognize.
+
+3. **Diff the type errors as a set, never as a count.** `tsc` output moves
+   around. A count that stays flat can hide one error disappearing and another
+   appearing. Sort the `file:line:code` lines and `comm` the two lists. A count
+   hid a relocated error twice on the work this skill came from.
+
+4. **Guard against a false zero.** Any check that counts matches in command
+   output reads a crashed run as "0 problems". Check the exit code too, and
+   confirm the run found the files it claims to have checked.
+
+5. **Prove every new test is load-bearing.** Revert _only_ the source file, not
+   the test, and confirm the test fails. `git stash` reverts both and the test
+   passes for the wrong reason. Two tests on the original stack passed against
+   the unfixed code before this step caught them.
+
+6. **Check the consumer.** A prop type change that looks harmless here can
+   add hundreds of errors in `control`. Build the packages, point `control` at
+   the build, and compare error sets before and after. Do not report a delta
+   you did not measure against a real baseline on both sides.
+
+## What is already enforced, and what is not
+
+Know which failures the toolchain catches so you spend review attention on the
+ones it does not.
+
+**Caught automatically:**
+
+- Type errors inside `*.test-d.tsx`, via `yarn test` (vitest `typecheck`).
+- An unused `@ts-expect-error`. If the code stops being an error, the directive
+  itself errors, so an assertion cannot silently stop asserting.
+
+**Not caught, and the reason:**
+
+- **A prop destructured out of props and never used.** `@typescript-eslint/no-unused-vars`
+  runs with `ignoreRestSiblings: true` (`@knocklabs/eslint-config/library.js`),
+  which exempts exactly this pattern, and the shared config loads `only-warn`,
+  so nothing in lint fails the build anyway. Sweep B exists for this.
+- **A prop declared and never destructured.** No rule models "this must not
+  reach the DOM." Sweep C exists for this.
+- **A catch-all index signature on a props type.** It makes every prop valid,
+  so no test fails. The `not.toHaveProperty("notARealProp")` assertion in each
+  package's `*.test-d.tsx` exists for this.
+- **Implementation type errors.** `vitest/config.mts` sets
+  `ignoreSourceErrors: true`, so the typecheck run reports only errors raised
+  inside the type tests. A broken component compiles as far as that suite is
+  concerned.
+- **Anything in a `*.test.tsx`.** Typecheck covers `**/*.test-d.{ts,tsx}` only
+  (`vitest/config.mts:26`). A `@ts-expect-error` in a `.test.tsx` asserts
+  nothing at all, because vitest strips the types with esbuild.
+- **A stale `dist`.** Nothing warns that the type tests just checked the last
+  release instead of the working tree.
+
+## Writing the review
+
+State the failure as a consumer would hit it, not as a description of the code.
+"`<Combobox.Empty>text</Combobox.Empty>` compiles and renders nothing" is
+reviewable. "`children` is unused" is not: it reads like a lint nit, and it got
+waved through on exactly that basis before.

--- a/.agents/skills/code-review/rules/polymorphic-types.md
+++ b/.agents/skills/code-review/rules/polymorphic-types.md
@@ -1,0 +1,195 @@
+# Polymorphic prop types
+
+Every Telegraph component takes `as` and forwards the props of whatever element
+it renders. The types that express this are load-bearing and easy to break in
+ways that compile. Each rule below has a shape to copy, a shape to reject, and
+the mechanism that makes the wrong shape wrong.
+
+## 1. Never build the element passthrough by hand
+
+```ts
+// Correct
+export type FooProps<T extends TgphElement = "div"> = PolymorphicProps<T> & {
+  variant?: "a" | "b";
+};
+
+// Wrong
+export type FooProps<T extends TgphElement = "div"> = Omit<
+  React.ComponentProps<T>,
+  "as"
+> & { variant?: "a" | "b" };
+```
+
+**Mechanism.** `T` is not always resolved. When a consumer writes `<Foo />` with
+no `as`, or when the type is referenced without an argument, `T` is the whole
+`React.ElementType` union. `React.ComponentProps<React.ElementType>` is
+`{ [x: string]: any }`, so `Omit<…, "as">` keeps that index signature. The
+resulting props type accepts every prop name in existence, and every component
+that intersects it inherits the hole.
+
+This is not theoretical. It was the state of the library before #922: 341 real
+prop errors in `control` were being hidden by it.
+
+`PolymorphicProps` (`packages/helpers/src/types/utility.ts:61`) guards the case
+with `React.ElementType extends E ? unknown : Omit<…>`, dropping the passthrough
+rather than widening it. Use it, or `PolymorphicPropsWithTgphRef` when the
+component also takes `tgphRef`.
+
+**Review check.** Any `React.ComponentProps<`, `ComponentPropsWithoutRef<`, or
+`JSX.IntrinsicElements[` applied to a generic parameter in a props type. It
+needs the unresolved-`E` guard or it is a hole.
+
+**Test.** Every package asserts this already. Add the type to the list:
+
+```ts
+expectTypeOf<FooProps>().not.toHaveProperty("notARealProp");
+```
+
+## 2. `as?: T` must sit at the top level of the intersection
+
+```ts
+// Correct — omit, then re-declare at the top level
+export type RootProps<T extends TgphElement = "button"> = Omit<
+  StackProps<T>,
+  "tgphRef" | "as" | "onClick"
+> &
+  AsAndTgphRefProps<T, HTMLButtonElement> &
+  RootBaseProps;
+
+// Wrong — the omit now wraps `as`, so `T` has no inference site
+export type RootProps<T extends TgphElement = "button"> = Omit<
+  StackProps<T> & { as?: T; tgphRef?: React.Ref<HTMLButtonElement> },
+  "onClick"
+> &
+  RootBaseProps;
+```
+
+**Mechanism.** TypeScript infers `T` from the `as` prop at the call site. It
+cannot infer through a mapped type. `Omit`, `Partial`, `Pick`, `Required` and
+`RemappedOmit` are all mapped types, so any of them in front of `as?: T` stops
+`<Root as="a" />` resolving `T` to `"a"`. `T` falls back to its default,
+`href` is rejected, and the component's whole reason for being polymorphic is
+gone.
+
+The two-line version reads redundant and it is not. Do not "simplify" it by
+folding the re-declaration back inside the omit. `AsAndTgphRefProps`
+(`packages/helpers/src/types/utility.ts:90`) exists to make the intent obvious
+and carries a comment saying so.
+
+**Review check.** A refactor that reduces an omit-then-re-declare into a single
+mapped type. It always compiles.
+
+**Test.**
+
+```ts
+<Foo as="a" href="/docs" />;          // must compile
+<Foo as="a" notAnAnchorProp="x" />;   // must be a @ts-expect-error
+```
+
+The first line alone is not enough. With a catch-all index signature it passes
+too.
+
+## 3. Never reference a generic props type bare
+
+```ts
+// Correct
+export type TabProps<T extends TgphElement = "button"> = {
+  value: string;
+} & TgphComponentProps<typeof MenuItem<T>>;
+
+// Wrong
+export type TabProps<T extends TgphElement = "button"> = {
+  value: string;
+  as?: T;
+} & MenuItemProps;
+```
+
+**Mechanism.** `MenuItemProps` has a default, so bare it means
+`MenuItemProps<"button">`, which carries `as?: "button"`. Intersecting that with
+`as?: T` gives `as?: "button" & T`. For any `T` that is not `"button"` the
+intersection is `never`, so `<Tab as={NextLink} />` reports that the component
+is not assignable to `"button"`.
+
+This is the defect #928 fixed across select, icon, toggle, combobox, menu and
+segmented-control.
+
+**Review check.** Any `SomethingProps` used without a type argument inside
+another props type. It is nearly always wrong. Pass `T` through, and when you
+need a component's props go through `TgphComponentProps<typeof X<T>>` so the
+generic travels with it.
+
+**Exception.** Resolving through the default is fine when the value provably
+does not depend on the element type, and the code says why:
+
+```ts
+// MenuItem's icon props do not depend on its element type, so resolving them
+// through the default element loses nothing.
+type TabIconProps = NonNullable<MenuItemProps<"button">["leadingIcon"]>;
+```
+
+## 4. Do not intersect a passthrough that is already inherited
+
+```ts
+// Correct — BoxProps<T> already carries the element props
+export type StackProps<T extends TgphElement = "div"> = Omit<
+  BoxProps<T>,
+  "as"
+> &
+  AsProp<T> &
+  StyleProps;
+
+// Wrong — repeats the entire element prop set a second time
+export type StackProps<T extends TgphElement = "div"> = BoxProps<T> &
+  PolymorphicProps<T> &
+  StyleProps;
+```
+
+**Mechanism.** The passthrough is large. Intersecting it twice does not change
+what the type accepts, so nothing fails, and it multiplies the work the checker
+does at every call site. #925 removed these; do not add them back.
+
+**Review check.** A props type that intersects both a Telegraph component's
+props and `PolymorphicProps`/`ComponentProps` for the same `T`.
+
+## 5. When a component ignores `as`, drop it from the type and cast in the body
+
+Some components render a fixed element on purpose. A `Modal.Root` is always the
+Base UI root; a `Combobox` trigger indicator is always `motion.span`. Those must
+not advertise `as`.
+
+```ts
+// Correct — `as` is absent from RootProps; the cast is on the value
+const Root = (rootProps: RootProps) => {
+  const {
+    // Discarded as well as dropped from the type, because a spread can still
+    // carry it.
+    as: _as,
+    ...props
+  } = rootProps as RootProps & { as?: TgphElement };
+
+// Wrong — the cast is on the parameter, which puts `as` back in the public type
+const Root = ({ as: _as, ...props }: RootProps & { as?: TgphElement }) => {
+```
+
+**Mechanism.** A parameter's declared type _is_ the component's public props
+type. Widening it there re-advertises `as`, so `<Modal.Root as="div">` compiles
+and does nothing — the exact bug the change was meant to remove. Casting the
+value inside the body strips the prop at runtime without touching the public
+type.
+
+Keep the discard named `_as`: `varsIgnorePattern: "^_"` in the shared eslint
+config depends on the prefix, and sweep A in `check-prop-plumbing.cjs` uses it
+to tell a deliberate discard from a dropped prop.
+
+**Review check.** Every `_`-prefixed discard must be paired with the prop being
+absent from the public type. Run sweep A and check each hit against its type.
+
+## 6. `Omit` versus `RemappedOmit`
+
+`Omit<T, K>` can resolve to `Record<string, any>` when `T` is a union or an
+unresolved generic, which reintroduces the hole from rule 1. `RemappedOmit`
+(`packages/helpers/src/types/utility.ts:107`) is a key-remapping mapped type
+that eliminates the keys outright.
+
+Prefer `RemappedOmit` when omitting from a type that is generic or a union.
+Both are mapped types, so rule 2 still applies to both.

--- a/.agents/skills/code-review/rules/prop-plumbing.md
+++ b/.agents/skills/code-review/rules/prop-plumbing.md
@@ -1,0 +1,128 @@
+# Prop plumbing
+
+Rule 1 of `polymorphic-types.md` covers types that lie about what they accept.
+This file covers the opposite direction: the type is right and the component
+does not honor it. Nothing in the toolchain reports any of these.
+
+Start by running the sweep. It is faster than reading and it does not get tired.
+
+```bash
+node .agents/skills/code-review/scripts/check-prop-plumbing.cjs
+```
+
+## 1. A destructured prop must be referenced (sweep B)
+
+```tsx
+const Root = <T extends TgphElement = "div">(rootProps: RootProps<T>) => {
+  const { as, className, ...props } = rootProps as RootProps<"div">;
+
+  // Wrong — `as` is accepted, pulled out of the spread, and thrown away
+  return <Stack direction="row" className={className} {...props} />;
+
+  // Correct
+  return <Stack as={as} direction="row" className={className} {...props} />;
+};
+```
+
+`Toggle.Root` shipped the wrong version. `<Toggle.Root as="fieldset">` compiled
+and rendered a `div`.
+
+**Why nothing catches it.** `@typescript-eslint/no-unused-vars` runs with
+`ignoreRestSiblings: true` in `@knocklabs/eslint-config/library.js`. That option
+exists to allow the omit-by-destructuring idiom, and it exempts this exact
+pattern by design. The shared config also loads `only-warn`, so even a hit would
+not fail anything.
+
+**The rule.** Every name you destructure out of props is either referenced later
+in the same function or renamed to `_name`. There is no third case. If you are
+pulling a prop out only to keep it off the spread, that is a discard: rename it
+and go to section 3.
+
+Sweep B covers both destructuring forms, `const { … } = rootProps` and
+`({ … }: RootProps) =>`. A sweep that handles only one leaves half the
+components unchecked.
+
+## 2. A prop you declare must be destructured (sweep C)
+
+```ts
+export type MenuItemProps<T extends TgphElement = "button"> =
+  TgphComponentProps<typeof Button.Root<T>> & {
+    // Declared rather than inherited: no `fontWeight` exists on Button.Root
+    // or the element passthrough.
+    fontWeight?: ButtonTextProps["weight"];
+  };
+```
+
+`MenuItem` did not destructure `fontWeight`, so it stayed in the rest element,
+spread onto `Button.Root`, and reached the DOM as a `font-weight` attribute on
+the rendered button.
+
+**The distinction that matters.** A prop _inherited_ from the element
+passthrough is safe in the rest spread: it is a real attribute of the element
+being rendered. A prop Telegraph _invents_ is not. It has to be destructured out
+before the spread, whether or not the component uses it.
+
+Sweep C reports invented props on exported `*Props` types that the file never
+destructures. Each hit needs a verdict, because forwarding to a Telegraph child
+that does consume the prop is legitimate.
+
+## 3. A discard must be paired with the type dropping the prop (sweep A)
+
+`const { as: _as, ...props } = rootProps as RootProps & { as?: TgphElement }`
+is correct only when `RootProps` does not declare `as`. The cast exists because
+a spread from a consumer can still carry the prop at runtime, not because the
+prop is part of the API.
+
+If the public type still advertises the prop, the discard is the bug. See rule 5
+of `polymorphic-types.md` for where the cast goes.
+
+## 4. A phantom prop is worse than a missing one
+
+`Tooltip` declared `asChild?: boolean` and had no code path that read it.
+A consumer passing it gets no error, no warning, and no behavior. Removing it is
+a breaking change to the type and a no-op at runtime, which is the best possible
+outcome and still a release note.
+
+Before adding a prop, find the line that consumes it. If you cannot point at
+one, do not declare it.
+
+## 5. Deriving the rendered element: use the shared predicate
+
+`Button.Root` does not always render the element you asked for:
+
+```ts
+const rendersNativeButton = (as?: TgphElement, disabled?: boolean) =>
+  !!disabled || !as || as === "button";
+
+const derivedAs = rendersNativeButton(as, disabled) ? "button" : as;
+```
+
+`disabled` forces a real `<button>` regardless of `as`, because the native
+`disabled` attribute is what actually blocks clicks.
+
+Base UI components take a `nativeButton` prop and log a development error when
+it disagrees with the tag that renders. Any wrapper that renders a
+`Button.Root` inside a Base UI component must derive that prop from the same
+predicate:
+
+```ts
+import { rendersNativeButton } from "@telegraph/button";
+
+const nativeButton = rendersNativeButton(props.as, disabled);
+```
+
+```ts
+// Wrong — ignores `disabled`, so a disabled `as={NextLink}` tab renders a
+// <button> while claiming it did not
+const nativeButton = !props.as || props.as === "button";
+```
+
+`Tab` shipped the wrong version. Four call sites derive this today: `Tab`,
+`SegmentedControl`, and two in `Menu`. If you add a fifth, import the predicate
+rather than re-deriving it.
+
+**Testing this one is unusual.** Base UI composite items such as tabs stay
+focusable while disabled so arrow-key navigation still reaches them, so they
+render `aria-disabled` plus `tabindex="0"` and never a native `disabled`
+attribute. Asserting on `disabled` will fail against both the broken and the
+fixed component. The observable signal is the console error, so spy on it.

--- a/.agents/skills/code-review/rules/type-tests.md
+++ b/.agents/skills/code-review/rules/type-tests.md
@@ -1,0 +1,152 @@
+# Type tests
+
+The prop types in this repo are the product. `*.test-d.tsx` files are how that
+product is tested. A change that adds or alters a public prop is not reviewable
+until the assertions exist.
+
+## How the harness runs
+
+`vitest/config.mts` turns on `typecheck` and scopes it:
+
+```ts
+typecheck: {
+  enabled: true,
+  include: ["**/*.test-d.{ts,tsx}"],
+  ignoreSourceErrors: true,
+},
+```
+
+They run as part of `yarn test`. Three consequences follow, and each is a way to
+write a test that asserts nothing.
+
+**Only `*.test-d.tsx` is typechecked.** In a `*.test.tsx`, vitest strips types
+with esbuild. A `@ts-expect-error` there is a comment, and `expectTypeOf` is a
+no-op. If you are asserting on types, the filename has to end `.test-d.tsx`.
+
+**`ignoreSourceErrors: true` hides implementation errors.** The suite reports
+only errors raised inside the type tests. A component whose body does not
+compile can still show green here. Do not read a passing run as "the package
+type-checks."
+
+**An unused `@ts-expect-error` is itself an error.** This is the one thing
+working in your favor: when a prop stops being rejected, the directive goes
+unused and the suite fails. It is why negative assertions do not rot.
+
+## The four assertions a public props type needs
+
+```tsx
+import { Foo } from ".";
+import type { FooProps } from ".";
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("Foo types", () => {
+  // 1. No catch-all. This is the one that catches a regression of the
+  //    passthrough guard, and nothing else does.
+  it("has no catch-all index signature", () => {
+    expectTypeOf<FooProps>().not.toHaveProperty("notARealProp");
+  });
+
+  // 2. Declared props keep their exact type rather than widening to `any`.
+  it("keeps declared props narrow", () => {
+    expectTypeOf<FooProps["variant"]>().not.toBeAny();
+  });
+
+  // 3. Unknown props and bad values are rejected.
+  it("rejects unknown props", () => {
+    <Foo
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+    <Foo
+      // @ts-expect-error not a variant
+      variant="notAVariant"
+    />;
+  });
+
+  // 4. `as` still resolves, so the element's own props are accepted.
+  it("accepts valid props", () => {
+    <Foo as="a" href="/docs" target="_blank" />;
+    <Foo variant="soft" className="c" data-testid="x" />;
+  });
+});
+```
+
+Assertions 1 and 3 both catch a regression of the passthrough guard. Keep both:
+assertion 3 fails with `Unused '@ts-expect-error' directive`, which does not
+name the cause, and assertion 1 fails with the property name, which does.
+
+Assertion 4 alone proves nothing. Under a catch-all, every line in it passes.
+Never ship a type test that only checks the accepting direction.
+
+## Build the packages first, or the suite tests the last release
+
+Cross-package types resolve through `dist`, not `src`. A worktree with a stale
+or missing `packages/*/dist` type-checks the tests against whatever was built
+last, so the suite reports the _previous_ version of the API.
+
+The symptom is specific and misleading:
+
+```
+TypeCheckError: Unused '@ts-expect-error' directive.
+ ❯ src/Button/Button.test-d.tsx:28:7
+```
+
+That reads like the assertion is wrong. It means the props type is currently
+accepting `notARealProp` — the catch-all is back — because `@telegraph/helpers`
+resolved to a build that predates the guard. Deleting the directive to make it
+pass reintroduces the regression the test exists to catch.
+
+Rebuild before believing any type-test result:
+
+```bash
+yarn build:packages
+```
+
+Never edit a type test to resolve a failure you have not seen against a fresh
+build.
+
+## Traps
+
+**Assert the exported name.** Consumers import `ButtonRootProps`, not the
+internal `RootProps`. Testing the internal alias can pass while the exported
+type is broken by a re-export that reshapes it.
+
+**Pin `as` when the component is polymorphic.** `expectTypeOf<FooProps>()` with
+no argument resolves the generic to its default. That is a real case worth
+testing, but it is not the same as `FooProps<"a">`, and a bug that only appears
+under an explicit `as` will not show up. Cover both.
+
+**Put the `@ts-expect-error` on the prop, not the element.** A directive above
+`<Foo` suppresses every error in the whole JSX expression, so one genuine
+failure masks the rest and the test still passes. One directive, one prop,
+directly above the line:
+
+```tsx
+<Foo
+  // @ts-expect-error unknown prop
+  notARealProp="x"
+/>
+```
+
+**Do not assert on a prop you did not exercise.** In a `.test.tsx` regression
+test, a fixture that never passes the prop passes with and without the fix. A
+`fontWeight` test caught nothing until the fixture actually set
+`fontWeight="bold"`.
+
+## Proving a test is load-bearing
+
+Revert **only** the source file and confirm the test fails.
+
+```bash
+git diff HEAD -- packages/foo/src/Foo/Foo.tsx > /tmp/fix.patch
+git checkout HEAD -- packages/foo/src/Foo/Foo.tsx
+yarn vitest run --config=./vitest/config.mts --project=foo   # must fail
+git apply /tmp/fix.patch
+```
+
+The project name is the bare package name from that package's
+`vitest.config.mts` (`foo`), not the workspace name (`@telegraph/foo`).
+
+`git stash` reverts the test with the source, so the suite passes and tells you
+nothing. Two tests on the original prop-validation stack passed against the
+unfixed code until this step caught them.

--- a/.agents/skills/code-review/scripts/check-prop-plumbing.cjs
+++ b/.agents/skills/code-review/scripts/check-prop-plumbing.cjs
@@ -1,0 +1,221 @@
+#!/usr/bin/env node
+/**
+ * Finds props that a Telegraph component's type and its body disagree about.
+ *
+ * Three sweeps, each a separate failure mode:
+ *
+ *   A  DISCARDED   a binding renamed to `_foo`. Deliberately thrown away, so
+ *                  the public props type must not still advertise `foo`.
+ *   B  DROPPED     a binding never referenced again inside its own function
+ *                  body. The prop type-checks and does nothing.
+ *   C  LEAKED      a prop declared in an inline object literal on a `*Props`
+ *                  type that the file never destructures. It stays in the rest
+ *                  element and gets spread onto the rendered element, so an
+ *                  invented prop reaches the DOM as an attribute.
+ *
+ * B is the only sweep that fails the run. A and C need a human verdict: a
+ * discard can be correct once the type drops the prop too, and a declared prop
+ * can be forwarded on purpose to a Telegraph child that consumes it.
+ *
+ * Built on the TypeScript AST. A regex sweep over the same files under-reports:
+ * a comment that contains `as="div"` corrupts the parse and the hit disappears.
+ *
+ * Usage:  node .agents/skills/code-review/scripts/check-prop-plumbing.cjs [dir]
+ * Default dir is `packages` at the repo root.
+ */
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+const ts = require("typescript");
+
+const repoRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+  encoding: "utf8",
+}).trim();
+const root = path.resolve(repoRoot, process.argv[2] || "packages");
+
+// Spread onward and consumed by a Telegraph child rather than the DOM.
+const FORWARDED = new Set(["children", "className", "style", "tgphRef", "as"]);
+
+const sourceFiles = (dir, out = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      sourceFiles(full, out);
+    } else if (
+      entry.name.endsWith(".tsx") &&
+      !/\.(test|test-d|stories|fixtures|browser\.test)\./.test(entry.name)
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+};
+
+const enclosingFunction = (node) => {
+  for (let n = node.parent; n; n = n.parent) {
+    if (
+      ts.isFunctionDeclaration(n) ||
+      ts.isArrowFunction(n) ||
+      ts.isFunctionExpression(n) ||
+      ts.isMethodDeclaration(n)
+    ) {
+      return n;
+    }
+  }
+  return null;
+};
+
+const bindingName = (element, src) =>
+  (element.propertyName ?? element.name).getText(src).replace(/["']/g, "");
+
+const discarded = [];
+const dropped = [];
+const leaked = [];
+
+for (const file of sourceFiles(root)) {
+  const src = ts.createSourceFile(
+    file,
+    fs.readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const rel = path.relative(repoRoot, file);
+  const lineOf = (node) =>
+    src.getLineAndCharacterOfPosition(node.getStart(src)).line + 1;
+
+  const declaredInLiteral = new Map();
+  const destructuredAnywhere = new Set();
+
+  // A and B, for one object binding pattern that unpacks props.
+  const checkPattern = (pattern, fn) => {
+    // Identifiers referenced inside the function body, excluding the binding
+    // pattern itself.
+    const referenced = new Set();
+    if (fn?.body) {
+      const collect = (n) => {
+        if (ts.isIdentifier(n)) {
+          let inPattern = false;
+          for (let p = n.parent; p && p !== fn; p = p.parent) {
+            if (p === pattern) {
+              inPattern = true;
+              break;
+            }
+          }
+          if (!inPattern) referenced.add(n.text);
+        }
+        ts.forEachChild(n, collect);
+      };
+      ts.forEachChild(fn.body, collect);
+    }
+
+    for (const element of pattern.elements) {
+      if (element.dotDotDotToken || !ts.isIdentifier(element.name)) continue;
+      const local = element.name.text;
+      const at = {
+        rel,
+        line: lineOf(element),
+        prop: bindingName(element, src),
+        local,
+      };
+
+      if (local.startsWith("_")) discarded.push(at);
+      else if (!referenced.has(local)) dropped.push(at);
+    }
+  };
+
+  const visit = (node) => {
+    // A and B, form 1: `const { as, ...props } = rootProps`.
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isObjectBindingPattern(node.name) &&
+      node.initializer &&
+      /props/i.test(node.initializer.getText(src))
+    ) {
+      checkPattern(node.name, enclosingFunction(node));
+    }
+
+    // A and B, form 2: `({ as, ...props }: RootProps) => …`. Both forms are in
+    // use, so a sweep that covers only one leaves half the components unchecked.
+    if (
+      ts.isParameter(node) &&
+      ts.isObjectBindingPattern(node.name) &&
+      node.type &&
+      /Props/.test(node.type.getText(src))
+    ) {
+      checkPattern(node.name, node.parent);
+    }
+
+    // C: props invented on an inline object literal of an exported `*Props`
+    // type. Exported only, because a leak needs a consumer able to pass the
+    // prop; internal context and render-prop types are spread by hand.
+    if (
+      ts.isTypeAliasDeclaration(node) &&
+      node.name.text.endsWith("Props") &&
+      node.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      const owner = node.name.text;
+      const collectMembers = (type) => {
+        if (ts.isTypeLiteralNode(type)) {
+          for (const member of type.members) {
+            if (!ts.isPropertySignature(member) || !member.name) continue;
+            const prop = member.name.getText(src).replace(/["']/g, "");
+            if (!declaredInLiteral.has(prop)) {
+              declaredInLiteral.set(prop, { line: lineOf(member), owner });
+            }
+          }
+        }
+        ts.forEachChild(type, collectMembers);
+      };
+      collectMembers(node.type);
+    }
+
+    if (ts.isObjectBindingPattern(node)) {
+      for (const element of node.elements) {
+        if (element.dotDotDotToken) continue;
+        destructuredAnywhere.add(bindingName(element, src));
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(src);
+
+  for (const [prop, where] of declaredInLiteral) {
+    if (destructuredAnywhere.has(prop) || FORWARDED.has(prop)) continue;
+    leaked.push({ rel, prop, ...where });
+  }
+}
+
+const report = (title, rows, format) => {
+  console.log(`\n${title}`);
+  if (rows.length === 0) {
+    console.log("  none");
+    return;
+  }
+  for (const row of rows) console.log(`  ${format(row)}`);
+};
+
+report(
+  "A. Discarded in the body — the public props type must not advertise these",
+  discarded,
+  (d) => `${d.rel}:${d.line}  ${d.prop} -> ${d.local}`,
+);
+report(
+  "B. Destructured then never referenced — accepted and silently ignored",
+  dropped,
+  (d) => `${d.rel}:${d.line}  ${d.prop}`,
+);
+report(
+  "C. Declared but never destructured — spreads onto the element and reaches the DOM",
+  leaked,
+  (d) => `${d.rel}:${d.line}  ${d.prop}  (declared on ${d.owner})`,
+);
+
+console.log(
+  `\n${discarded.length} discarded, ${dropped.length} dropped, ${leaked.length} possibly leaked`,
+);
+
+// Only B is unambiguous. A and C are reported for a human verdict.
+process.exit(dropped.length > 0 ? 1 : 0);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,30 @@ Guidance for AI agents working in this repository.
 Before writing code, read the SKILL.md (and its referenced files) for any
 applicable skill below:
 
-| Task                                  | Skill                          |
-| ------------------------------------- | ------------------------------ |
-| Writing a browser-mode component test | `write-browser-component-test` |
+| Task                                          | Skill                                 |
+| --------------------------------------------- | ------------------------------------- |
+| Reviewing a diff, a PR, or your own work      | `.agents/skills/code-review/SKILL.md` |
+| Changing a props type, or destructuring props | `.agents/skills/code-review/SKILL.md` |
+| Writing a browser-mode component test         | `write-browser-component-test`        |
+
+Skills under `.agents/skills` live in this repo and are always available. Skills
+named without a path are published to Knock's
+[skillset](https://github.com/knocklabs/skillset); install a missing one with
+`skillset install <name>`.
+
+## Prop types are the public API
+
+Every prop type in `packages/*/src` is type-checked against by consuming apps. A
+prop type that is wrong does not fail here — it fails in the consumer, one
+release later. The whole family of defects that produces compiles cleanly, so
+reading the diff is not enough.
+
+Before changing a props type, adding an `as` prop, or destructuring props, read
+`.agents/skills/code-review/SKILL.md` and run:
+
+```bash
+node .agents/skills/code-review/scripts/check-prop-plumbing.cjs
+```
 
 ## Browser-mode component tests (Vitest)
 


### PR DESCRIPTION
Adds `.agents/skills/code-review`, a repo-local skill for reviewing Telegraph changes.

## The problem

The prop-validation stack (#922, #924, #925, #928, #931) fixed one family of defect. In every case the props type and the component disagreed:

```tsx
<Text fontSize={16} />            // accepted. Text has no fontSize
<Popover.Content as={motion.div}> // accepted. The animation never runs
<Toggle.Root as="fieldset">       // accepted. Renders a div
```

None of these produce a type error, a lint warning, or a failing test. Reading the diff does not find them. Six review passes over that stack missed three, and a mechanical sweep found them in seconds.

Two of those misses had a specific cause. `@typescript-eslint/no-unused-vars` runs with `ignoreRestSiblings: true` in `@knocklabs/eslint-config/library.js`, which exempts the dropped-prop pattern by design. The shared config also loads `only-warn`, so lint cannot fail the build either way.

## The solution

Write the invariants down, and ship the sweep that finds what a reader misses.

## What is in this one

- **`SKILL.md`** — the review procedure, plus a list of which failures the toolchain catches and which it structurally cannot.
- **`rules/polymorphic-types.md`** — six rules on types that lie about what they accept. Catch-all index signatures, `as?: T` losing its inference site behind a mapped type, bare generic collapse, repeated passthroughs, cast placement.
- **`rules/prop-plumbing.md`** — five rules on components that ignore a correct type. Dropped props, leaked props, discards, phantom props, `nativeButton` derivation.
- **`rules/type-tests.md`** — the `*.test-d.tsx` contract and the traps that make a type test assert nothing.
- **`scripts/check-prop-plumbing.cjs`** — three AST sweeps over `packages/*/src`.
- `AGENTS.md` routes to the skill.

Each rule states the symptom, the mechanism, the shape to copy, the shape to reject, and how to detect it.

## The sweep

```bash
node .agents/skills/code-review/scripts/check-prop-plumbing.cjs
```

Three sweeps. **A** finds `_`-prefixed discards, which are correct only when the public type also drops the prop. **B** finds props destructured and never referenced. **C** finds invented props never destructured, which reach the DOM as attributes. Only B fails the run, because A and C need a human verdict.

This merges the two throwaway scripts from the original stack and extends them. Sweep C is now scoped to exported types, which took it from 17 false positives to zero. Sweeps A and B now cover parameter destructuring as well as `const { … } = props`, which the originals missed entirely.

I verified the teeth by planting all three defects in a fixture. Each one fired.

## One finding on main

The parameter-destructuring coverage found a live case, so the sweep currently exits 1:

```
packages/combobox/src/Combobox/Combobox.tsx:1029  children
```

`Combobox.Empty` inherits `children` from `StackProps`, destructures it out of the spread, and never renders it. `<Combobox.Empty>No matches</Combobox.Empty>` compiles and the text disappears. The intent looks right, since `children` reaching the `Stack` would collide with the icon and message, but then it should be `_children` with `children` omitted from `EmptyProps`.

Not fixed here. That is a component change with a changeset, and it belongs in its own PR.

## Impact

Documentation and one script. No package source changed, so nothing publishes and no changeset is needed. Nothing runs in CI yet, and the finding above is why: wiring the sweep into a workflow should wait until it is green.
