### PR TITLE
chore: deduplicate yarn.lock after postcss bump

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10470,15 +10470,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.17":
   version: 3.3.17
   resolution: "nanoid@npm:3.3.17"
@@ -11422,18 +11413,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.23":
-  version: 8.5.26
-  resolution: "postcss@npm:8.5.26"
-  dependencies:
-    nanoid: "npm:^3.3.17"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.26":
+"postcss@npm:^8.5.23, postcss@npm:^8.5.26":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The postcss 8.5.26 Dependabot bump (PR #953) was merged without running a full `yarn install`, leaving two stale entries in `yarn.lock`:

- **`nanoid@npm:^3.3.16`** — orphaned entry for an old range that has since been superseded by `^3.3.17`; the 3.3.16 package entry can be dropped
- **`postcss@npm:^8.5.23`** and **`postcss@npm:^8.5.26`** as separate keys — both resolve to the same `8.5.26` package, so they should be a single combined key

These stale entries cause `yarn --immutable` to exit non-zero with `YN0028: The lockfile would have been modified by this install`, which broke the `check-package-sizes` CI job for all open PRs (the workflow checks out `main` and runs `yarn --immutable` to build the comparison baseline).

**Fix:** ran `yarn install` on `main` to let Yarn deduplicate; the resulting diff is a clean 22-line removal with no functional change to the resolved dependency tree.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31e9a6e1-71e2-4578-baeb-50378477fe3a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31e9a6e1-71e2-4578-baeb-50378477fe3a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

