### PR TITLE
feat(radio): add a standalone Radio and RadioGroup

### DIFF
--- a/.changeset/plain-radios-appear.md
+++ b/.changeset/plain-radios-appear.md
@@ -1,0 +1,18 @@
+---
+"@telegraph/radio": minor
+---
+
+feat(radio): add a standalone `Radio` and `RadioGroup`
+
+A plain radio to sit beside `@telegraph/checkbox`: rounded with a dot rather
+than squared with a check, and matching it on every other axis. It renders a
+real `<input type="radio">`, so form submission, keyboard support, and roving
+focus come from the platform and Base UI.
+
+- `size` (`"1" | "2"`) and `color` (the same palette as `@telegraph/button`)
+- `RadioGroup` with group-level `size` / `color` / `disabled` defaults, and
+  `value` / `defaultValue` / `onValueChange` matching `Toggle` and `Checkbox`
+- Composable `Radio.Root` / `Radio.Control` / `Radio.Label`, plus a
+  `Radio.Default` that renders the control and label together
+
+`RadioCards` is untouched.

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -153,13 +153,35 @@ The first of these that applies wins:
 
 1. `aria-labelledby` on `Radio.Root`
 2. A visible `Radio.Label`
-3. `aria-label` on `Radio.Root`
-4. A wrapping `<label>` or a `Field.Label`
+3. A wrapping `<label>` or a `Field.Label`
+4. `aria-label` on `Radio.Root`
 
 So `aria-label` is for a radio with no visible label. Passing it alongside a
 label does nothing, because Base UI derives `aria-labelledby` from the
 associated `<label>` and that outranks `aria-label`. Use `aria-labelledby` when
 the accessible name has to differ from the visible text.
+
+### Inside a `Field`
+
+Wrap each radio in a `Field.Item`:
+
+```tsx
+<Field.Root>
+  <Field.Label>Billing plan</Field.Label>
+  <RadioGroup name="plan" defaultValue="pro">
+    <Field.Item>
+      <Radio.Default value="free" label="Free" />
+    </Field.Item>
+    <Field.Item>
+      <Radio.Default value="pro" label="Pro" />
+    </Field.Item>
+  </RadioGroup>
+</Field.Root>
+```
+
+A `Field.Root` carries one control id and hands it to every radio inside it, so
+without `Field.Item` all the inputs share an id and only the first label
+responds to a click. `Field.Item` gives each radio its own scope.
 
 ### `<RadioGroup>`
 

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -1,6 +1,13 @@
-# 📻 Radio Cards
+# 📻 Radio
 
