### PR TITLE
fix(combobox): preserve input cancellation for bulk paste handling

### DIFF
--- a/.changeset/combobox-cancel-input-change.md
+++ b/.changeset/combobox-cancel-input-change.md
@@ -1,0 +1,5 @@
+---
+"@telegraph/combobox": patch
+---
+
+Honor canceled `onInputValueChange` events before updating the internal search query, and preserve a multi-select search while the popup stays open. Consumers can intercept pasted text without retaining it as a query and select several filtered options in succession.

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -96,7 +96,7 @@ The root component that manages the state and context for the combobox.
 | `manualFiltering`    | `boolean`                                                   | automatic    | Show rendered options without the built-in text filter; controlled Search enables it by default |
 | `onItemHighlighted`  | `(value: string \| undefined, details: ComboboxHighlightDetails) => void` | `undefined` | Called when virtual option focus changes               |
 | `selectionMode`      | `"single" \| "multiple" \| "none"`                         | inferred     | Select one, select many, or accept free text           |
-| `inputValue`         | `string`                                                    | `undefined`  | Controlled text for `Combobox.Input`                   |
+| `inputValue`         | `string`                                                    | `undefined`  | Controlled text for `Combobox.Input` or `Combobox.Search` |
 | `defaultInputValue`  | `string`                                                    | `undefined`  | Initial uncontrolled input text                        |
 | `onInputValueChange` | `(value: string, details: ComboboxChangeDetails) => void`   | `undefined`  | Called when the input text changes                     |
 | `autocompleteMode`   | `"list" \| "inline" \| "both" \| "none"`                    | `"list"`     | Autocomplete behavior for free-text input              |
@@ -128,6 +128,11 @@ navigate the popup options.
 Drive its text with `inputValue`, `defaultInputValue`, and
 `onInputValueChange` on `Combobox.Root`. In `selectionMode="none"`, the text is
 the value and any typed text is valid.
+
+The same Root props control the popup's `Combobox.Search` when the combobox uses
+a button trigger. Call `details.cancel()` from `onInputValueChange` to reject an
+input change before Telegraph stores it as the search query—for example, when a
+consumer converts pasted text into multiple selected values.
 
 `Combobox.Input` accepts Telegraph Input props except `value`, `defaultValue`,
 and `onChange`, which the combobox engine owns.
@@ -494,6 +499,11 @@ the rendered options, which preserves the legacy controlled-Search contract and
 supports server-side filtering. An explicit `manualFiltering` value on
 `Combobox.Root` takes precedence: set it to `false` to retain Telegraph's
 built-in text filter with a controlled Search.
+
+The equivalent Root-level `inputValue`, `defaultInputValue`, and
+`onInputValueChange` props can control or intercept the same text. Call
+`details.cancel()` from the Root callback to reject a change before Telegraph
+stores it as the query.
 
 ### `<Combobox.Empty>`
 

--- a/packages/combobox/src/Combobox/Combobox.browser.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.browser.test.tsx
@@ -148,6 +148,79 @@ const RewritingSearchCombobox = () => {
   );
 };
 
+const BulkPasteCombobox = () => {
+  const [values, setValues] = useState<Array<string>>([]);
+
+  return (
+    <>
+      <input aria-label="Paste source" defaultValue="email, sms" />
+      <output data-selected-channels>{values.join(", ")}</output>
+      <Combobox.Root
+        value={values}
+        onValueChange={(next) => setValues(next as Array<string>)}
+        onInputValueChange={(next, details) => {
+          if (
+            details.reason !== "input-change" ||
+            !(details.event instanceof InputEvent) ||
+            details.event.inputType !== "insertFromPaste"
+          ) {
+            return;
+          }
+
+          details.cancel();
+          setValues(
+            next
+              .split(",")
+              .map((value) => value.trim())
+              .filter(Boolean),
+          );
+        }}
+      >
+        <Combobox.Trigger aria-label="Choose channel">
+          Choose channel
+        </Combobox.Trigger>
+        <Combobox.Content>
+          <Combobox.Search aria-label="Search channels" />
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </>
+  );
+};
+
+const PersistentMultiSearchCombobox = () => {
+  const [values, setValues] = useState<Array<string>>([]);
+
+  return (
+    <>
+      <output data-selected-channels>{values.join(", ")}</output>
+      <Combobox.Root
+        closeOnSelect={false}
+        value={values}
+        onValueChange={(next) => setValues(next as Array<string>)}
+      >
+        <Combobox.Trigger aria-label="Choose channel" />
+        <Combobox.Content>
+          <Combobox.Search aria-label="Search channels" />
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    </>
+  );
+};
+
 const getTrigger = async () => {
   const trigger = page.getByRole("combobox", { name: "Choose channel" });
   await expect.element(trigger).toBeInTheDocument();
@@ -305,6 +378,87 @@ describe("Combobox controlled Search (real browser)", () => {
   });
 });
 
