### PR TITLE
fix(combobox): stop Trigger stretching to a definite-height ancestor

### DIFF
--- a/.changeset/olive-moons-shave.md
+++ b/.changeset/olive-moons-shave.md
@@ -1,0 +1,17 @@
+---
+"@telegraph/combobox": patch
+---
+
+fix(combobox): stop `Combobox.Trigger` stretching to a definite-height ancestor
+
+The trigger hard-coded `h="full"` (`height: 100%`). Against an auto-height
+ancestor that collapses to `auto` and does nothing, but inside any ancestor
+with a definite height — a flex row with a fixed height, a sized block, a grid
+row — the trigger filled it instead of using its own size. A size-`1` trigger
+rendered 80px tall in an 80px container rather than 24px, and a parent's
+`align-items: center` could not opt out of it.
+
+`h` is now `auto`, so `minH` sets the floor and content drives growth. It is
+set explicitly rather than dropped because `Button.Root` applies a fixed
+per-size `h` underneath, which would otherwise clip the multi-select `wrap`
+layout when tags run onto a second line.

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -339,7 +339,10 @@ const Trigger = <V extends ChildrenValue>({
         variant="outline"
         align="center"
         minH={TRIGGER_MIN_HEIGHT[size]}
-        h="full"
+        // `auto` (not `full`) so the trigger grows with wrapped tags but never
+        // stretches to a definite-height ancestor. Button.Root would otherwise
+        // apply its fixed per-size `h`, which clips the wrap layout.
+        h="auto"
         w="full"
         py="0_5"
         pr="1_5"


### PR DESCRIPTION
### What changed?

- a combobox trigger keeps its own height inside a fixed-height container, instead of filling it
- before, a size `1` trigger rendered 80px tall in an 80px row, now 24px
- `h` is `auto`, not removed: `Button.Root`'s fixed per-size `h` would clip the multi-select wrap layout

### Why?

`h="full"` means `height: 100%`. against a parent sized by its content that collapses to `auto`, so nothing happened. inside a parent with a real height it wins, and `align-items: center` on that parent cannot opt out of it. `Input`, the closest sibling, sets no `h` on its root.

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [ ] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [ ] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [ ] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?

### Screenshots or Loom

<table><tr><td><b>before</b><br /><img width="380" alt="The trigger stretched to fill all three dashed 80px containers: a flex row, a block and a grid row" src="https://gist.githubusercontent.com/kylemcd/87eb36175e9f33e8d09d0fc2d46ba723/raw/before.png" /></td><td><b>after</b><br /><img width="380" alt="The trigger at its own 24px height in the same three containers" src="https://gist.githubusercontent.com/kylemcd/87eb36175e9f33e8d09d0fc2d46ba723/raw/after.png" /></td></tr></table>