-> Card-style radio group component with flexible layouts and Telegraph design system integration.
+> A standalone radio and a card-style radio group for the Telegraph design system.
+
+This package ships two ways to pick one option from a set:
+
+- **`Radio`** with **`RadioGroup`** — a plain radio: a circle with a dot, and a
+  label. Visually the checkbox from `@telegraph/checkbox`, rounded.
+- **`RadioCards`** — the same choice rendered as selectable cards, with a
+  title, description, and icon per option.
 
 ![Telegraph by Knock](https://github.com/knocklabs/telegraph/assets/29106675/9b5022e3-b02c-4582-ba57-3d6171e45e44)
 
@@ -71,6 +78,115 @@ export const ActionSelector = () => {
 ```
 
 ## API Reference
+
+### A note on `value`
+
+Two props share the name and do different jobs. Worth reading once:
+
+| Prop               | Type     | What it is                                   |
+| ------------------ | -------- | -------------------------------------------- |
+| `RadioGroup.value` | `string` | Which option is selected                     |
+| `Radio.value`      | `string` | This option's identity, and its form payload |
+
+A radio has no selected state of its own. Base UI derives it entirely from the
+enclosing group, so `Radio` needs a `RadioGroup` ancestor and there is no
+single-radio API. That also means there is no `indeterminate` state: radios do
+not have one.
+
+`RadioGroup` owns the `name`, so each radio's `value` is what the form submits
+under it. The `formValue` collision that `@telegraph/checkbox` has does not
+arise here.
+
+### `<Radio.Default>` (Default Component)
+
+Renders the control and an associated label.
+
+| Prop           | Type                | Default     | Description                             |
+| -------------- | ------------------- | ----------- | --------------------------------------- |
+| `value`        | `string`            | —           | **Required.** This option's identity    |
+| `label`        | `ReactNode`         | —           | Visible label, associated via `htmlFor` |
+| `size`         | `"1" \| "2"`        | `"2"`       | Control size                            |
+| `color`        | `RadioColor`        | `"default"` | Color when selected                     |
+| `disabled`     | `boolean`           | `false`     | Disables this option                    |
+| `readOnly`     | `boolean`           | `false`     | Blocks changes, but still submits       |
+| `required`     | `boolean`           | `false`     | Must be chosen before the form submits  |
+| `labelProps`   | `RadioLabelProps`   | —           | Forwarded to `Radio.Label`. No `id`     |
+| `controlProps` | `RadioControlProps` | —           | Forwarded to `Radio.Control`            |
+
+`color` accepts `default`, `accent`, `blue`, `gray`, `green`, `purple`, `red`,
+and `yellow` — the same set as `@telegraph/button` and `@telegraph/checkbox`.
+
+```tsx
+import { Radio, RadioGroup } from "@telegraph/radio";
+
+<RadioGroup name="plan" value={plan} onValueChange={setPlan}>
+  <Radio.Default value="free" label="Free" />
+  <Radio.Default value="pro" label="Pro" />
+  <Radio.Default value="enterprise" label="Enterprise" disabled />
+</RadioGroup>;
+```
+
+### Composable parts
+
+```tsx
+<RadioGroup name="plan" defaultValue="pro">
+  <Radio.Root value="pro">
+    <Radio.Control />
+    <Radio.Label>Pro</Radio.Label>
+  </Radio.Root>
+</RadioGroup>
+```
+
+- **`<Radio.Root>`** — holds state and layout, and provides context. Takes
+  every prop in the table above except `label`, `labelProps` and
+  `controlProps`. Also accepts `Stack` layout props and `as` / `tgphRef`.
+- **`<Radio.Control>`** — the circle and its dot. Takes `Stack` layout props,
+  so `controlProps={{ w: "6" }}` resizes it. Pass `dotProps` to restyle the
+  dot.
+- **`<Radio.Label>`** — the label, associated with the control automatically.
+  It sets its own `id`, because that is what the control points
+  `aria-labelledby` at, so `labelProps` does not take one.
+
+### What names the control
+
+The first of these that applies wins:
+
+1. `aria-labelledby` on `Radio.Root`
+2. A visible `Radio.Label`
+3. `aria-label` on `Radio.Root`
+4. A wrapping `<label>` or a `Field.Label`
+
+So `aria-label` is for a radio with no visible label. Passing it alongside a
+label does nothing, because Base UI derives `aria-labelledby` from the
+associated `<label>` and that outranks `aria-label`. Use `aria-labelledby` when
+the accessible name has to differ from the visible text.
+
+### `<RadioGroup>`
+
+| Prop            | Type                    | Default    | Description                                   |
+| --------------- | ----------------------- | ---------- | --------------------------------------------- |
+| `value`         | `string`                | —          | Controlled selection                          |
+| `defaultValue`  | `string`                | —          | Initial selection when uncontrolled           |
+| `onValueChange` | `(value, eventDetails)` | —          | Fired when the selection changes              |
+| `name`          | `string`                | —          | Form field name for the whole group           |
+| `form`          | `string`                | —          | Id of a form the group is rendered outside of |
+| `size`          | `"1" \| "2"`            | —          | Applied to children that don't set their own  |
+| `color`         | `RadioColor`            | —          | Applied to children that don't set their own  |
+| `disabled`      | `boolean`               | `false`    | Disables every child                          |
+| `readOnly`      | `boolean`               | `false`    | Blocks changes across the group               |
+| `required`      | `boolean`               | `false`    | An option must be chosen before submitting    |
+| `direction`     | `"row" \| "column"`     | `"column"` | Layout direction                              |
+| `gap`           | Telegraph spacing token | `"2"`      | Space between radios                          |
+
+It renders a `Stack`, so the usual layout props apply. Arrow keys move the
+selection and the whole group is a single tab stop — that is Base UI's own
+roving focus, not a Telegraph shim.
+
+A group's `disabled` wins over a child's. `<Radio.Default disabled={false}>`
+inside a disabled group stays disabled, which is Base UI's rule.
+
+The second argument to `onValueChange` is Base UI's event detail, matching
+`@telegraph/checkbox`. It carries the native event and `cancel()`.
 
 ### `<RadioCards>`
 

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -35,7 +35,8 @@
     "@telegraph/button": "workspace:^",
     "@telegraph/helpers": "workspace:^",
     "@telegraph/icon": "workspace:^",
-    "@telegraph/layout": "workspace:^"
+    "@telegraph/layout": "workspace:^",
+    "@telegraph/typography": "workspace:^"
   },
   "devDependencies": {
     "@knocklabs/eslint-config": "^0.0.6",

--- a/packages/radio/src/Radio/Radio.constants.ts
+++ b/packages/radio/src/Radio/Radio.constants.ts
@@ -3,15 +3,17 @@
 // the control and label sizes have to match. The two packages are independent
 // and a shared constants dependency is not worth two package entries, so this
 // is a copy on purpose: change one, change the other.
+// `dotSize` is radio-only, and deliberately half the control at both sizes.
+// A smaller dot reads as a thick ring rather than a radio.
 export const RADIO_SIZE_MAP = {
   "1": {
     size: "4",
-    dotSize: "1_5",
+    dotSize: "2",
     labelSize: "1",
   },
   "2": {
     size: "5",
-    dotSize: "2",
+    dotSize: "2_5",
     labelSize: "2",
   },
 } as const;

--- a/packages/radio/src/Radio/Radio.constants.ts
+++ b/packages/radio/src/Radio/Radio.constants.ts
@@ -1,0 +1,40 @@
+// Deliberately kept in sync with `CHECKBOX_SIZE_MAP` in `@telegraph/checkbox`.
+// A radio and a checkbox at the same size sit next to each other in forms, so
+// the control and label sizes have to match. The two packages are independent
+// and a shared constants dependency is not worth two package entries, so this
+// is a copy on purpose: change one, change the other.
+export const RADIO_SIZE_MAP = {
+  "1": {
+    size: "4",
+    dotSize: "1_5",
+    labelSize: "1",
+  },
+  "2": {
+    size: "5",
+    dotSize: "2",
+    labelSize: "2",
+  },
+} as const;
+
+// Mirrors `CHECKBOX_COLOR_MAP`. Keep the key set aligned with `ButtonColor`.
+// `dotColor` is the checkbox's `indicatorColor` as a background token, because
+// the dot is a `Box` rather than an `Icon`.
+export const RADIO_COLOR_MAP = {
+  default: { backgroundColor: "gray-12", dotColor: "surface-1" },
+  accent: { backgroundColor: "accent-9", dotColor: "white" },
+  blue: { backgroundColor: "blue-9", dotColor: "white" },
+  gray: { backgroundColor: "gray-9", dotColor: "white" },
+  green: { backgroundColor: "green-9", dotColor: "white" },
+  purple: { backgroundColor: "purple-9", dotColor: "white" },
+  red: { backgroundColor: "red-9", dotColor: "white" },
+  yellow: { backgroundColor: "yellow-9", dotColor: "black" },
+} as const;
+
+// Applied when the radio is not selected.
+export const RADIO_UNSELECTED = {
+  borderColor: "gray-6",
+  backgroundColor: "surface-1",
+} as const;
+
+export type RadioSize = keyof typeof RADIO_SIZE_MAP;
+export type RadioColor = keyof typeof RADIO_COLOR_MAP;

--- a/packages/radio/src/Radio/Radio.helpers.test.tsx
+++ b/packages/radio/src/Radio/Radio.helpers.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { countLabels } from "./Radio.helpers";
+
+const Label = () => null;
+const NotALabel = () => null;
+// Stands in for any component that returns a label from inside itself.
+const Opaque = () => <Label />;
+
+const count = (node: Parameters<typeof countLabels>[0]) =>
+  countLabels(node, Label);
+
+describe("countLabels", () => {
+  it("returns 0 when there is nothing to find", () => {
+    expect(count(null)).toBe(0);
+    expect(count(undefined)).toBe(0);
+    expect(count(false)).toBe(0);
+    expect(count("Free plan")).toBe(0);
+    expect(count(<NotALabel />)).toBe(0);
+  });
+
+  it("counts a direct child", () => {
+    expect(count(<Label />)).toBe(1);
+  });
+
+  it("counts through nested wrappers", () => {
+    expect(
+      count(
+        <div>
+          <span>
+            <Label />
+          </span>
+        </div>,
+      ),
+    ).toBe(1);
+  });
+
+  it("counts every label in the tree", () => {
+    expect(
+      count(
+        <>
+          <Label />
+          <div>
+            <Label />
+          </div>
+        </>,
+      ),
+    ).toBe(2);
+  });
+
+  // The known limitation: a label a custom component renders is invisible here,
+  // because that component has not been called yet. `Radio.Control` then leaves
+  // `aria-labelledby` unset and Base UI names the control from the rendered
+  // `<label for>` instead.
+  it("cannot see a label returned by a custom component", () => {
+    expect(count(<Opaque />)).toBe(0);
+  });
+
+  it("ignores a different component that takes children", () => {
+    expect(
+      count(
+        <NotALabel>
+          <NotALabel />
+        </NotALabel>,
+      ),
+    ).toBe(0);
+  });
+});

--- a/packages/radio/src/Radio/Radio.helpers.ts
+++ b/packages/radio/src/Radio/Radio.helpers.ts
@@ -1,0 +1,23 @@
+import {
+  Children,
+  type ElementType,
+  type ReactNode,
+  isValidElement,
+} from "react";
+
+// Walks nested children, so a label inside a wrapper still counts. The
+// component is a parameter rather than an import to keep this file free of a
+// cycle back to `Radio.tsx`.
+//
+// It cannot see through a custom component: a label returned by one counts as
+// zero, and Base UI then names the control from the rendered `<label for>`.
+export const countLabels = (
+  node: ReactNode,
+  labelComponent: ElementType,
+): number =>
+  Children.toArray(node).reduce<number>((total, child) => {
+    if (!isValidElement(child)) return total;
+    if (child.type === labelComponent) return total + 1;
+    const nested = (child.props as { children?: ReactNode }).children;
+    return nested ? total + countLabels(nested, labelComponent) : total;
+  }, 0);

--- a/packages/radio/src/Radio/Radio.stories.tsx
+++ b/packages/radio/src/Radio/Radio.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Stack } from "@telegraph/layout";
+import { Text } from "@telegraph/typography";
+import { useState } from "react";
+
+import { RadioGroup } from "../RadioGroup";
+
+import { type DefaultProps, Radio } from "./Radio";
+import { RADIO_COLOR_MAP, RADIO_SIZE_MAP } from "./Radio.constants";
+
+const SIZES = Object.keys(RADIO_SIZE_MAP) as Array<keyof typeof RADIO_SIZE_MAP>;
+const COLORS = Object.keys(RADIO_COLOR_MAP) as Array<
+  keyof typeof RADIO_COLOR_MAP
+>;
+
+const meta: Meta<typeof Radio.Default> = {
+  title: "Components/Radio",
+  component: Radio.Default,
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: "select", options: SIZES },
+    color: { control: "select", options: COLORS },
+    disabled: { control: "boolean" },
+    label: { control: "text" },
+  },
+  args: {
+    value: "pro",
+    label: "Pro",
+    size: "2",
+    color: "default",
+    disabled: false,
+  },
+  // Every radio needs a group: Base UI derives selection from the group, so a
+  // radio on its own has no way to be selected.
+  decorators: [
+    (Story) => (
+      <RadioGroup name="plan" defaultValue="pro">
+        <Story />
+      </RadioGroup>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<DefaultProps<"div">>;
+
+export const Default: Story = {};
+
+/**
+ * Selected, unselected and disabled. A radio is rounded with a dot where the
+ * checkbox is squared with a check, and matches it at every other axis.
+ */
+export const States: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <RadioGroup name="states" defaultValue="selected">
+      <Radio.Default value="unselected" label="Unselected" />
+      <Radio.Default value="selected" label="Selected" />
+      <Radio.Default value="disabled" label="Disabled" disabled />
+      <Radio.Default
+        value="disabled-selected"
+        label="Disabled, selected"
+        disabled
+      />
+    </RadioGroup>
+  ),
+};
+
+/**
+ * Both sizes, next to each other. Size `1` is a 16px control, size `2` is
+ * 20px, matching `@telegraph/checkbox`.
+ */
+export const Sizes: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <Stack direction="column" gap="4">
+      {SIZES.map((size) => (
+        <Stack key={size} direction="column" gap="1">
+          <Text as="span" size="0" color="gray">
+            size {size}
+          </Text>
+          <RadioGroup name={`size-${size}`} size={size} defaultValue="on">
+            <Radio.Default value="on" label="Selected" />
+            <Radio.Default value="off" label="Unselected" />
+          </RadioGroup>
+        </Stack>
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * The same palette as `@telegraph/button`, so a selected radio matches a solid
+ * button of the same color.
+ */
+export const Colors: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <Stack direction="column" gap="2">
+      {COLORS.map((color) => (
+        <RadioGroup key={color} name={color} color={color} defaultValue="on">
+          <Radio.Default value="on" label={color} />
+        </RadioGroup>
+      ))}
+    </Stack>
+  ),
+};
+
+/**
+ * The composable parts. `Radio.Root` holds state and layout, `Radio.Control`
+ * is the circle and its dot, and `Radio.Label` associates itself with the
+ * control automatically.
+ */
+export const Composed: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <RadioGroup name="composed" defaultValue="pro">
+      <Radio.Root value="free">
+        <Radio.Control />
+        <Radio.Label>Free</Radio.Label>
+      </Radio.Root>
+      <Radio.Root value="pro">
+        <Radio.Control />
+        <Radio.Label>Pro</Radio.Label>
+      </Radio.Root>
+    </RadioGroup>
+  ),
+};
+
+/**
+ * A controlled group. Arrow keys move the selection, and the whole group is a
+ * single tab stop.
+ */
+export const Controlled: Story = {
+  decorators: [(Story) => <Story />],
+  render: function ControlledStory() {
+    const [plan, setPlan] = useState("free");
+    return (
+      <Stack direction="column" gap="3">
+        <RadioGroup name="plan" value={plan} onValueChange={setPlan}>
+          <Radio.Default value="free" label="Free" />
+          <Radio.Default value="pro" label="Pro" />
+          <Radio.Default value="enterprise" label="Enterprise" disabled />
+        </RadioGroup>
+        <Text as="span" size="1" color="gray">
+          selected: {plan}
+        </Text>
+      </Stack>
+    );
+  },
+};

--- a/packages/radio/src/Radio/Radio.stories.tsx
+++ b/packages/radio/src/Radio/Radio.stories.tsx
@@ -53,17 +53,23 @@ export const Default: Story = {};
  */
 export const States: Story = {
   decorators: [(Story) => <Story />],
+  // Two groups on purpose. A group holds one selection, so the selected and
+  // the disabled-selected radios cannot both be checked inside the same one.
   render: () => (
-    <RadioGroup name="states" defaultValue="selected">
-      <Radio.Default value="unselected" label="Unselected" />
-      <Radio.Default value="selected" label="Selected" />
-      <Radio.Default value="disabled" label="Disabled" disabled />
-      <Radio.Default
-        value="disabled-selected"
-        label="Disabled, selected"
-        disabled
-      />
-    </RadioGroup>
+    <Stack direction="column" gap="4">
+      <RadioGroup name="states" defaultValue="selected">
+        <Radio.Default value="unselected" label="Unselected" />
+        <Radio.Default value="selected" label="Selected" />
+        <Radio.Default value="disabled" label="Disabled" disabled />
+      </RadioGroup>
+      <RadioGroup name="states-disabled" defaultValue="disabled-selected">
+        <Radio.Default
+          value="disabled-selected"
+          label="Disabled, selected"
+          disabled
+        />
+      </RadioGroup>
+    </Stack>
   ),
 };
 

--- a/packages/radio/src/Radio/Radio.styles.css
+++ b/packages/radio/src/Radio/Radio.styles.css
@@ -1,0 +1,65 @@
+/* Mirrors `Checkbox.styles.css`. The only visual differences are the rounding
+   and the dot, so any change here probably belongs there too.
+
+   `cursor` lives here rather than inline on the root, so it covers only the
+   parts that actually respond to a click. The root is a plain `div` with no
+   handler of its own, so the gap between the control and the label does
+   nothing — a pointer over it was a lie. */
+[data-tgph-radio-control] {
+  /* Without this the 1px border sits outside the size token, so size "2"
+     renders 22px instead of 20px and falls off the spacing grid. */
+  box-sizing: border-box;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition:
+    background-color 120ms cubic-bezier(0.16, 1, 0.3, 1),
+    border-color 120ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* Base UI puts `role="radio"` and `tabindex="0"` on the element it renders
+   (this one) and keeps the real input as an aria-hidden, tabindex="-1"
+   sibling. So focus lands here, not on the input — don't reach for
+   `:has(input:focus-visible)` like Toggle does; the input is not a descendant
+   and never receives focus. */
+[data-tgph-radio-control]:focus-visible {
+  outline: 2px solid var(--tgph-blue-8);
+  outline-offset: 2px;
+}
+
+/* Read-only is not disabled: the value still submits and the control stays in
+   the tab order, so it must not read as inert. Only the cursor changes. This
+   sits above the disabled rule so that disabled wins when both are set; the
+   two selectors have equal specificity. */
+[data-tgph-radio-control][data-readonly] {
+  cursor: default;
+}
+
+[data-tgph-radio-control][data-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* The dot scales off the size map, so it only needs to hold its shape. */
+[data-tgph-radio-indicator] {
+  line-height: 0;
+}
+
+[data-tgph-radio-label] {
+  cursor: pointer;
+  user-select: none;
+}
+
+[data-tgph-radio-root]:has([data-tgph-radio-control][data-readonly])
+  [data-tgph-radio-label] {
+  cursor: default;
+}
+
+/* Keyed off Base UI's own `data-disabled` rather than a flag this package
+   computes. Base UI ORs together the radio prop, the group, and any enclosing
+   `Field`, and only the first two are visible from here — so deriving it a
+   second time drifts, and the label renders enabled over a dead control. */
+[data-tgph-radio-root]:has([data-tgph-radio-control][data-disabled])
+  [data-tgph-radio-label] {
+  cursor: not-allowed;
+  color: var(--tgph-gray-9);
+}

--- a/packages/radio/src/Radio/Radio.test-d.tsx
+++ b/packages/radio/src/Radio/Radio.test-d.tsx
@@ -1,0 +1,290 @@
+import { Radio } from ".";
+import type {
+  RadioColor,
+  RadioControlProps,
+  RadioLabelProps,
+  RadioProps,
+  RadioRootBaseProps,
+  RadioRootProps,
+  RadioSize,
+} from ".";
+import type { RadioGroupChangeEventDetails } from "@base-ui/react/radio-group";
+import type { RefObject } from "react";
+import { describe, expectTypeOf, it } from "vitest";
+
+import { RadioGroup } from "../RadioGroup";
+import type { RadioGroupBaseProps, RadioGroupProps } from "../RadioGroup";
+
+describe("Radio types", () => {
+  it("has no catch-all index signature", () => {
+    expectTypeOf<RadioProps>().not.toHaveProperty("notARealProp");
+    expectTypeOf<RadioRootProps>().not.toHaveProperty("notARealProp");
+    // Also closed when the element is pinned to something other than the default.
+    expectTypeOf<RadioRootProps<"section">>().not.toHaveProperty(
+      "notARealProp",
+    );
+    expectTypeOf<RadioProps<"a">>().not.toHaveProperty("notARealProp");
+    expectTypeOf<RadioRootBaseProps>().not.toHaveProperty("notARealProp");
+    expectTypeOf<RadioControlProps>().not.toHaveProperty("notARealProp");
+    expectTypeOf<RadioLabelProps>().not.toHaveProperty("notARealProp");
+  });
+
+  it("keeps declared props narrow", () => {
+    expectTypeOf<RadioSize>().not.toBeAny();
+    expectTypeOf<RadioColor>().not.toBeAny();
+    expectTypeOf<RadioProps["size"]>().not.toBeAny();
+    expectTypeOf<RadioProps["color"]>().not.toBeAny();
+    expectTypeOf<RadioProps["value"]>().not.toBeAny();
+    expectTypeOf<RadioProps["disabled"]>().not.toBeAny();
+    expectTypeOf<RadioProps["label"]>().not.toBeAny();
+    expectTypeOf<RadioRootBaseProps["value"]>().not.toBeAny();
+  });
+
+  // A radio's `value` is the option's identity, not what the control holds.
+  // It is required, unlike every other prop on the surface.
+  it("types value as a required string", () => {
+    expectTypeOf<RadioProps["value"]>().toEqualTypeOf<string>();
+    // @ts-expect-error value is required
+    <Radio.Root />;
+    // @ts-expect-error value is required
+    <Radio.Default label="Pro" />;
+  });
+
+  it("rejects unknown props", () => {
+    <Radio.Default
+      value="pro"
+      // @ts-expect-error unknown prop
+      fontSize={16}
+    />;
+    <Radio.Default
+      value="pro"
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+    <Radio.Root
+      value="pro"
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+    <Radio.Control
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+    <Radio.Label
+      as="label"
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+  });
+
+  // Nested prop bags get excess-property checking as fresh object literals,
+  // unlike hyphenated JSX attributes.
+  it("rejects unknown props inside nested prop bags", () => {
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      // @ts-expect-error unknown prop in the label bag
+      labelProps={{ notARealProp: "x" }}
+    />;
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      // @ts-expect-error unknown prop in the control bag
+      controlProps={{ notARealProp: "x" }}
+    />;
+  });
+
+  // `Radio.Control` points `aria-labelledby` at the id the root resolved, so a
+  // caller-supplied label id would leave a dangling IDREF.
+  it("rejects id on the label", () => {
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      // @ts-expect-error id belongs to the root
+      labelProps={{ id: "my-label" }}
+    />;
+    <Radio.Root value="pro">
+      {/* @ts-expect-error id belongs to the root */}
+      <Radio.Label id="my-label">Pro</Radio.Label>
+    </Radio.Root>;
+  });
+
+  // `Radio.Root` owns these and forwards them. Through `controlProps` they
+  // would spread over the resolved value.
+  it("rejects root-owned state props on the control", () => {
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      disabled
+      // @ts-expect-error disabled belongs on the root
+      controlProps={{ disabled: false }}
+    />;
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      // @ts-expect-error readOnly belongs on the root
+      controlProps={{ readOnly: true }}
+    />;
+    // The root still takes them.
+    <Radio.Default value="pro" label="Pro" disabled readOnly required />;
+  });
+
+  it("rejects invalid values for declared props", () => {
+    <Radio.Default
+      value="pro"
+      // @ts-expect-error not a radio size
+      size="3"
+    />;
+    <Radio.Default
+      value="pro"
+      // @ts-expect-error not a radio color
+      color="notAColor"
+    />;
+    <Radio.Default
+      // @ts-expect-error value must be a string
+      value={1}
+    />;
+    <Radio.Default
+      value="pro"
+      // @ts-expect-error not a spacing token
+      p={12345}
+    />;
+    <Radio.Label
+      as="label"
+      // @ts-expect-error not a text size token
+      size="99"
+    />;
+  });
+
+  it("renders as another element and types tgphRef to match", () => {
+    <Radio.Root as="span" value="pro" />;
+    <Radio.Default as="section" value="pro" label="Pro" />;
+    <Radio.Label as="span">Pro</Radio.Label>;
+
+    <Radio.Root
+      as="span"
+      value="pro"
+      tgphRef={(node) => {
+        expectTypeOf(node).toEqualTypeOf<HTMLElement | null>();
+      }}
+    />;
+  });
+
+  it("rejects a tgphRef that does not match the element", () => {
+    const svgRef = {} as RefObject<SVGSVGElement>;
+    <Radio.Root
+      value="pro"
+      // @ts-expect-error the root renders an HTML element, not an SVG one
+      tgphRef={svgRef}
+    />;
+  });
+
+  // Every row of the README's Radio table, so a documented-but-nonexistent
+  // prop is a compile error.
+  it("accepts every prop the README documents", () => {
+    <Radio.Default
+      value="pro"
+      label="Pro"
+      size="2"
+      color="blue"
+      disabled={false}
+      readOnly={false}
+      required={false}
+      labelProps={{ color: "gray" }}
+      controlProps={{ inputRef: { current: null } }}
+    />;
+  });
+});
+
+describe("RadioGroup types", () => {
+  it("has no catch-all index signature", () => {
+    expectTypeOf<RadioGroupProps>().not.toHaveProperty("notARealProp");
+    expectTypeOf<RadioGroupBaseProps>().not.toHaveProperty("notARealProp");
+  });
+
+  it("keeps declared props narrow", () => {
+    expectTypeOf<RadioGroupProps["value"]>().not.toBeAny();
+    expectTypeOf<RadioGroupProps["defaultValue"]>().not.toBeAny();
+    expectTypeOf<RadioGroupProps["onValueChange"]>().not.toBeAny();
+    expectTypeOf<RadioGroupProps["size"]>().not.toBeAny();
+    expectTypeOf<RadioGroupProps["color"]>().not.toBeAny();
+  });
+
+  // A radio group holds one option, so `value` is a string rather than the
+  // checkbox group's array.
+  it("types the selection as a single string", () => {
+    expectTypeOf<RadioGroupProps["value"]>().toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf<
+      Parameters<NonNullable<RadioGroupProps["onValueChange"]>>
+    >().toEqualTypeOf<[string, RadioGroupChangeEventDetails]>();
+  });
+
+  // KNO-14309: wrapping a Base UI callback can collapse its params to `any` at
+  // the JSX call site while the props type still looks right. Only an
+  // assertion inside the JSX catches that.
+  it("types onValueChange at the JSX call site, never any", () => {
+    <RadioGroup
+      name="plan"
+      onValueChange={(value, eventDetails) => {
+        expectTypeOf(value).toEqualTypeOf<string>();
+        expectTypeOf(
+          eventDetails,
+        ).toEqualTypeOf<RadioGroupChangeEventDetails>();
+        expectTypeOf(eventDetails.cancel).toBeFunction();
+      }}
+    />;
+  });
+
+  // The group renders its element inside Base UI's `render` callback, so it is
+  // deliberately not polymorphic.
+  it("rejects as", () => {
+    // @ts-expect-error RadioGroup is not polymorphic
+    <RadioGroup as="section" />;
+    // @ts-expect-error not even the element it actually renders
+    <RadioGroup as="div" />;
+  });
+
+  it("rejects unknown props and invalid values", () => {
+    <RadioGroup
+      // @ts-expect-error unknown prop
+      notARealProp="x"
+    />;
+    <RadioGroup
+      // @ts-expect-error a radio group holds one value, not a list
+      value={["pro"]}
+    />;
+    <RadioGroup
+      // @ts-expect-error not a radio size
+      size="3"
+    />;
+    <RadioGroup
+      // @ts-expect-error not a flex direction
+      direction="sideways"
+    />;
+    <RadioGroup
+      // @ts-expect-error onValueChange receives a string
+      onValueChange={(value: number) => value}
+    />;
+  });
+
+  // Every row of the README's RadioGroup table.
+  it("accepts every prop the README documents", () => {
+    <RadioGroup
+      value="pro"
+      onValueChange={() => {}}
+      name="plan"
+      size="2"
+      color="blue"
+      disabled={false}
+      readOnly={false}
+      required={false}
+      direction="column"
+      gap="2"
+    >
+      <Radio.Default value="pro" label="Pro" />
+    </RadioGroup>;
+    <RadioGroup defaultValue="free" direction="row" form="my-form" />;
+  });
+});

--- a/packages/radio/src/Radio/Radio.test.tsx
+++ b/packages/radio/src/Radio/Radio.test.tsx
@@ -2,7 +2,7 @@ import { Field } from "@base-ui/react/field";
 import { Stack } from "@telegraph/layout";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { FormEvent } from "react";
+import type { ComponentProps, FormEvent, ReactNode } from "react";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -22,10 +22,7 @@ const getInputs = (container: HTMLElement) =>
     container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
   );
 
-const Group = ({
-  children,
-  ...props
-}: React.ComponentProps<typeof RadioGroup>) => (
+const Group = ({ children, ...props }: ComponentProps<typeof RadioGroup>) => (
   <RadioGroup name="plan" {...props}>
     {children ?? (
       <>
@@ -113,7 +110,7 @@ describe("Radio", () => {
   });
 
   describe("form submission", () => {
-    const renderForm = (ui: React.ReactNode, onSubmit: (d: FormData) => void) =>
+    const renderForm = (ui: ReactNode, onSubmit: (d: FormData) => void) =>
       render(
         <form
           onSubmit={(event: FormEvent<HTMLFormElement>) => {
@@ -224,6 +221,61 @@ describe("Radio", () => {
       );
 
       expect(getRadio("Pro")).toHaveAccessibleDescription("Billed yearly");
+    });
+
+    // Base UI resolves the input id through `useLabelableId`, which returns
+    // the enclosing labelable scope's control id ahead of the `id` we pass, so
+    // the input does not always keep the id `Radio.Root` generated.
+    // `Radio.Control` reports the real one back and `Radio.Label` points
+    // `htmlFor` at that. With one radio the first id happens to line up
+    // anyway, so this needs three to catch a regression.
+    it("keeps label association working for every radio inside a Field", async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      const { container } = render(
+        <Field.Root>
+          <RadioGroup name="plan" onValueChange={onValueChange}>
+            <Field.Item>
+              <Radio.Default value="free" label="Free" />
+            </Field.Item>
+            <Field.Item>
+              <Radio.Default value="pro" label="Pro" />
+            </Field.Item>
+            <Field.Item>
+              <Radio.Default value="enterprise" label="Enterprise" />
+            </Field.Item>
+          </RadioGroup>
+        </Field.Root>,
+      );
+
+      const ids = getInputs(container).map((input) => input.id);
+      expect(new Set(ids).size).toBe(3);
+
+      // Every label resolves to its own input, not just the first.
+      const labels = Array.from(container.querySelectorAll("label"));
+      expect(labels.map((label) => label.control)).not.toContain(null);
+
+      // The last label is the one that breaks when the ids collide.
+      await user.click(screen.getByText("Enterprise"));
+      expect(onValueChange.mock.calls[0]![0]).toBe("enterprise");
+    });
+
+    // A bare `Field.Root` holds one control id and hands it to every radio
+    // inside it, so the inputs collide and only the first label works. That is
+    // Base UI's scoping, not something this package can undo: `Field.Item` is
+    // the supported way to put more than one control in a field. Pinned so a
+    // future Base UI release that fixes it shows up as a failure here.
+    it("shares one input id across radios in a bare Field, so Field.Item is required", () => {
+      const { container } = render(
+        <Field.Root>
+          <RadioGroup name="plan">
+            <Radio.Default value="free" label="Free" />
+            <Radio.Default value="pro" label="Pro" />
+          </RadioGroup>
+        </Field.Root>,
+      );
+      const ids = getInputs(container).map((input) => input.id);
+      expect(new Set(ids).size).toBe(1);
     });
 
     // A visible label wins over `aria-label`: Base UI's fallback re-derives

--- a/packages/radio/src/Radio/Radio.test.tsx
+++ b/packages/radio/src/Radio/Radio.test.tsx
@@ -1,0 +1,322 @@
+import { Field } from "@base-ui/react/field";
+import { Stack } from "@telegraph/layout";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { FormEvent } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+import { RadioGroup } from "../RadioGroup";
+
+import { Radio } from "./Radio";
+
+// Base UI puts `role="radio"` and `aria-checked` on the element it renders
+// (our styled Stack), and keeps the real `<input>` out of the a11y tree. So
+// aria assertions go through `getRadio`, and anything about the actual form
+// control goes through the hidden input.
+const getRadio = (name: string) => screen.getByRole("radio", { name });
+
+const getInputs = (container: HTMLElement) =>
+  Array.from(
+    container.querySelectorAll<HTMLInputElement>('input[type="radio"]'),
+  );
+
+const Group = ({
+  children,
+  ...props
+}: React.ComponentProps<typeof RadioGroup>) => (
+  <RadioGroup name="plan" {...props}>
+    {children ?? (
+      <>
+        <Radio.Default value="free" label="Free" />
+        <Radio.Default value="pro" label="Pro" />
+        <Radio.Default value="enterprise" label="Enterprise" />
+      </>
+    )}
+  </RadioGroup>
+);
+
+describe("Radio", () => {
+  it("is accessible", async () => {
+    const { container } = render(<Group defaultValue="free" />);
+    expectToHaveNoViolations(await axe(container));
+  });
+
+  it("is accessible when disabled", async () => {
+    const { container } = render(
+      <RadioGroup name="plan">
+        <Radio.Default value="free" label="Free" disabled />
+      </RadioGroup>,
+    );
+    expectToHaveNoViolations(await axe(container));
+  });
+
+  it("renders a real radio input under the group name", () => {
+    const { container } = render(<Group />);
+    const inputs = getInputs(container);
+
+    expect(inputs).toHaveLength(3);
+    expect(inputs[0]!.type).toBe("radio");
+    expect(inputs.every((input) => input.name === "plan")).toBe(true);
+  });
+
+  // `Radio.styles.css` hangs the focus ring off
+  // `[data-tgph-radio-control]:focus-visible`, which is only correct because
+  // Base UI makes the rendered element focusable and keeps the real input
+  // hidden beside it. If Base UI ever moves focus onto the input, the ring
+  // silently stops rendering — so pin the structure here.
+  it("puts focus on the control, not the hidden input", () => {
+    const { container } = render(<Group />);
+    const control = getRadio("Free");
+    const input = getInputs(container)[0]!;
+
+    expect(control).toHaveAttribute("tabindex", "0");
+    expect(input).toHaveAttribute("tabindex", "-1");
+    expect(input).toHaveAttribute("aria-hidden", "true");
+    // The input is a sibling of the control, never a descendant.
+    expect(control.contains(input)).toBe(false);
+  });
+
+  it("associates the label with the input", async () => {
+    const user = userEvent.setup();
+    render(<Group />);
+
+    // Clicking the label text selects, which only works if htmlFor points at
+    // the input's id.
+    await user.click(screen.getByText("Pro"));
+    expect(getRadio("Pro")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("selects one option at a time", async () => {
+    const user = userEvent.setup();
+    render(<Group defaultValue="free" />);
+
+    expect(getRadio("Free")).toHaveAttribute("aria-checked", "true");
+    await user.click(getRadio("Pro"));
+
+    expect(getRadio("Pro")).toHaveAttribute("aria-checked", "true");
+    expect(getRadio("Free")).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("does not select a disabled option", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup name="plan" onValueChange={onValueChange}>
+        <Radio.Default value="free" label="Free" disabled />
+      </RadioGroup>,
+    );
+
+    await user.click(getRadio("Free"));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  describe("form submission", () => {
+    const renderForm = (ui: React.ReactNode, onSubmit: (d: FormData) => void) =>
+      render(
+        <form
+          onSubmit={(event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            onSubmit(new FormData(event.currentTarget));
+          }}
+        >
+          {ui}
+          <button type="submit">Submit</button>
+        </form>,
+      );
+
+    it("submits the selected value under the group name", async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      renderForm(<Group defaultValue="pro" />, onSubmit);
+
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+
+      const data = onSubmit.mock.calls[0]![0] as FormData;
+      expect(data.get("plan")).toBe("pro");
+      // One value, not one entry per radio.
+      expect(data.getAll("plan")).toEqual(["pro"]);
+    });
+
+    it("submits nothing when no option is selected", async () => {
+      const user = userEvent.setup();
+      const onSubmit = vi.fn();
+      renderForm(<Group />, onSubmit);
+
+      await user.click(screen.getByRole("button", { name: "Submit" }));
+
+      expect((onSubmit.mock.calls[0]![0] as FormData).get("plan")).toBeNull();
+    });
+  });
+
+  describe("composition", () => {
+    it("renders Root / Control / Label", async () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Root value="pro">
+            <Radio.Control />
+            <Radio.Label>Pro</Radio.Label>
+          </Radio.Root>
+        </RadioGroup>,
+      );
+
+      expect(getRadio("Pro")).toBeInTheDocument();
+      expectToHaveNoViolations(await axe(container));
+    });
+
+    it("names the control from a label nested in a wrapper", () => {
+      render(
+        <RadioGroup name="plan">
+          <Radio.Root value="pro">
+            <Radio.Control />
+            <Stack>
+              <Radio.Label>Pro</Radio.Label>
+            </Stack>
+          </Radio.Root>
+        </RadioGroup>,
+      );
+      expect(getRadio("Pro")).toBeInTheDocument();
+    });
+  });
+
+  // Label presence is decided during render, not in an effect. An effect never
+  // runs on the server, so server-rendered markup would ship an unnamed radio.
+  it("names the control in server-rendered markup", () => {
+    const html = renderToString(
+      <RadioGroup name="plan">
+        <Radio.Default value="pro" label="Pro" />
+      </RadioGroup>,
+    );
+    const control = html.slice(html.indexOf('role="radio"'));
+
+    expect(control).toContain("aria-labelledby=");
+    const labelId = /aria-labelledby="([^"]+)"/.exec(control)![1]!;
+    expect(html).toContain(`id="${labelId}"`);
+  });
+
+  describe("aria props on Root", () => {
+    it("forwards aria-label to the control", () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Default value="pro" aria-label="Pro plan" />
+        </RadioGroup>,
+      );
+
+      expect(getRadio("Pro plan")).toBeInTheDocument();
+      expect(
+        container.querySelector("[data-tgph-radio-root]"),
+      ).not.toHaveAttribute("aria-label");
+    });
+
+    // Base UI does not destructure `aria-describedby`, so it lands in
+    // `elementProps` and merges after `getDescriptionProps` — and that merge
+    // overwrites with `undefined`. Forwarding the prop unconditionally would
+    // erase whatever a wrapping `Field` had computed.
+    it("does not erase a Field description by forwarding undefined", () => {
+      render(
+        <Field.Root>
+          <RadioGroup name="plan">
+            <Radio.Default value="pro" label="Pro" />
+          </RadioGroup>
+          <Field.Description>Billed yearly</Field.Description>
+        </Field.Root>,
+      );
+
+      expect(getRadio("Pro")).toHaveAccessibleDescription("Billed yearly");
+    });
+
+    // A visible label wins over `aria-label`: Base UI's fallback re-derives
+    // `aria-labelledby` from the associated `<label>`, and that outranks
+    // `aria-label`. `aria-labelledby` is the escape hatch.
+    it("lets aria-labelledby override a visible label", () => {
+      render(
+        <>
+          <span id="row">Pro plan, billed yearly</span>
+          <RadioGroup name="plan">
+            <Radio.Default value="pro" aria-labelledby="row" label="Pro" />
+          </RadioGroup>
+        </>,
+      );
+      expect(getRadio("Pro plan, billed yearly")).toBeInTheDocument();
+    });
+  });
+
+  describe("label rendering", () => {
+    // `{label && …}` renders a bare `0` instead of a label.
+    it("renders a zero label inside a real label element", () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Default value="zero" label={0} />
+        </RadioGroup>,
+      );
+      expect(container.querySelector("label")).toHaveTextContent("0");
+    });
+
+    it("renders no label for false", () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Default value="pro" aria-label="Pro" label={false} />
+        </RadioGroup>,
+      );
+      expect(container.querySelector("label")).toBeNull();
+    });
+
+    // `Radio.Control` points `aria-labelledby` at `context.labelId` during
+    // render, so a caller-supplied id would leave a dangling IDREF.
+    it("keeps its own id even when a caller passes one", () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Default
+            value="pro"
+            label="Pro"
+            // @ts-expect-error id is not part of the label surface
+            labelProps={{ id: "my-label" }}
+          />
+        </RadioGroup>,
+      );
+
+      const label = container.querySelector("label")!;
+      expect(label.id).not.toBe("my-label");
+      expect(getRadio("Pro")).toHaveAttribute("aria-labelledby", label.id);
+    });
+  });
+
+  describe("styling hooks", () => {
+    it("exposes size and color as data attributes", () => {
+      render(
+        <RadioGroup name="plan" size="1" color="red">
+          <Radio.Default value="free" label="Free" />
+          <Radio.Default value="pro" label="Pro" size="2" />
+        </RadioGroup>,
+      );
+
+      const control = (name: string) =>
+        getRadio(name).closest("[data-tgph-radio-control]") ?? getRadio(name);
+
+      expect(control("Free")).toHaveAttribute("data-tgph-radio-size", "1");
+      expect(control("Free")).toHaveAttribute("data-tgph-radio-color", "red");
+      // A radio's own size prop beats the group default.
+      expect(control("Pro")).toHaveAttribute("data-tgph-radio-size", "2");
+      expect(control("Pro")).toHaveAttribute("data-tgph-radio-color", "red");
+    });
+
+    it("puts className on each part", () => {
+      const { container } = render(
+        <RadioGroup name="plan">
+          <Radio.Default
+            value="pro"
+            label="Pro"
+            className="my-root"
+            controlProps={{ className: "my-control" }}
+            labelProps={{ className: "my-label" }}
+          />
+        </RadioGroup>,
+      );
+
+      expect(container.querySelector(".my-root")).toBeInTheDocument();
+      expect(container.querySelector(".my-control")).toBeInTheDocument();
+      expect(container.querySelector(".my-label")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/radio/src/Radio/Radio.tsx
+++ b/packages/radio/src/Radio/Radio.tsx
@@ -49,7 +49,14 @@ export type RootBaseProps = Pick<
 
 // `value` is stripped from the `Stack` half because a radio's `value` is a
 // string option id, while every element declares its own conflicting `value`.
-type StripConflicting = "value" | "defaultValue" | "onChange" | "disabled";
+// `disabled` and `id` are declared on `RootBaseProps` instead, since the root
+// renders a `div` but forwards them to the input `Radio.Control` renders.
+type StripConflicting =
+  | "value"
+  | "defaultValue"
+  | "onChange"
+  | "disabled"
+  | "id";
 
 export type RootProps<T extends TgphElement = "div"> = RemappedOmit<
   StackProps<T>,
@@ -368,4 +375,4 @@ const Radio = {
   Label,
 };
 
-export { Radio, RadioContext };
+export { Radio };

--- a/packages/radio/src/Radio/Radio.tsx
+++ b/packages/radio/src/Radio/Radio.tsx
@@ -1,0 +1,371 @@
+import {
+  Radio as BaseRadio,
+  type RadioRootProps as BaseRadioRootProps,
+} from "@base-ui/react/radio";
+import {
+  type AsAndTgphRefProps,
+  type RemappedOmit,
+  type TgphElement,
+  createTgphBaseUIRender,
+} from "@telegraph/helpers";
+import { Box, Stack, type StackProps } from "@telegraph/layout";
+import { Text, type TextProps } from "@telegraph/typography";
+import {
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+  type Ref,
+  createContext,
+  useContext,
+  useId,
+  useMemo,
+} from "react";
+
+import { useRadioGroupContext } from "../RadioGroup/RadioGroup.context";
+
+import {
+  RADIO_COLOR_MAP,
+  RADIO_SIZE_MAP,
+  RADIO_UNSELECTED,
+  type RadioColor,
+  type RadioSize,
+} from "./Radio.constants";
+import { countLabels } from "./Radio.helpers";
+
+// `value` identifies the option and is required, unlike the checkbox where it
+// held the checked state. `disabled`, `required` and `readOnly` pass straight
+// through to Base UI. Whether a radio is selected is owned entirely by the
+// enclosing group, so there is no `checked` prop and no indeterminate state.
+export type RootBaseProps = Pick<
+  BaseRadioRootProps,
+  "disabled" | "required" | "readOnly"
+> & {
+  // This option's identity, and the string the form submits under the group's
+  // `name`. Required by Base UI.
+  value: string;
+  size?: RadioSize;
+  color?: RadioColor;
+  id?: string;
+};
+
+// `value` is stripped from the `Stack` half because a radio's `value` is a
+// string option id, while every element declares its own conflicting `value`.
+type StripConflicting = "value" | "defaultValue" | "onChange" | "disabled";
+
+export type RootProps<T extends TgphElement = "div"> = RemappedOmit<
+  StackProps<T>,
+  "tgphRef" | "as" | StripConflicting
+> &
+  AsAndTgphRefProps<T, HTMLElement> &
+  RootBaseProps;
+
+// Everything the root resolves and the parts read back. Sourced from
+// `RootBaseProps` so a prop added to the public surface cannot silently fail
+// to reach the parts that render it.
+type InternalContextType = Pick<
+  RootBaseProps,
+  "value" | "disabled" | "required" | "readOnly"
+> &
+  Pick<BaseRadioRootProps, "aria-label" | "aria-describedby"> & {
+    // `Root` always resolves these, so the context holds them where
+    // `RootBaseProps` leaves them optional.
+    size: RadioSize;
+    color: RadioColor;
+    id: string;
+    labelId: string;
+    // Decided during render, not in an effect: the control has to emit
+    // `aria-labelledby` in the first pass or SSR ships an unnamed radio.
+    hasLabel: boolean;
+    // Base UI types this as `string | null`; we only ever pass a string.
+    "aria-labelledby"?: string;
+  };
+
+const RadioContext = createContext<InternalContextType>({
+  value: "",
+  size: "2",
+  color: "default",
+  disabled: false,
+  id: "",
+  labelId: "",
+  hasLabel: false,
+});
+
+const Root = <T extends TgphElement = "div">(rootProps: RootProps<T>) => {
+  const {
+    size: sizeProp,
+    color: colorProp,
+    value,
+    disabled: disabledProp,
+    required,
+    readOnly,
+    id: idProp,
+    className,
+    children,
+    as,
+    style,
+    // These three describe the radio, so they belong on the element Base UI
+    // gives `role="radio"`. Left in the spread they land on the layout
+    // wrapper, where a screen reader never reads them.
+    "aria-label": ariaLabel,
+    "aria-labelledby": ariaLabelledBy,
+    "aria-describedby": ariaDescribedBy,
+    ...props
+  } = rootProps as RootProps<"div">;
+  const group = useRadioGroupContext();
+
+  // Own prop wins, then the group's default, then the component default.
+  const size = sizeProp ?? group?.size ?? "2";
+  const color = colorProp ?? group?.color ?? "default";
+  // `disabled` is the exception: Base UI ORs the group's value over the
+  // radio's own, so a group that disables its children cannot be opted out of.
+  // Match that here or the label styles itself enabled over a control Base UI
+  // has already disabled.
+  const disabled = group?.disabled || disabledProp || false;
+
+  const generatedId = useId();
+  const id = idProp || generatedId;
+  const labelId = `${id}-label`;
+
+  const hasLabel = useMemo(() => countLabels(children, Label) > 0, [children]);
+
+  return (
+    <RadioContext.Provider
+      value={{
+        size,
+        color,
+        value,
+        disabled,
+        required,
+        readOnly,
+        id,
+        labelId,
+        hasLabel,
+        "aria-label": ariaLabel,
+        "aria-labelledby": ariaLabelledBy,
+        "aria-describedby": ariaDescribedBy,
+      }}
+    >
+      <Stack
+        as={as}
+        align="center"
+        gap="2"
+        className={className}
+        data-tgph-radio-root
+        style={style}
+        {...props}
+      >
+        {children}
+      </Stack>
+    </RadioContext.Provider>
+  );
+};
+
+type BaseRadioRenderProps = ComponentPropsWithoutRef<"span"> & {
+  ref?: Ref<HTMLElement>;
+};
+
+type BaseRadioState = {
+  checked: boolean;
+  disabled: boolean;
+  readOnly: boolean;
+  required: boolean;
+};
+
+// `Radio.Indicator` exposes a narrower state than the root: just `checked` and
+// a transition status. Declaring the root's state here would ask for fields
+// Base UI never passes.
+type BaseRadioIndicatorState = {
+  checked: boolean;
+};
+
+// Picked, not omitted: `Radio.Root` owns every other Base UI prop and forwards
+// it, and the HTML attribute surface already arrives with the `Stack` props
+// below. An omit list would let anything Base UI adds later type-check here
+// and then spread onto the styled `div`.
+export type ControlProps = Pick<BaseRadioRootProps, "inputRef"> &
+  // Layout props reach the styled circle, so callers can size or recolor it.
+  RemappedOmit<StackProps<"div">, "as" | "tgphRef" | "color"> & {
+    tgphRef?: Ref<HTMLElement>;
+    // Overrides the dot. Listed field by field rather than omitted from
+    // `StackProps`, so the surface stays small and obvious.
+    dotProps?: {
+      bg?: StackProps<"div">["bg"];
+      w?: StackProps<"div">["w"];
+      h?: StackProps<"div">["h"];
+    };
+  };
+
+const Control = (controlProps: ControlProps) => {
+  const {
+    tgphRef,
+    dotProps,
+    inputRef,
+    // Keeping these out of `ControlProps` only stops a type-checked caller.
+    // Base UI resolves them from the root, so drop anything that slips
+    // through untyped rather than let it spread over the resolved value.
+    disabled: _disabled,
+    readOnly: _readOnly,
+    required: _required,
+    ...stackProps
+  } = controlProps as ControlProps & {
+    disabled?: boolean;
+    readOnly?: boolean;
+    required?: boolean;
+  };
+  const context = useContext(RadioContext);
+  const { size, dotSize } = RADIO_SIZE_MAP[context.size];
+  const { backgroundColor, dotColor } = RADIO_COLOR_MAP[context.color];
+
+  // Only the aria props we actually have. Base UI does not destructure
+  // `aria-describedby`, so it lands in `elementProps` and merges *after*
+  // `getDescriptionProps` — and that merge has no undefined guard. Passing
+  // `aria-describedby={undefined}` would erase the id a wrapping
+  // `Field.Description` or `Field.Error` just computed.
+  const ariaProps = {
+    ...(context["aria-label"] !== undefined && {
+      "aria-label": context["aria-label"],
+    }),
+    ...(context["aria-describedby"] !== undefined && {
+      "aria-describedby": context["aria-describedby"],
+    }),
+  };
+
+  return (
+    <BaseRadio.Root
+      inputRef={inputRef}
+      id={context.id}
+      value={context.value}
+      disabled={context.disabled}
+      required={context.required}
+      readOnly={context.readOnly}
+      {...ariaProps}
+      // An explicit `aria-labelledby` wins. Otherwise point at our own label
+      // whenever one exists. `aria-label` does not suppress this: Base UI's
+      // fallback re-derives `aria-labelledby` from the associated `<label>`
+      // anyway, and that outranks `aria-label` in the name computation.
+      aria-labelledby={
+        context["aria-labelledby"] ??
+        (context.hasLabel ? context.labelId : undefined)
+      }
+      render={createTgphBaseUIRender<BaseRadioRenderProps, BaseRadioState>(
+        (state) => (
+          <Stack
+            align="center"
+            justify="center"
+            w={size}
+            h={size}
+            rounded="full"
+            border="px"
+            borderColor={
+              state.checked ? backgroundColor : RADIO_UNSELECTED.borderColor
+            }
+            bg={
+              state.checked ? backgroundColor : RADIO_UNSELECTED.backgroundColor
+            }
+            data-tgph-radio-control
+            data-tgph-radio-size={context.size}
+            data-tgph-radio-color={context.color}
+            tgphRef={tgphRef}
+            {...stackProps}
+          >
+            <BaseRadio.Indicator
+              render={createTgphBaseUIRender<
+                BaseRadioRenderProps,
+                BaseRadioIndicatorState
+              >(() => (
+                <Stack
+                  align="center"
+                  justify="center"
+                  data-tgph-radio-indicator
+                >
+                  <Box
+                    w={dotSize}
+                    h={dotSize}
+                    rounded="full"
+                    bg={dotColor}
+                    {...dotProps}
+                  />
+                </Stack>
+              ))}
+            />
+          </Stack>
+        ),
+      )}
+    />
+  );
+};
+
+// `as` is re-declared as optional so `<Radio.Label>` works without it;
+// Telegraph's `Text` otherwise requires `as` unless `internal_optionalAs` is
+// set. `id` is not the caller's to set: `Radio.Control` points
+// `aria-labelledby` at `context.labelId` during render, so a different id here
+// leaves a dangling IDREF and the control ends up with no accessible name.
+export type LabelProps<T extends TgphElement = "label"> = RemappedOmit<
+  TextProps<T>,
+  "as" | "id"
+> & {
+  as?: T;
+};
+
+const Label = <T extends TgphElement = "label">(labelProps: LabelProps<T>) => {
+  // `id` is destructured away rather than merely omitted from the type, so an
+  // untyped caller cannot spread over the one `aria-labelledby` points at.
+  const {
+    as,
+    style,
+    id: _id,
+    ...props
+  } = labelProps as LabelProps<"label"> & { id?: string };
+  const context = useContext(RadioContext);
+
+  return (
+    <Text
+      as={as || "label"}
+      htmlFor={context.id}
+      id={context.labelId}
+      size={RADIO_SIZE_MAP[context.size].labelSize}
+      data-tgph-radio-label
+      style={style}
+      {...props}
+    />
+  );
+};
+
+// `children` is dropped: `Default` renders its own control and label, so
+// anything passed would be silently discarded.
+export type DefaultProps<T extends TgphElement = "div"> = RemappedOmit<
+  RootProps<T>,
+  "children"
+> & {
+  label?: ReactNode;
+  labelProps?: RemappedOmit<LabelProps<"label">, "as">;
+  controlProps?: ControlProps;
+};
+
+const Default = <T extends TgphElement = "div">({
+  label,
+  labelProps,
+  controlProps,
+  ...props
+}: DefaultProps<T>) => {
+  return (
+    <Root {...(props as RootProps<T>)}>
+      <Control {...controlProps} />
+      {/* Not `label &&`: that renders a bare `0` for `label={0}`, and `false`
+          is what `label={cond && "text"}` yields when the condition fails. */}
+      {label != null && label !== false && (
+        <Label as="label" {...labelProps}>
+          {label}
+        </Label>
+      )}
+    </Root>
+  );
+};
+
+const Radio = {
+  Default,
+  Root,
+  Control,
+  Label,
+};
+
+export { Radio, RadioContext };

--- a/packages/radio/src/Radio/index.ts
+++ b/packages/radio/src/Radio/index.ts
@@ -1,0 +1,9 @@
+export { Radio } from "./Radio";
+export type {
+  RootProps as RadioRootProps,
+  RootBaseProps as RadioRootBaseProps,
+  ControlProps as RadioControlProps,
+  LabelProps as RadioLabelProps,
+  DefaultProps as RadioProps,
+} from "./Radio";
+export type { RadioSize, RadioColor } from "./Radio.constants";

--- a/packages/radio/src/RadioGroup/RadioGroup.context.tsx
+++ b/packages/radio/src/RadioGroup/RadioGroup.context.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from "react";
+
+import type { RadioColor, RadioSize } from "../Radio/Radio.constants";
+
+// Group-level defaults that individual radios inherit. Its own module so
+// `Radio` can read it without importing `RadioGroup`, which renders radios —
+// that keeps the dependency pointing one way.
+export type RadioGroupContextType = {
+  size?: RadioSize;
+  color?: RadioColor;
+  disabled?: boolean;
+};
+
+const RadioGroupContext = createContext<RadioGroupContextType | null>(null);
+
+const useRadioGroupContext = () => useContext(RadioGroupContext);
+
+export { RadioGroupContext, useRadioGroupContext };

--- a/packages/radio/src/RadioGroup/RadioGroup.test.tsx
+++ b/packages/radio/src/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { axe, expectToHaveNoViolations } from "../../../../vitest/axe";
+import { Radio } from "../Radio";
+
+import { RadioGroup } from "./RadioGroup";
+
+const PLANS = ["free", "pro", "enterprise"];
+
+const getRadio = (name: string) => screen.getByRole("radio", { name });
+
+const Options = () => (
+  <>
+    {PLANS.map((plan) => (
+      <Radio.Default key={plan} value={plan} label={plan} />
+    ))}
+  </>
+);
+
+const Controlled = ({
+  initialValue,
+  onValueChange,
+}: {
+  initialValue?: string;
+  onValueChange?: (value: string) => void;
+}) => {
+  const [value, setValue] = useState<string | undefined>(initialValue);
+  return (
+    <RadioGroup
+      name="plan"
+      value={value}
+      onValueChange={(next) => {
+        setValue(next);
+        onValueChange?.(next);
+      }}
+    >
+      <Options />
+    </RadioGroup>
+  );
+};
+
+describe("RadioGroup", () => {
+  it("is accessible", async () => {
+    const { container } = render(
+      <RadioGroup name="plan" defaultValue="free">
+        <Options />
+      </RadioGroup>,
+    );
+    expectToHaveNoViolations(await axe(container));
+  });
+
+  it("renders a radiogroup role", () => {
+    render(
+      <RadioGroup name="plan">
+        <Options />
+      </RadioGroup>,
+    );
+    expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+  });
+
+  it("supports an uncontrolled default value", async () => {
+    const user = userEvent.setup();
+    render(
+      <RadioGroup name="plan" defaultValue="free">
+        <Options />
+      </RadioGroup>,
+    );
+
+    expect(getRadio("free")).toHaveAttribute("aria-checked", "true");
+
+    await user.click(getRadio("pro"));
+    expect(getRadio("pro")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("supports a controlled value", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<Controlled initialValue="free" onValueChange={onValueChange} />);
+
+    await user.click(getRadio("pro"));
+
+    expect(onValueChange).toHaveBeenCalledWith("pro");
+    expect(getRadio("pro")).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("applies group size and color to every child", () => {
+    render(
+      <RadioGroup name="plan" size="1" color="green">
+        <Radio.Default value="free" label="free" />
+        <Radio.Default value="pro" label="pro" color="red" />
+      </RadioGroup>,
+    );
+
+    expect(getRadio("free")).toHaveAttribute("data-tgph-radio-size", "1");
+    expect(getRadio("free")).toHaveAttribute("data-tgph-radio-color", "green");
+    // A radio's own color prop beats the group default.
+    expect(getRadio("pro")).toHaveAttribute("data-tgph-radio-color", "red");
+  });
+
+  it("disables every child when the group is disabled", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup name="plan" disabled onValueChange={onValueChange}>
+        <Options />
+      </RadioGroup>,
+    );
+
+    await user.click(getRadio("free"));
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  // Base UI ORs the group's `disabled` over the radio's own, so a child cannot
+  // opt out. This package matches that rather than letting the label style
+  // itself enabled over a control Base UI has already disabled.
+  it("does not let a child opt out of a disabled group", () => {
+    render(
+      <RadioGroup name="plan" disabled>
+        <Radio.Default value="free" label="free" disabled={false} />
+      </RadioGroup>,
+    );
+    expect(getRadio("free")).toHaveAttribute("data-disabled");
+  });
+
+  it("disables one option without affecting the others", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <RadioGroup name="plan" onValueChange={onValueChange}>
+        <Radio.Default value="free" label="free" disabled />
+        <Radio.Default value="pro" label="pro" />
+      </RadioGroup>,
+    );
+
+    await user.click(getRadio("free"));
+    expect(onValueChange).not.toHaveBeenCalled();
+
+    await user.click(getRadio("pro"));
+    // First argument only: the second is Base UI's event detail.
+    expect(onValueChange.mock.calls[0]![0]).toBe("pro");
+  });
+
+  // Base UI owns roving focus for a radio group. This package adds no shim, so
+  // the test is here to catch a Base UI regression rather than our own.
+  it("moves selection with the arrow keys", async () => {
+    const user = userEvent.setup();
+    render(
+      <RadioGroup name="plan" defaultValue="free">
+        <Options />
+      </RadioGroup>,
+    );
+
+    await user.tab();
+    expect(getRadio("free")).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(getRadio("pro")).toHaveAttribute("aria-checked", "true");
+    expect(getRadio("pro")).toHaveFocus();
+  });
+
+  it("puts one tab stop on the whole group", async () => {
+    const user = userEvent.setup();
+    render(
+      <RadioGroup name="plan" defaultValue="pro">
+        <Options />
+      </RadioGroup>,
+    );
+
+    await user.tab();
+    // Roving focus: the selected option is the tab stop, not the first one.
+    expect(getRadio("pro")).toHaveFocus();
+    expect(getRadio("free")).toHaveAttribute("tabindex", "-1");
+  });
+
+  // Matches `@telegraph/checkbox`: the second argument is Base UI's event
+  // detail, which carries the native event and `cancel()`.
+  describe("event details", () => {
+    it("passes Base UI's event details as a second argument", async () => {
+      const user = userEvent.setup();
+      const onValueChange = vi.fn();
+      render(
+        <RadioGroup name="plan" onValueChange={onValueChange}>
+          <Options />
+        </RadioGroup>,
+      );
+
+      await user.click(getRadio("pro"));
+
+      expect(onValueChange.mock.calls[0]).toHaveLength(2);
+      const eventDetails = onValueChange.mock.calls[0]![1];
+      expect(eventDetails.event).toBeInstanceOf(Event);
+      expect(typeof eventDetails.cancel).toBe("function");
+    });
+  });
+
+  it("takes Stack layout props", () => {
+    render(
+      <RadioGroup name="plan" direction="row" gap="4" data-testid="group">
+        <Options />
+      </RadioGroup>,
+    );
+    expect(screen.getByTestId("group")).toBeInTheDocument();
+  });
+});

--- a/packages/radio/src/RadioGroup/RadioGroup.tsx
+++ b/packages/radio/src/RadioGroup/RadioGroup.tsx
@@ -1,0 +1,120 @@
+import {
+  RadioGroup as BaseRadioGroup,
+  type RadioGroupProps as BaseRadioGroupProps,
+  type RadioGroupChangeEventDetails,
+} from "@base-ui/react/radio-group";
+import { type RemappedOmit, createTgphBaseUIRender } from "@telegraph/helpers";
+import { Stack, type StackProps } from "@telegraph/layout";
+import type {
+  CSSProperties,
+  ComponentPropsWithoutRef,
+  ReactNode,
+  Ref,
+} from "react";
+
+import type { RadioColor, RadioSize } from "../Radio/Radio.constants";
+
+import { RadioGroupContext } from "./RadioGroup.context";
+
+type BaseRadioGroupRenderProps = ComponentPropsWithoutRef<"div"> & {
+  ref?: Ref<HTMLElement>;
+};
+
+type BaseRadioGroupState = {
+  disabled: boolean;
+};
+
+// `name`, `form`, `readOnly` and `required` pass straight through to Base UI.
+// The selection props are declared here because Base UI types `value` as its
+// generic `Value`, and Telegraph pins it to the string a radio submits.
+export type RadioGroupBaseProps = Pick<
+  BaseRadioGroupProps,
+  "name" | "form" | "readOnly" | "required" | "inputRef"
+> & {
+  // The selected option. A radio group holds one value, so this is a string
+  // rather than the checkbox group's array.
+  value?: string;
+  defaultValue?: string;
+  // The second argument is Base UI's event detail, matching
+  // `@telegraph/checkbox`. It carries the native event and `cancel()`.
+  onValueChange?: (
+    value: string,
+    eventDetails: RadioGroupChangeEventDetails,
+  ) => void;
+  // Applied to every radio in the group unless one sets its own.
+  size?: RadioSize;
+  color?: RadioColor;
+  disabled?: boolean;
+  children?: ReactNode;
+};
+
+// Not polymorphic: the element resolves inside Base UI's `render` callback, so
+// `StackProps<"div">` pins the passthrough to what is actually rendered.
+//
+// Base UI's props are destructured by name below and everything else spreads
+// onto the `Stack`. Handing the leftovers to Base UI instead would let it
+// swallow any prop it happens to consume.
+export type RadioGroupProps = RemappedOmit<
+  StackProps<"div">,
+  "tgphRef" | "as" | "value" | "defaultValue" | "onChange" | "color"
+> &
+  RadioGroupBaseProps & {
+    style?: CSSProperties;
+    tgphRef?: Ref<HTMLElement>;
+  };
+
+const RadioGroup = ({
+  value,
+  defaultValue,
+  onValueChange,
+  name,
+  form,
+  readOnly,
+  required,
+  inputRef,
+  size,
+  color,
+  disabled = false,
+  direction = "column",
+  gap = "2",
+  children,
+  tgphRef,
+  ...stackProps
+}: RadioGroupProps) => {
+  return (
+    <RadioGroupContext.Provider value={{ size, color, disabled }}>
+      <BaseRadioGroup
+        value={value}
+        defaultValue={defaultValue}
+        // Base UI types the callback value as its generic `Value`. Every radio
+        // in this package takes a string `value`, so the cast reflects what a
+        // group can actually emit rather than widening the public callback.
+        onValueChange={(nextValue, eventDetails) =>
+          onValueChange?.(nextValue as string, eventDetails)
+        }
+        name={name}
+        form={form}
+        disabled={disabled}
+        readOnly={readOnly}
+        required={required}
+        inputRef={inputRef}
+        render={createTgphBaseUIRender<
+          BaseRadioGroupRenderProps,
+          BaseRadioGroupState
+        >(() => (
+          <Stack
+            direction={direction}
+            gap={gap}
+            data-tgph-radio-group
+            tgphRef={tgphRef}
+            {...stackProps}
+          >
+            {children}
+          </Stack>
+        ))}
+      />
+    </RadioGroupContext.Provider>
+  );
+};
+
+export { RadioGroup };

--- a/packages/radio/src/RadioGroup/index.ts
+++ b/packages/radio/src/RadioGroup/index.ts
@@ -1,0 +1,2 @@
+export { RadioGroup } from "./RadioGroup";
+export type { RadioGroupProps, RadioGroupBaseProps } from "./RadioGroup";

--- a/packages/radio/src/default.css
+++ b/packages/radio/src/default.css
@@ -1,1 +1,2 @@
 @import "./RadioCards/RadioCards.styles.css";
+@import "./Radio/Radio.styles.css";

--- a/packages/radio/src/index.ts
+++ b/packages/radio/src/index.ts
@@ -7,3 +7,17 @@ export type {
   RadioCardsItemIconProps,
   RadioCardsProps,
 } from "./RadioCards";
+
+export { Radio } from "./Radio";
+export type {
+  RadioRootProps,
+  RadioRootBaseProps,
+  RadioControlProps,
+  RadioLabelProps,
+  RadioProps,
+  RadioSize,
+  RadioColor,
+} from "./Radio";
+
+export { RadioGroup } from "./RadioGroup";
+export type { RadioGroupProps, RadioGroupBaseProps } from "./RadioGroup";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3911,6 +3911,7 @@ __metadata:
     "@telegraph/icon": "workspace:^"
     "@telegraph/layout": "workspace:^"
     "@telegraph/postcss-config": "workspace:^"
+    "@telegraph/typography": "workspace:^"
     "@telegraph/vite-config": "workspace:^"
     "@types/react": "npm:^19.2.17"
     eslint: "npm:^10.4.0"


### PR DESCRIPTION
### What changed?

- inside a `Field.Root`, each radio needs a `Field.Item` or only the first label works
- a radio needs a `RadioGroup`: Base UI derives selection from the group
- a radio's `value` names which option it is, and it's what the form submits
- the ring targets the styled circle, because the real input stays hidden and untabbable
- `aria-describedby` only goes through when set, so a wrapping `Field.Description` survives
- a caller can't set the label's `id`, which would otherwise leave the control unnamed
- `RadioCards` is untouched, and its tests pass unmodified
- the dot is half the control, plus stories, README, changeset, type tests, and the `@telegraph/typography` dep

### Why?

the package shipped `RadioCards` only, and a card draws selection with its own border. nothing in Telegraph rendered a radio dot, and a form had no plain radio to sit beside a checkbox.

`onValueChange` hands back both of Base UI's arguments, so a caller can reach the native event and `cancel()`. the checkbox does the same.

a bare `Field.Root` carries one control id and hands it to every radio under it, so the inputs collide. that is Base UI's scoping, not something this package can undo. the README points at `Field.Item`, and tests cover both shapes.

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [x] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [x] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [x] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?

### Screenshots or Loom

| States, light | States, dark |
| --- | --- |
| <img width="320" alt="Unselected, selected, disabled and disabled selected in the light theme" src="https://gist.githubusercontent.com/kylemcd/c538ff22d47ed461a96269c318e463d9/raw/radio-states.png" /> | <img width="320" alt="The same four states in the dark theme" src="https://gist.githubusercontent.com/kylemcd/c538ff22d47ed461a96269c318e463d9/raw/radio-states-dark.png" /> |

| Sizes | Colors |
| --- | --- |
| <img width="320" alt="Selected and unselected radios at size 1 and size 2" src="https://gist.githubusercontent.com/kylemcd/c538ff22d47ed461a96269c318e463d9/raw/radio-sizes.png" /> | <img width="320" alt="One selected radio for each color in the palette" src="https://gist.githubusercontent.com/kylemcd/c538ff22d47ed461a96269c318e463d9/raw/radio-colors.png" /> |

every story is live in the [storybook preview](https://telegraph-storybook-git-kyle-kno-14482-add-a-s-56e90e-knocklabs.vercel.app/?path=/story/components-radio--states).