+describe("Combobox canceled paste (real browser)", () => {
+  it("lets a consumer convert pasted text into selections without retaining a search query", async () => {
+    await render(<BulkPasteCombobox />);
+
+    const source = page.getByRole("textbox", { name: "Paste source" });
+    await expect.element(source).toBeInTheDocument();
+    const sourceInput = source.element() as HTMLInputElement;
+    sourceInput.select();
+    await userEvent.copy();
+
+    await openViaTriggerClick();
+    await userEvent.paste();
+
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-selected-channels]")?.textContent,
+      ).toBe("email, sms");
+      expect(
+        document.querySelector<HTMLInputElement>("[data-tgph-combobox-search]")
+          ?.value,
+      ).toBe("");
+      expect(
+        document.querySelectorAll("[data-tgph-combobox-option]"),
+      ).toHaveLength(VALUES.length);
+    });
+  });
+});
+
+describe("Combobox persistent multi-select Search (real browser)", () => {
+  it("keeps the query while toggling options and still lets the user clear it", async () => {
+    await render(<PersistentMultiSearchCombobox />);
+    await openViaTriggerClick();
+
+    await userEvent.keyboard("sm");
+
+    const getSearch = () =>
+      document.querySelector<HTMLInputElement>("[data-tgph-combobox-search]");
+    const getSmsOption = () =>
+      document.querySelector<HTMLElement>(
+        '[data-tgph-combobox-option-value="sms"]',
+      );
+    await vi.waitFor(() => {
+      expect(getSearch()?.value).toBe("sm");
+      expect(
+        document.querySelectorAll("[data-tgph-combobox-option]"),
+      ).toHaveLength(1);
+    });
+
+    await userEvent.click(getSmsOption()!);
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-selected-channels]")?.textContent,
+      ).toBe("sms");
+      expect(getSearch()?.value).toBe("sm");
+      expect(
+        document.querySelectorAll("[data-tgph-combobox-option]"),
+      ).toHaveLength(1);
+    });
+
+    await userEvent.click(getSmsOption()!);
+    await vi.waitFor(() => {
+      expect(
+        document.querySelector("[data-selected-channels]")?.textContent,
+      ).toBe("");
+      expect(getSearch()?.value).toBe("sm");
+    });
+
+    const clearButton = document
+      .querySelector('[aria-label="Clear Search Query"]')
+      ?.closest("button");
+    await userEvent.click(clearButton as HTMLButtonElement);
+
+    await vi.waitFor(() => {
+      expect(getSearch()?.value).toBe("");
+      expect(
+        document.querySelectorAll("[data-tgph-combobox-option]"),
+      ).toHaveLength(VALUES.length);
+    });
+  });
+});
+
 describe("Combobox keydown propagation (real browser)", () => {
   it("contains popup keys but lets closed-trigger Escape propagate", async () => {
     const onAncestorKeyDown = vi.fn();
@@ -329,7 +483,6 @@ describe("Combobox keydown propagation (real browser)", () => {
     expect(onAncestorKeyDown.mock.calls[0]?.[0].key).toBe("Escape");
   });
 });
-
 describe("Combobox type-to-filter highlight (real browser)", () => {
   // Diagnostic for the auto-highlight-on-type case flagged in the rewrite: with
   // a non-first existing selection, does typing to filter highlight the first

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -7,6 +7,7 @@ import { axe, expectToHaveNoViolations } from "vitest.axe";
 import { Combobox } from "./Combobox";
 import { findStringNodes, getOptionAccessibleLabel } from "./Combobox.helpers";
 import type {
+  ComboboxChangeDetails,
   ComboboxContentProps,
   ComboboxOptionProps,
   ComboboxOptionsProps,
@@ -220,6 +221,48 @@ describe("Combobox", () => {
 
     expect(container.querySelector("b")).toBeNull();
     expect(container.querySelector("span")).not.toBeNull();
+  });
+
+  it("does not filter options when the consumer cancels an input change", async () => {
+    const user = userEvent.setup();
+    const onInputValueChange = vi.fn(
+      (_nextValue: string, details: ComboboxChangeDetails) => {
+        details.cancel();
+      },
+    );
+
+    render(
+      <Combobox.Root
+        defaultOpen
+        value={[]}
+        onInputValueChange={onInputValueChange}
+      >
+        <Combobox.Trigger aria-label="Choose channel" />
+        <Combobox.Content>
+          <Combobox.Search aria-label="Search channels" />
+          <Combobox.Options>
+            {VALUES.map((option, index) => (
+              <Combobox.Option key={option} value={option}>
+                {LABELS[index]}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>,
+    );
+
+    const search = queryPortalElement(
+      "[data-tgph-combobox-search]",
+    ) as HTMLInputElement;
+    await user.type(search, "sms");
+
+    expect(onInputValueChange).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(search.value).toBe("");
+      expect(queryPortalElements("[data-tgph-combobox-option]")).toHaveLength(
+        VALUES.length,
+      );
+    });
   });
 
   describe("Single Select", () => {
@@ -678,6 +721,82 @@ describe("Combobox", () => {
       // option is tracked with data-highlighted rather than receiving DOM focus.
       expect(queryPortalElement("[data-tgph-combobox-search]")).toHaveFocus();
       expect(getSmsOption()?.getAttribute("data-highlighted")).not.toBeNull();
+    });
+
+    it("keeps a multi-select query through selection and deselection until it is cleared", async () => {
+      const user = userEvent.setup();
+
+      const Harness = () => {
+        const [value, setValue] = useState<Array<string>>([]);
+        return (
+          <Combobox.Root
+            closeOnSelect={false}
+            value={value}
+            onValueChange={setValue}
+          >
+            <Combobox.Trigger />
+            <Combobox.Content>
+              <Combobox.Search />
+              <Combobox.Options>
+                {VALUES.map((option, index) => (
+                  <Combobox.Option key={option} value={option}>
+                    {LABELS[index]}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
+            </Combobox.Content>
+          </Combobox.Root>
+        );
+      };
+
+      const { container } = render(<Harness />);
+      const trigger = container.querySelector("[data-tgph-combobox-trigger]");
+      await user.click(trigger!);
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute("aria-expanded", "true"),
+      );
+
+      const search = queryPortalElement(
+        "[data-tgph-combobox-search]",
+      ) as HTMLInputElement;
+      await user.type(search, "sm");
+
+      const getSmsOption = () =>
+        queryPortalElement(
+          '[data-tgph-combobox-option-value="sms"]',
+        ) as HTMLElement | null;
+      await waitFor(() => {
+        expect(search.value).toBe("sm");
+        expect(queryPortalElements("[data-tgph-combobox-option]")).toHaveLength(
+          1,
+        );
+      });
+
+      await user.click(getSmsOption()!);
+      await waitFor(() => expect(trigger?.textContent).toBe("SMS"));
+      expect(search.value).toBe("sm");
+      expect(queryPortalElements("[data-tgph-combobox-option]")).toHaveLength(
+        1,
+      );
+
+      await user.click(getSmsOption()!);
+      await waitFor(() => expect(trigger?.textContent).toBe(""));
+      expect(search.value).toBe("sm");
+      expect(queryPortalElements("[data-tgph-combobox-option]")).toHaveLength(
+        1,
+      );
+
+      const clearButton = queryPortalElement(
+        '[aria-label="Clear Search Query"]',
+      )?.closest("button");
+      await user.click(clearButton!);
+
+      await waitFor(() => {
+        expect(search.value).toBe("");
+        expect(queryPortalElements("[data-tgph-combobox-option]")).toHaveLength(
+          VALUES.length,
+        );
+      });
     });
 
     it("empty state should show when there are no results", async () => {

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -145,8 +145,9 @@ type RootSharedProps = {
   // Autocomplete root, where there is no selected value and the input text is
   // the state.
   selectionMode?: ComboboxSelectionMode;
-  // Controlled input text, distinct from the selected `value`. Only meaningful
-  // with a `Combobox.Input` anchor (and the sole state in `selectionMode="none"`).
+  // Controlled input text, distinct from the selected `value`. Controls either
+  // a `Combobox.Input` anchor or the popup's `Combobox.Search` input (and is the
+  // sole state in `selectionMode="none"`).
   inputValue?: string;
   defaultInputValue?: string;
   onInputValueChange?: (value: string, details: ComboboxChangeDetails) => void;
@@ -531,6 +532,7 @@ const RootImplementation = ({
   // The query that drives children-mode filtering is derived during render so
   // external Search or Root input-value changes filter without a stale frame.
   const activeSearchQuery = searchQuery;
+  const preserveMultiSearchQueryRef = useRef(false);
   const shouldFilterOptions =
     !manualFiltering &&
     (!isNoneMode || autocompleteMode === "list" || autocompleteMode === "both");
@@ -643,6 +645,7 @@ const RootImplementation = ({
     // `inputValue`/`defaultInputValue`. Free text persists across open/close (the
     // anchor input is the state), so it is never reset here.
     if (wasOpenRef.current && !open) {
+      preserveMultiSearchQueryRef.current = false;
       // Reset the page-slide direction on close so reopening shows the active
       // page in place; only a real switch should slide.
       pageDirectionRef.current = undefined;
@@ -685,6 +688,15 @@ const RootImplementation = ({
         return;
       }
 
+      // Base UI clears an in-popup input after every filtered multi-select item
+      // press. The menu-backed combobox kept that query while the popup stayed
+      // open, allowing several matching options to be toggled in succession.
+      preserveMultiSearchQueryRef.current =
+        multiple &&
+        closeOnSelect === false &&
+        eventDetails.reason === ITEM_PRESS_REASON &&
+        activeSearchQuery.trim() !== "";
+
       // Preserve the menu-backed callback order. Controlled callers observe the
       // popup close before they receive the selected value.
       if (closeOnSelect === true && next != null) {
@@ -706,7 +718,13 @@ const RootImplementation = ({
         setOpen(false);
       }
     },
-    [multiple, setValue, closeOnSelect, setOpen],
+    [
+      multiple,
+      setValue,
+      closeOnSelect,
+      setOpen,
+      activeSearchQuery,
+    ],
   );
 
   const handleBaseOpenChange = useCallback(
@@ -759,6 +777,21 @@ const RootImplementation = ({
         return;
       }
 
+      const isPostSelectionClear =
+        preserveMultiSearchQueryRef.current &&
+        eventDetails.reason === "input-clear";
+      preserveMultiSearchQueryRef.current = false;
+      if (isPostSelectionClear) {
+        eventDetails.cancel();
+        return;
+      }
+
+      // Give consumers first refusal over the input change, matching Base UI's
+      // cancelable callback contract. This lets callers translate a paste into
+      // selected values without Telegraph retaining the pasted text as a query.
+      onInputValueChangeProp?.(nextValue, eventDetails);
+      if (eventDetails.isCanceled) return;
+
       // Mirror the query into the popup search-query state so children-mode
       // filtering runs — but only when the user edited the input, never for Base
       // UI's programmatic label resyncs (reason `"none"`) or item-press fills,
@@ -774,8 +807,6 @@ const RootImplementation = ({
       if (isNoneMode && !isInputControlled) {
         setUncontrolledInputValue(nextValue);
       }
-
-      onInputValueChangeProp?.(nextValue, eventDetails);
     },
     [isNoneMode, isInputControlled, onInputValueChangeProp],
   );
@@ -785,6 +816,7 @@ const RootImplementation = ({
   // so clear its uncontrolled value instead of the unused search-query state.
   const clearSearchQuery = useCallback(
     (query: string) => {
+      preserveMultiSearchQueryRef.current = false;
       if (isNoneMode) {
         if (!isInputControlled) setUncontrolledInputValue(query);
         return;

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -718,13 +718,7 @@ const RootImplementation = ({
         setOpen(false);
       }
     },
-    [
-      multiple,
-      setValue,
-      closeOnSelect,
-      setOpen,
-      activeSearchQuery,
-    ],
+    [multiple, setValue, closeOnSelect, setOpen, activeSearchQuery],
   );
 
   const handleBaseOpenChange = useCallback(


### PR DESCRIPTION
### What changed?

- honor a consumer's canceled `onInputValueChange` before Telegraph stores the text as its search query
- let bulk-paste consumers select comma-separated values without retaining the pasted text
- preserve filtered multi-select queries after option presses while the popup remains open
- reset preservation after user edits, clear actions, and popup close
- document both contracts and cover them with unit tests, browser tests, and a patch changeset

### Why?

The input bridge updated its internal query before consumers could cancel a paste, and Base UI cleared multi-select input after each item press. Those two behaviors broke bulk paste and forced users to retype a filter between selections.

### Screenshots or Loom

![Canceled bulk paste before and after](https://gist.githubusercontent.com/kylemcd/c23e7189e8f95283f4a1f1c2da218f34/raw/8eb2acb92dca45a0472c6018e358cdd80734b76a/pr-972-canceled-bulk-paste-before-after.gif)

![Persistent multi-select search before and after](https://gist.githubusercontent.com/kylemcd/c23e7189e8f95283f4a1f1c2da218f34/raw/fba3b5ee969827ae864772afe41a3ccbda3c8db8/pr-972-persistent-multi-search-before-after.gif)

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [x] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [ ] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [ ] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?
