### PR TITLE
fix(layout): stop prop `color` type-checking on Box and Stack

### DIFF
--- a/.changeset/lucky-pandas-wave.md
+++ b/.changeset/lucky-pandas-wave.md
@@ -1,5 +1,5 @@
 ---
-"@telegraph/layout": minor
+"@telegraph/layout": patch
 ---
 
 `Box` and `Stack` reject `color`.

--- a/.changeset/lucky-pandas-wave.md
+++ b/.changeset/lucky-pandas-wave.md
@@ -1,0 +1,16 @@
+---
+"@telegraph/layout": minor
+---
+
+`Box` and `Stack` reject `color`.
+
+`color` is a deprecated HTML attribute that React accepts on every element, so it reached these components through the element passthrough rather than through their style props. It type-checked, rendered a `color` attribute, and painted nothing.
+
+The trap was the collision. `Text`, `Button` and `Icon` all have a real `color` prop, so the same prop name worked on those and silently did nothing on the layout primitives.
+
+```tsx
+<Box color="red" />   // used to compile and paint nothing. Now an error.
+<Text color="red" />  // unchanged. Still works.
+```
+
+Runtime behaviour does not change, because the attribute never did anything. To set a background, use `bg`. To set text colour, use `Text`.

--- a/packages/layout/src/Box/Box.test-d.tsx
+++ b/packages/layout/src/Box/Box.test-d.tsx
@@ -49,6 +49,20 @@ describe("Box types", () => {
     />;
   });
 
+  it("rejects `color`, which rendered an attribute and painted nothing", () => {
+    expectTypeOf<BoxProps>().not.toHaveProperty("color");
+    expectTypeOf<BoxProps<"a">>().not.toHaveProperty("color");
+    <Box
+      // @ts-expect-error `color` is not a Box style prop
+      color="red"
+    />;
+    <Box
+      as="a"
+      // @ts-expect-error a resolved element does not bring `color` back
+      color="red"
+    />;
+  });
+
   it("rejects invalid values for declared props", () => {
     <Box
       // @ts-expect-error not a spacing token

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -1,5 +1,7 @@
 import type {
+  AsAndTgphRefProps,
   PolymorphicPropsWithTgphRef,
+  RemappedOmit,
   TgphElement,
 } from "@telegraph/helpers";
 import { useStyleEngine } from "@telegraph/style-engine";
@@ -7,8 +9,18 @@ import clsx from "clsx";
 
 import { StyleProps, cssVars } from "./Box.constants";
 
-export type BoxProps<T extends TgphElement = "div"> =
-  PolymorphicPropsWithTgphRef<T, HTMLElement> & StyleProps;
+// `color` is dropped from the passthrough. It is a deprecated HTML attribute
+// that React accepts on every element, so it type-checked here and rendered a
+// `color` attribute that paints nothing. `Text`, `Button` and `Icon` all have a
+// real `color` prop, so the name worked on those and did nothing on this one.
+// `as` and `tgphRef` come back at the top level, because a mapped type in front
+// of `as?: T` stops `<Box as="a" />` resolving `T`.
+export type BoxProps<T extends TgphElement = "div"> = RemappedOmit<
+  PolymorphicPropsWithTgphRef<T, HTMLElement>,
+  "as" | "tgphRef" | "color"
+> &
+  AsAndTgphRefProps<T, HTMLElement> &
+  StyleProps;
 
 const Box = <T extends TgphElement = "div">({
   as,

--- a/packages/layout/src/Box/Box.tsx
+++ b/packages/layout/src/Box/Box.tsx
@@ -9,12 +9,8 @@ import clsx from "clsx";
 
 import { StyleProps, cssVars } from "./Box.constants";
 
-// `color` is dropped from the passthrough. It is a deprecated HTML attribute
-// that React accepts on every element, so it type-checked here and rendered a
-// `color` attribute that paints nothing. `Text`, `Button` and `Icon` all have a
-// real `color` prop, so the name worked on those and did nothing on this one.
-// `as` and `tgphRef` come back at the top level, because a mapped type in front
-// of `as?: T` stops `<Box as="a" />` resolving `T`.
+// `color` is dropped from the passthrough. React accepts it on every element,
+// so it type-checked here and rendered an attribute that paints nothing.
 export type BoxProps<T extends TgphElement = "div"> = RemappedOmit<
   PolymorphicPropsWithTgphRef<T, HTMLElement>,
   "as" | "tgphRef" | "color"

--- a/packages/layout/src/Stack/Stack.test-d.tsx
+++ b/packages/layout/src/Stack/Stack.test-d.tsx
@@ -45,6 +45,15 @@ describe("Stack types", () => {
     />;
   });
 
+  it("inherits the `color` omission from BoxProps", () => {
+    expectTypeOf<StackProps>().not.toHaveProperty("color");
+    expectTypeOf<StackProps<"a">>().not.toHaveProperty("color");
+    <Stack
+      // @ts-expect-error `color` is not a Stack style prop
+      color="red"
+    />;
+  });
+
   it("rejects invalid values for declared props", () => {
     <Stack
       // @ts-expect-error not a flex direction


### PR DESCRIPTION
## The problem

`color` type-checked on `Box` and `Stack` and did nothing.

```tsx
<Box color="red" />   // compiled, rendered <div color="red">, painted nothing
<Text color="red" />  // compiled, worked
```

React accepts `color` on every element, so it arrived through the element passthrough instead of the style props. `Text`, `Button` and `Icon` have a real `color` prop. The same name worked on those and did nothing here.

## The solution

Drop `color` from the passthrough. Re-declare `as` and `tgphRef` at the top level so `<Box as="a" />` still resolves its element type.

```ts
export type BoxProps<T extends TgphElement = "div"> = RemappedOmit<
  PolymorphicPropsWithTgphRef<T, HTMLElement>,
  "as" | "tgphRef" | "color"
> &
  AsAndTgphRefProps<T, HTMLElement> &
  StyleProps;
```

## What is in this one

- `BoxProps` omits `color`. `Stack` inherits it and needs no change.
- Type tests in both packages, with `as` unresolved and with `as="a"`.
- A changeset.

I swept 20 style-looking HTML attributes. Only `color` and `content` still compile and do nothing. Only `color` collides with a real Telegraph prop.

## Impact

Breaking for the type. Runtime does not change, because the attribute never did anything.

Every consumer `<Box color>` becomes an error. Each one already painted nothing, so delete it or move the color to a `Text` child.

Verified: 744 tests pass, 31 packages build. Reverting only `Box.tsx` turns the new tests red.

Resolves [KNO-14574](https://linear.app/knock/issue/KNO-14574/telegraph-omit-color-from-box-and-stack-props)
