### PR TITLE
refactor(types): use exported props types instead of TgphComponentProps (KNO-14778)

### DIFF
--- a/.changeset/exported-props-types.md
+++ b/.changeset/exported-props-types.md
@@ -1,0 +1,20 @@
+---
+"@telegraph/button": patch
+"@telegraph/combobox": patch
+"@telegraph/link": patch
+"@telegraph/menu": patch
+"@telegraph/modal": patch
+"@telegraph/radio": patch
+"@telegraph/tabs": patch
+"@telegraph/tag": patch
+"@telegraph/toggle": patch
+"@telegraph/tooltip": patch
+"@telegraph/truncate": patch
+"@telegraph/typography": patch
+---
+
+Type sub-components with the upstream's exported props type instead of `TgphComponentProps<typeof X<T>>`.
+
+`TgphComponentProps<typeof X<T>>` resolves through `React.ComponentProps` on a generic component, which defers the mapped type at an unresolved `T`. Every one of these sites now names the props type the upstream package already exports (`BoxProps`, `StackProps`, `IconProps`, `TextProps`, `ButtonRootProps`, `TagRootProps`, `MenuItemProps`, and so on).
+
+The resolved types are unchanged — only the expression that names them — so this is emitted-declaration churn, not an API change. `*.test-d.tsx` now pins each of those exported types to the component's own `ComponentProps`, so the two cannot drift apart again.

--- a/packages/button/src/Button/Button.test-d.tsx
+++ b/packages/button/src/Button/Button.test-d.tsx
@@ -1,3 +1,5 @@
+import type { IconProps as TelegraphIconProps } from "@telegraph/icon";
+import type { TextProps as TypographyTextProps } from "@telegraph/typography";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -69,5 +71,27 @@ describe("Button types", () => {
     <Button disabled type="submit" onClick={() => {}} />;
     <Button aria-label="save" data-testid="save" className="c" />;
     <Button style={{ opacity: 0.5 }} state="loading" active />;
+  });
+
+  // Pins the KNO-14778 swap. `Button.Icon` widens icon's props on purpose —
+  // dropping `internal_iconType` to "simplify" it would break icon placement.
+  it("derives its sub-component props from the upstream exported types", () => {
+    expectTypeOf<ButtonIconProps<"span">>().toEqualTypeOf<
+      TelegraphIconProps<"span"> & {
+        internal_iconType?: "leading" | "trailing";
+      }
+    >();
+    expectTypeOf<ButtonTextProps<"span">["size"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["size"]
+    >();
+    expectTypeOf<ButtonTextProps<"span">["color"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["color"]
+    >();
+    expectTypeOf<ButtonTextProps<"span">["weight"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["weight"]
+    >();
+    // Re-declared, so it stays `T` rather than typography's
+    // `OptionalAsPropConfig` pair.
+    expectTypeOf<ButtonTextProps<"p">["as"]>().toEqualTypeOf<"p" | undefined>();
   });
 });

--- a/packages/button/src/Button/Button.tsx
+++ b/packages/button/src/Button/Button.tsx
@@ -2,15 +2,21 @@ import {
   type AsAndTgphRefProps,
   RemappedOmit,
   type Required,
-  type TgphComponentProps,
   type TgphElement,
   defineNativeButtonResolver,
   useDeterminateState,
 } from "@telegraph/helpers";
-import { Spinner, Icon as TelegraphIcon } from "@telegraph/icon";
+import {
+  Spinner,
+  Icon as TelegraphIcon,
+  type IconProps as TelegraphIconProps,
+} from "@telegraph/icon";
 import { Stack, type StackProps } from "@telegraph/layout";
 import { useStyleEngine } from "@telegraph/style-engine";
-import { Text as TelegraphText } from "@telegraph/typography";
+import {
+  Text as TelegraphText,
+  type TextProps as TelegraphTextProps,
+} from "@telegraph/typography";
 import clsx from "clsx";
 import React from "react";
 
@@ -185,11 +191,10 @@ const Root = <T extends TgphElement = "button">(rootProps: RootProps<T>) => {
   );
 };
 
-export type IconProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof TelegraphIcon<T>
-> & {
-  internal_iconType?: "leading" | "trailing";
-};
+export type IconProps<T extends TgphElement = "span"> =
+  TelegraphIconProps<T> & {
+    internal_iconType?: "leading" | "trailing";
+  };
 
 const Icon = <T extends TgphElement = "span">(
   buttonIconProps: IconProps<T>,
@@ -239,7 +244,7 @@ const Icon = <T extends TgphElement = "span">(
       {...a11yProps}
       {...iconProps}
       {...(props as Omit<
-        TgphComponentProps<typeof TelegraphIcon<"span">>,
+        TelegraphIconProps<"span">,
         "icon" | "size" | "color" | "variant" | "alt" | "aria-hidden"
       >)}
     />
@@ -247,7 +252,7 @@ const Icon = <T extends TgphElement = "span">(
 };
 
 export type TextProps<T extends TgphElement = "span"> = RemappedOmit<
-  TgphComponentProps<typeof TelegraphText<T>>,
+  TelegraphTextProps<T>,
   "as"
 > & {
   as?: T;
@@ -285,7 +290,7 @@ const Text = <T extends TgphElement = "span">(
         ...style,
       }}
       {...(props as Omit<
-        TgphComponentProps<typeof TelegraphText<"span">>,
+        TelegraphTextProps<"span">,
         "as" | "color" | "size" | "weight" | "style"
       >)}
     />

--- a/packages/combobox/src/Combobox/Combobox.primitives.tsx
+++ b/packages/combobox/src/Combobox/Combobox.primitives.tsx
@@ -1,12 +1,21 @@
-import { Button } from "@telegraph/button";
+import {
+  Button,
+  type ButtonIconProps,
+  type ButtonProps,
+  type ButtonTextProps,
+} from "@telegraph/button";
 import {
   RefToTgphRef,
   type RemappedOmit,
-  type TgphComponentProps,
   type TgphElement,
 } from "@telegraph/helpers";
 import { Box, Stack, type StackProps } from "@telegraph/layout";
-import { Tag } from "@telegraph/tag";
+import {
+  Tag,
+  type TagButtonProps,
+  type TagRootProps,
+  type TagTextProps,
+} from "@telegraph/tag";
 import { Tooltip, type TooltipProps } from "@telegraph/tooltip";
 import { TooltipIfTruncated } from "@telegraph/truncate";
 import { Text } from "@telegraph/typography";
@@ -33,7 +42,7 @@ import type { MultiSelect, SingleSelect } from "./Combobox.types";
 // the body discards it, so leaving it in the type promised an accessible name
 // this never renders.
 type TriggerIndicatorProps<T extends TgphElement> = Omit<
-  Partial<TgphComponentProps<typeof Button.Icon<T>>>,
+  Partial<ButtonIconProps<T>>,
   "as" | "alt"
 >;
 
@@ -61,16 +70,14 @@ const TriggerIndicator = <T extends TgphElement = "span">(
       icon={icon}
       aria-hidden={ariaHidden}
       {...(props as RemappedOmit<
-        TgphComponentProps<typeof Button.Icon<typeof motion.span>>,
+        ButtonIconProps<typeof motion.span>,
         "as" | "icon" | "alt" | "aria-hidden"
       >)}
     />
   );
 };
 
-type TriggerClearProps<T extends TgphElement> = TgphComponentProps<
-  typeof Button<T>
-> & {
+type TriggerClearProps<T extends TgphElement> = ButtonProps<T> & {
   tooltipProps?: TooltipProps;
 };
 
@@ -135,7 +142,7 @@ const TriggerClear = <T extends TgphElement = "button">(
           marginBottom: "calc(-1 * var(--tgph-spacing-1)",
         }}
         {...(props as RemappedOmit<
-          TgphComponentProps<typeof Button<"button">>,
+          ButtonProps<"button">,
           | "type"
           | "icon"
           | "leadingIcon"
@@ -150,9 +157,7 @@ const TriggerClear = <T extends TgphElement = "button">(
   );
 };
 
-type TriggerTextProps<T extends TgphElement> = TgphComponentProps<
-  typeof Button.Text<T>
->;
+type TriggerTextProps<T extends TgphElement> = ButtonTextProps<T>;
 
 const TriggerText = <T extends TgphElement = "span">(
   triggerTextProps: TriggerTextProps<T>,
@@ -175,7 +180,7 @@ const TriggerText = <T extends TgphElement = "span">(
         textOverflow="ellipsis"
         overflow="hidden"
         {...(props as RemappedOmit<
-          TgphComponentProps<typeof Button.Text<"span">>,
+          ButtonTextProps<"span">,
           "color" | "textOverflow" | "overflow" | "children"
         >)}
       >
@@ -185,9 +190,7 @@ const TriggerText = <T extends TgphElement = "span">(
   );
 };
 
-type TriggerPlaceholderProps<T extends TgphElement> = TgphComponentProps<
-  typeof Button.Text<T>
->;
+type TriggerPlaceholderProps<T extends TgphElement> = ButtonTextProps<T>;
 
 const TriggerPlaceholder = <T extends TgphElement = "span">(
   triggerPlaceholderProps: TriggerPlaceholderProps<T>,
@@ -202,7 +205,7 @@ const TriggerPlaceholder = <T extends TgphElement = "span">(
         textOverflow="ellipsis"
         overflow="hidden"
         {...(props as RemappedOmit<
-          TgphComponentProps<typeof Button.Text<"span">>,
+          ButtonTextProps<"span">,
           "color" | "textOverflow" | "overflow" | "children"
         >)}
       >
@@ -287,7 +290,7 @@ const TriggerTagContext = createContext<{
 // Drop `as`: this always renders `motion.span` (KNO-14501).
 type TriggerTagRootProps<T extends TgphElement> = {
   value: string;
-} & RemappedOmit<TgphComponentProps<typeof Tag.Root<T>>, "as">;
+} & RemappedOmit<TagRootProps<T>, "as">;
 
 const TriggerTagRoot = <T extends TgphElement = "span">(
   triggerTagRootProps: TriggerTagRootProps<T>,
@@ -313,7 +316,7 @@ const TriggerTagRoot = <T extends TgphElement = "span">(
         rounded="1"
         layout="position"
         {...(props as RemappedOmit<
-          TgphComponentProps<typeof Tag.Root<typeof motion.span>>,
+          TagRootProps<typeof motion.span>,
           "as" | "size" | "maxH" | "rounded" | "children"
         >)}
       >
@@ -323,9 +326,7 @@ const TriggerTagRoot = <T extends TgphElement = "span">(
   );
 };
 
-type TriggerTagTextProps<T extends TgphElement> = TgphComponentProps<
-  typeof Tag.Text<T>
->;
+type TriggerTagTextProps<T extends TgphElement> = TagTextProps<T>;
 
 const TriggerTagText = <T extends TgphElement = "span">(
   triggerTagTextProps: TriggerTagTextProps<T>,
@@ -354,20 +355,13 @@ const TriggerTagText = <T extends TgphElement = "span">(
   }, [context.options, context.value, triggerTagContext.value]);
 
   return (
-    <Tag.Text
-      {...(props as RemappedOmit<
-        TgphComponentProps<typeof Tag.Text<"span">>,
-        "children"
-      >)}
-    >
+    <Tag.Text {...(props as RemappedOmit<TagTextProps<"span">, "children">)}>
       {children || option}
     </Tag.Text>
   );
 };
 
-type TriggerTagButtonProps<T extends TgphElement> = TgphComponentProps<
-  typeof Tag.Button<T>
->;
+type TriggerTagButtonProps<T extends TgphElement> = TagButtonProps<T>;
 
 const TriggerTagButton = <T extends TgphElement = "button">(
   triggerTagButtonProps: TriggerTagButtonProps<T>,
@@ -400,7 +394,7 @@ const TriggerTagButton = <T extends TgphElement = "button">(
       }}
       data-tgph-combobox-tag-button
       {...(props as RemappedOmit<
-        TgphComponentProps<typeof Tag.Button<"button">>,
+        TagButtonProps<"button">,
         | "icon"
         | "leadingIcon"
         | "trailingIcon"
@@ -415,9 +409,7 @@ const TriggerTagButton = <T extends TgphElement = "button">(
   );
 };
 
-type TriggerTagDefaultProps<T extends TgphElement> = TgphComponentProps<
-  typeof TriggerTagRoot<T>
->;
+type TriggerTagDefaultProps<T extends TgphElement> = TriggerTagRootProps<T>;
 
 const TriggerTagDefault = <T extends TgphElement = "span">(
   triggerTagDefaultProps: TriggerTagDefaultProps<T>,

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -1,12 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
-import type { TgphComponentProps } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { Modal } from "@telegraph/modal";
 import { Text } from "@telegraph/typography";
 import { useState } from "react";
 
-import { Combobox as TelegraphCombobox } from "../Combobox";
+import {
+  Combobox as TelegraphCombobox,
+  type ComboboxRootProps,
+} from "../Combobox";
 
 const meta: Meta = {
   tags: ["autodocs"],
@@ -22,10 +24,7 @@ export default meta;
 // The value-carrying props are dropped from the shared args: every story owns
 // that state locally, over its own value type.
 type Story = StoryObj<
-  Omit<
-    TgphComponentProps<typeof TelegraphCombobox.Root>,
-    "value" | "defaultValue" | "onValueChange" | "layout"
-  >
+  Omit<ComboboxRootProps, "value" | "defaultValue" | "onValueChange" | "layout">
 >;
 
 const LABELS = ["Email", "SMS", "Push", "In-App", "Webhook"];

--- a/packages/combobox/src/Combobox/Combobox.test.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test.tsx
@@ -2818,9 +2818,12 @@ describe("engine compatibility", () => {
     );
 
     await user.click(trigger!);
+    // `aria-expanded` flips a tick before Base UI moves focus into the popup,
+    // so waiting on it alone leaves Escape dispatching at the trigger.
     await waitFor(() =>
-      expect(trigger).toHaveAttribute("aria-expanded", "true"),
+      expect(queryPortalElement("[data-tgph-combobox-search]")).toHaveFocus(),
     );
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
     await user.keyboard("[Escape]");
 
     await waitFor(() =>
@@ -2828,7 +2831,10 @@ describe("engine compatibility", () => {
     );
     expect(onAncestorKeyDown).not.toHaveBeenCalled();
 
+    // Dismissal restores focus to the trigger asynchronously, and jsdom
+    // re-asserts `activeElement` after `.focus()`, so settle before dispatching.
     trigger?.focus();
+    await waitFor(() => expect(trigger).toHaveFocus());
     await user.keyboard("[Escape]");
 
     expect(onAncestorKeyDown).toHaveBeenCalledTimes(1);

--- a/packages/icon/src/Icon/Icon.test-d.tsx
+++ b/packages/icon/src/Icon/Icon.test-d.tsx
@@ -1,3 +1,4 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -89,5 +90,16 @@ describe("Icon types", () => {
     <Icon icon={Bell} alt="bell" as="div" />;
     <Icon icon={Bell} alt="bell" className="c" style={{ opacity: 0.5 }} />;
     <Icon icon={Bell} alt="bell" data-testid="icon" onClick={() => {}} />;
+  });
+
+  // Downstream packages reach these props through the exported alias, not
+  // `TgphComponentProps<typeof Icon<T>>` (KNO-14778). They must not drift.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<IconProps<"span">>().toEqualTypeOf<
+      TgphComponentProps<typeof Icon<"span">>
+    >();
+    expectTypeOf<IconProps<"div">>().toEqualTypeOf<
+      TgphComponentProps<typeof Icon<"div">>
+    >();
   });
 });

--- a/packages/layout/src/Box/Box.test-d.tsx
+++ b/packages/layout/src/Box/Box.test-d.tsx
@@ -1,3 +1,4 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Box } from ".";
@@ -108,5 +109,19 @@ describe("Box types", () => {
     <Box data-testid="box" onClick={() => {}}>
       children
     </Box>;
+  });
+
+  // Downstream packages reach these props through the exported alias, not
+  // `TgphComponentProps<typeof Box<T>>` (KNO-14778). They must not drift.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<BoxProps<"div">>().toEqualTypeOf<
+      TgphComponentProps<typeof Box<"div">>
+    >();
+    expectTypeOf<BoxProps<"a">>().toEqualTypeOf<
+      TgphComponentProps<typeof Box<"a">>
+    >();
+    expectTypeOf<BoxProps<"label">>().toEqualTypeOf<
+      TgphComponentProps<typeof Box<"label">>
+    >();
   });
 });

--- a/packages/layout/src/Stack/Stack.test-d.tsx
+++ b/packages/layout/src/Stack/Stack.test-d.tsx
@@ -1,3 +1,4 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Stack } from ".";
@@ -93,5 +94,19 @@ describe("Stack types", () => {
     <Stack data-testid="stack" onClick={() => {}}>
       children
     </Stack>;
+  });
+
+  // Downstream packages reach these props through the exported alias, not
+  // `TgphComponentProps<typeof Stack<T>>` (KNO-14778). They must not drift.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<StackProps<"div">>().toEqualTypeOf<
+      TgphComponentProps<typeof Stack<"div">>
+    >();
+    expectTypeOf<StackProps<"a">>().toEqualTypeOf<
+      TgphComponentProps<typeof Stack<"a">>
+    >();
+    expectTypeOf<StackProps<"label">>().toEqualTypeOf<
+      TgphComponentProps<typeof Stack<"label">>
+    >();
   });
 });

--- a/packages/link/src/Link/Link.test-d.tsx
+++ b/packages/link/src/Link/Link.test-d.tsx
@@ -1,3 +1,5 @@
+import type { IconProps } from "@telegraph/icon";
+import type { TextProps as TypographyTextProps } from "@telegraph/typography";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -102,5 +104,18 @@ describe("Link types", () => {
     <Link.Root as="span" className="c" style={{ opacity: 0.5 }} />;
     <Link.Text as="p" data-testid="text" />;
     <Link.Icon icon={Bell} aria-hidden color="blue" mr="1" />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Icon<T>` / `typeof Text<T>`.
+  // Nothing else fails if a rename picks the wrong upstream type.
+  it("derives its sub-component props from the upstream exported types", () => {
+    expectTypeOf<LinkIconProps<"span">>().toEqualTypeOf<IconProps<"span">>();
+    expectTypeOf<LinkTextProps<"span">["size"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["size"]
+    >();
+    expectTypeOf<LinkTextProps<"span">["color"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["color"]
+    >();
+    expectTypeOf<LinkTextProps<"p">["as"]>().toEqualTypeOf<"p" | undefined>();
   });
 });

--- a/packages/link/src/Link/Link.tsx
+++ b/packages/link/src/Link/Link.tsx
@@ -3,10 +3,12 @@ import type {
   PolymorphicPropsWithTgphRef,
   RemappedOmit,
   Required,
-  TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
-import { Icon as TelegraphIcon } from "@telegraph/icon";
+import {
+  Icon as TelegraphIcon,
+  type IconProps as TelegraphIconProps,
+} from "@telegraph/icon";
 import { Stack, type StackProps } from "@telegraph/layout";
 import { Text as TelegraphText } from "@telegraph/typography";
 import type { TextProps as TypographyTextProps } from "@telegraph/typography";
@@ -76,7 +78,7 @@ const Root = <T extends TgphElement = "a">(rootProps: RootProps<T>) => {
 };
 
 export type TextProps<T extends TgphElement = "span"> = RemappedOmit<
-  TgphComponentProps<typeof TelegraphText<T>>,
+  TypographyTextProps<T>,
   "as"
 > & {
   as?: T;
@@ -103,9 +105,7 @@ const Text = <T extends TgphElement = "span">(linkTextProps: TextProps<T>) => {
   );
 };
 
-export type IconProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof TelegraphIcon<T>
->;
+export type IconProps<T extends TgphElement = "span"> = TelegraphIconProps<T>;
 
 const Icon = <T extends TgphElement = "span">(linkIconProps: IconProps<T>) => {
   const { icon, size, color, ...props } = linkIconProps as IconProps<"span">;
@@ -124,7 +124,7 @@ const Icon = <T extends TgphElement = "span">(linkIconProps: IconProps<T>) => {
 type DefaultIconProps = RemappedOmit<IconProps, "as"> & { as?: TgphElement };
 type DefaultTextProps = RemappedOmit<TextProps, "as"> & { as?: TgphElement };
 export type DefaultProps<T extends TgphElement = "a"> = PolymorphicProps<T> &
-  TgphComponentProps<typeof Root<T>> & {
+  RootProps<T> & {
     icon?: DefaultIconProps;
     textProps?: DefaultTextProps;
   };

--- a/packages/menu/src/Menu/Menu.fixtures.tsx
+++ b/packages/menu/src/Menu/Menu.fixtures.tsx
@@ -1,8 +1,7 @@
-import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { useState } from "react";
 
-import { Menu } from "./Menu";
+import { Menu, type RootProps as MenuRootProps } from "./Menu";
 
 const PROPERTIES = [
   "workflow.name",
@@ -32,9 +31,7 @@ const PROPERTIES = [
  * keys, so the `onKeyDown` below must stop propagation for everything except
  * navigation/selection keys.
  */
-export const TypeableTriggerExample = (
-  args: Partial<TgphComponentProps<typeof Menu.Root>> = {},
-) => {
+export const TypeableTriggerExample = (args: Partial<MenuRootProps> = {}) => {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState("");
   const matches = PROPERTIES.filter((property) =>

--- a/packages/menu/src/Menu/Menu.stories.tsx
+++ b/packages/menu/src/Menu/Menu.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
-import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import {
   Archive,
@@ -12,7 +11,7 @@ import {
   Share2,
 } from "lucide-react";
 
-import { Menu as TelegraphMenu } from "./Menu";
+import { Menu as TelegraphMenu, type RootProps as MenuRootProps } from "./Menu";
 import { TypeableTriggerExample } from "./Menu.fixtures";
 
 const meta: Meta = {
@@ -41,7 +40,7 @@ const meta: Meta = {
 
 export default meta;
 
-type Story = StoryObj<TgphComponentProps<typeof TelegraphMenu.Root>>;
+type Story = StoryObj<MenuRootProps>;
 
 export const Default: Story = {
   render: ({ ...args }) => {

--- a/packages/menu/src/MenuItem/MenuItem.test-d.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.test-d.tsx
@@ -1,3 +1,4 @@
+import type { ButtonRootProps } from "@telegraph/button";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -77,5 +78,22 @@ describe("MenuItem types", () => {
       leadingComponent={<span />}
       onClick={() => {}}
     />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Button.Root<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives its base props from Button.Root's exported props type", () => {
+    expectTypeOf<MenuItemProps<"button">>().toExtend<
+      ButtonRootProps<"button">
+    >();
+    expectTypeOf<MenuItemProps<"button">["variant"]>().toEqualTypeOf<
+      ButtonRootProps<"button">["variant"]
+    >();
+    expectTypeOf<MenuItemProps<"button">["size"]>().toEqualTypeOf<
+      ButtonRootProps<"button">["size"]
+    >();
+    expectTypeOf<MenuItemProps<"a">["as"]>().toEqualTypeOf<
+      ButtonRootProps<"a">["as"]
+    >();
   });
 });

--- a/packages/menu/src/MenuItem/MenuItem.tsx
+++ b/packages/menu/src/MenuItem/MenuItem.tsx
@@ -1,9 +1,10 @@
 import {
   Button,
   type ButtonIconProps,
+  type ButtonRootProps,
   type ButtonTextProps,
 } from "@telegraph/button";
-import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
+import type { TgphElement } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Check } from "lucide-react";
 import * as motion from "motion/react-m";
@@ -16,7 +17,7 @@ type MenuItemIconProps = {
 };
 
 export type MenuItemProps<T extends TgphElement = "button"> =
-  TgphComponentProps<typeof Button.Root<T>> &
+  ButtonRootProps<T> &
     MenuItemIconProps & {
       selected?: boolean | null;
       leadingComponent?: ReactNode;

--- a/packages/modal/src/Modal/Modal.test-d.tsx
+++ b/packages/modal/src/Modal/Modal.test-d.tsx
@@ -1,3 +1,4 @@
+import type { ButtonProps } from "@telegraph/button";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Modal } from ".";
@@ -175,5 +176,20 @@ describe("Modal types", () => {
     <Modal.Header as="header" className="header" />;
     <Modal.Footer as="footer" style={{ opacity: 1 }} />;
     <Modal.Heading as="h3" size="3" weight="medium" />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Button<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives its close props from Button's exported props type", () => {
+    expectTypeOf<ModalCloseProps<"button">>().toExtend<ButtonProps<"button">>();
+    expectTypeOf<ModalCloseProps<"button">["variant"]>().toEqualTypeOf<
+      ButtonProps<"button">["variant"]
+    >();
+    expectTypeOf<ModalCloseProps<"button">["size"]>().toEqualTypeOf<
+      ButtonProps<"button">["size"]
+    >();
+    expectTypeOf<ModalCloseProps<"a">["as"]>().toEqualTypeOf<
+      ButtonProps<"a">["as"]
+    >();
   });
 });

--- a/packages/modal/src/Modal/Modal.tsx
+++ b/packages/modal/src/Modal/Modal.tsx
@@ -1,11 +1,14 @@
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
-import { Button, resolveButtonNativeButton } from "@telegraph/button";
+import {
+  Button,
+  type ButtonProps,
+  resolveButtonNativeButton,
+} from "@telegraph/button";
 import {
   type LegacyDismissEventHandler,
   type LegacyDismissHandlers,
   RefToTgphRef,
   RemappedOmit,
-  type TgphComponentProps,
   type TgphElement,
   VisuallyHidden,
   callLegacyDismissHandlers,
@@ -13,7 +16,10 @@ import {
   useControllableState,
 } from "@telegraph/helpers";
 import { Box, type BoxProps, Stack, type StackProps } from "@telegraph/layout";
-import { Heading as TelegraphHeading } from "@telegraph/typography";
+import {
+  Heading as TelegraphHeading,
+  type HeadingProps as TypographyHeadingProps,
+} from "@telegraph/typography";
 import { X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
 import * as motion from "motion/react-m";
@@ -676,9 +682,7 @@ const Content = ({
   );
 };
 
-export type CloseProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof Button<T>
-> &
+export type CloseProps<T extends TgphElement = "button"> = ButtonProps<T> &
   Omit<BaseDialogCloseProps, "children" | "color" | "render">;
 const Close = <T extends TgphElement = "button">(closeProps: CloseProps<T>) => {
   const {
@@ -725,7 +729,7 @@ const Close = <T extends TgphElement = "button">(closeProps: CloseProps<T>) => {
           variant={variant}
           size={size}
           {...(props as Omit<
-            TgphComponentProps<typeof Button<"button">>,
+            ButtonProps<"button">,
             // `icon`/`leadingIcon`/`trailingIcon` are not destructured — a
             // caller can still replace the close glyph. They are omitted here
             // because Button's icon union rejects the explicit `icon` below
@@ -796,7 +800,7 @@ const Footer = <T extends TgphElement = "div">(footerProps: FooterProps<T>) => {
 };
 
 type HeadingProps<T extends TgphElement> = RemappedOmit<
-  TgphComponentProps<typeof TelegraphHeading<T>>,
+  TypographyHeadingProps<T>,
   "as"
 > & {
   as?: T;
@@ -813,7 +817,7 @@ const Heading = <T extends TgphElement = "h2">({
     size,
     weight,
     ...props,
-  } as TgphComponentProps<typeof TelegraphHeading<T>>;
+  } as TypographyHeadingProps<T>;
 
   return <TelegraphHeading {...headingProps} />;
 };

--- a/packages/popover/src/Popover/Popover.stories.tsx
+++ b/packages/popover/src/Popover/Popover.stories.tsx
@@ -1,10 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
-import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 import { Ellipsis } from "lucide-react";
 
-import { Popover } from "./Popover";
+import {
+  Popover,
+  type ContentProps as PopoverContentProps,
+  type RootProps as PopoverRootProps,
+} from "./Popover";
 
 const placementOptions = [
   {
@@ -57,10 +60,7 @@ const meta: Meta = {
 
 export default meta;
 
-type Story = StoryObj<
-  TgphComponentProps<typeof Popover.Root> &
-    TgphComponentProps<typeof Popover.Content>
->;
+type Story = StoryObj<PopoverRootProps & PopoverContentProps>;
 
 export const Default: Story = {
   render: ({ ...args }) => {

--- a/packages/radio/src/RadioCards/RadioCards.test-d.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.test-d.tsx
@@ -1,3 +1,4 @@
+import type { ButtonIconProps, ButtonTextProps } from "@telegraph/button";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -164,5 +165,19 @@ describe("RadioCards types", () => {
         <RadioCards.ItemTitle as="span">Option two</RadioCards.ItemTitle>
       </RadioCards.Item>
     </RadioCards.Root>;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Button.Text<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives its item sub-component props from Button's exported types", () => {
+    expectTypeOf<RadioCardsItemTitleProps<"span">>().toEqualTypeOf<
+      ButtonTextProps<"span">
+    >();
+    expectTypeOf<RadioCardsItemDescriptionProps<"span">>().toEqualTypeOf<
+      ButtonTextProps<"span">
+    >();
+    expectTypeOf<RadioCardsItemIconProps<"span">>().toEqualTypeOf<
+      ButtonIconProps<"span">
+    >();
   });
 });

--- a/packages/radio/src/RadioCards/RadioCards.tsx
+++ b/packages/radio/src/RadioCards/RadioCards.tsx
@@ -5,10 +5,13 @@ import {
 } from "@base-ui/react/direction-provider";
 import { Radio as BaseRadio } from "@base-ui/react/radio";
 import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
-import { Button } from "@telegraph/button";
+import {
+  Button,
+  type ButtonIconProps,
+  type ButtonTextProps,
+} from "@telegraph/button";
 import {
   type CSSPropertiesWithVars,
-  type TgphComponentProps,
   type TgphElement,
   createTgphBaseUIRender,
 } from "@telegraph/helpers";
@@ -201,9 +204,7 @@ const Item = forwardRef<ItemRef, ItemProps>(
 );
 Item.displayName = "Item";
 
-export type ItemTitleProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof Button.Text<T>
->;
+export type ItemTitleProps<T extends TgphElement = "span"> = ButtonTextProps<T>;
 
 const ItemTitle = <T extends TgphElement = "span">(
   itemTitleProps: ItemTitleProps<T>,
@@ -219,7 +220,7 @@ const ItemTitle = <T extends TgphElement = "span">(
 };
 
 export type ItemDescriptionProps<T extends TgphElement = "span"> =
-  TgphComponentProps<typeof Button.Text<T>>;
+  ButtonTextProps<T>;
 const ItemDescription = <T extends TgphElement = "span">(
   itemDescriptionProps: ItemDescriptionProps<T>,
 ) => {
@@ -236,9 +237,7 @@ const ItemDescription = <T extends TgphElement = "span">(
   );
 };
 
-export type ItemIconProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof Button.Icon<T>
->;
+export type ItemIconProps<T extends TgphElement = "span"> = ButtonIconProps<T>;
 
 const ItemIcon = <T extends TgphElement = "span">(props: ItemIconProps<T>) => {
   return <Button.Icon color="gray" data-tgph-radio-card-icon {...props} />;

--- a/packages/tabs/src/Tab/Tab.test-d.tsx
+++ b/packages/tabs/src/Tab/Tab.test-d.tsx
@@ -1,3 +1,4 @@
+import type { MenuItemProps } from "@telegraph/menu";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Tab } from ".";
@@ -56,5 +57,17 @@ describe("Tab types", () => {
     <Tab value="a" size="1" selected disabled p="2" />;
     <Tab value="a" as="a" className="c" style={{ opacity: 1 }} />;
     <Tab value="a" aria-label="tab" data-testid="tab" onClick={() => {}} />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof MenuItem<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives its base props from MenuItem's exported props type", () => {
+    expectTypeOf<TabProps<"button">>().toExtend<MenuItemProps<"button">>();
+    expectTypeOf<TabProps<"button">["leadingIcon"]>().toEqualTypeOf<
+      MenuItemProps<"button">["leadingIcon"]
+    >();
+    expectTypeOf<TabProps<"button">["textProps"]>().toEqualTypeOf<
+      MenuItemProps<"button">["textProps"]
+    >();
   });
 });

--- a/packages/tabs/src/Tab/Tab.tsx
+++ b/packages/tabs/src/Tab/Tab.tsx
@@ -1,10 +1,6 @@
 import { Tabs as BaseTabs } from "@base-ui/react/tabs";
 import { resolveButtonNativeButton } from "@telegraph/button";
-import {
-  type TgphComponentProps,
-  type TgphElement,
-  createTgphBaseUIRender,
-} from "@telegraph/helpers";
+import { type TgphElement, createTgphBaseUIRender } from "@telegraph/helpers";
 import { MenuItem, type MenuItemProps } from "@telegraph/menu";
 import { type ComponentPropsWithoutRef, type Ref } from "react";
 
@@ -19,7 +15,7 @@ type BaseTabState = {
 export type TabProps<T extends TgphElement = "button"> = {
   nativeButton?: boolean;
   value: string;
-} & TgphComponentProps<typeof MenuItem<T>>;
+} & MenuItemProps<T>;
 
 // MenuItem's icon props do not depend on its element type, so resolving them
 // through the default element loses nothing.
@@ -38,8 +34,8 @@ const Tab = <T extends TgphElement = "button">(tabProps: TabProps<T>) => {
     ...props
   } = tabProps as TabProps<"button">;
 
-  // Asserted because `@telegraph/menu` derives its icon props from a bare
-  // `TgphComponentProps<typeof Button.Icon>`, which hides `data-*` attributes.
+  // Asserted because `@telegraph/menu` derives its icon props from
+  // `ButtonIconProps`, which hides `data-*` attributes.
   const defaultIconProps = {
     size: "6",
     color: "gray",
@@ -55,7 +51,7 @@ const Tab = <T extends TgphElement = "button">(tabProps: TabProps<T>) => {
   const combinedTrailingIcon = trailingIcon
     ? ({ ...defaultIconProps, ...trailingIcon } as const)
     : undefined;
-  const menuItemProps = props as TgphComponentProps<typeof MenuItem<T>>;
+  const menuItemProps = props as MenuItemProps<T>;
   const nativeButton = resolveButtonNativeButton({
     as: props.as,
     disabled,

--- a/packages/tag/src/Tag/Tag.test-d.tsx
+++ b/packages/tag/src/Tag/Tag.test-d.tsx
@@ -1,3 +1,6 @@
+import type { ButtonProps } from "@telegraph/button";
+import type { IconProps } from "@telegraph/icon";
+import type { TextProps as TypographyTextProps } from "@telegraph/typography";
 import { Bell } from "lucide-react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -129,5 +132,18 @@ describe("Tag types", () => {
     <Tag.CopyButton textToCopy="copy me" />;
     <Tag.CopyButton textToCopy="copy me" onClick={() => {}} className="c" />;
     <Tag.Icon icon={Bell} aria-hidden mr="1" />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Icon<T>` / `typeof Button<T>`.
+  // Nothing else fails if a rename picks the wrong upstream type.
+  it("derives its sub-component props from the upstream exported types", () => {
+    expectTypeOf<TagIconProps<"span">>().toEqualTypeOf<IconProps<"span">>();
+    expectTypeOf<TagButtonProps<"button">>().toEqualTypeOf<
+      ButtonProps<"button">
+    >();
+    expectTypeOf<TagTextProps<"span">["size"]>().toEqualTypeOf<
+      TypographyTextProps<"span">["size"]
+    >();
+    expectTypeOf<TagTextProps<"p">["as"]>().toEqualTypeOf<"p" | undefined>();
   });
 });

--- a/packages/tag/src/Tag/Tag.tsx
+++ b/packages/tag/src/Tag/Tag.tsx
@@ -1,20 +1,26 @@
 import {
   type ButtonRootProps,
   Button as TelegraphButton,
+  type ButtonProps as TelegraphButtonProps,
 } from "@telegraph/button";
 import type {
   PolymorphicProps,
   PolymorphicPropsWithTgphRef,
   RemappedOmit,
   Required,
-  TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
-import { Icon as TelegraphIcon } from "@telegraph/icon";
+import {
+  Icon as TelegraphIcon,
+  type IconProps as TelegraphIconProps,
+} from "@telegraph/icon";
 import { Stack, type StackProps } from "@telegraph/layout";
 import { useStyleEngine } from "@telegraph/style-engine";
 import { Tooltip } from "@telegraph/tooltip";
-import { Text as TelegraphText } from "@telegraph/typography";
+import {
+  Text as TelegraphText,
+  type TextProps as TypographyTextProps,
+} from "@telegraph/typography";
 import { clsx } from "clsx";
 import { Check, Copy, X } from "lucide-react";
 import { LazyMotion, domAnimation } from "motion/react";
@@ -87,7 +93,7 @@ const Root = <T extends TgphElement = "span">(rootProps: RootProps<T>) => {
 };
 
 export type TextProps<T extends TgphElement = "span"> = RemappedOmit<
-  TgphComponentProps<typeof TelegraphText<T>>,
+  TypographyTextProps<T>,
   "as"
 > & {
   as?: T;
@@ -121,9 +127,8 @@ const Text = <T extends TgphElement = "span">(tagTextProps: TextProps<T>) => {
     />
   );
 };
-export type ButtonProps<T extends TgphElement = "button"> = TgphComponentProps<
-  typeof TelegraphButton<T>
->;
+export type ButtonProps<T extends TgphElement = "button"> =
+  TelegraphButtonProps<T>;
 
 export type CopyButtonProps = ButtonRootProps & {
   textToCopy?: string;
@@ -210,9 +215,7 @@ const Button = <T extends TgphElement = "button">({
     />
   );
 };
-export type IconProps<T extends TgphElement = "span"> = TgphComponentProps<
-  typeof TelegraphIcon<T>
->;
+export type IconProps<T extends TgphElement = "span"> = TelegraphIconProps<T>;
 
 const Icon = <T extends TgphElement = "span">(tagIconProps: IconProps<T>) => {
   const {
@@ -240,7 +243,7 @@ const Icon = <T extends TgphElement = "span">(tagIconProps: IconProps<T>) => {
 };
 
 export type DefaultProps<T extends TgphElement = "span"> = PolymorphicProps<T> &
-  TgphComponentProps<typeof Root<T>> & {
+  RootProps<T> & {
     icon?: IconProps;
     textProps?: TextProps;
     onRemove?: () => void;

--- a/packages/toggle/src/Toggle/Toggle.test-d.tsx
+++ b/packages/toggle/src/Toggle/Toggle.test-d.tsx
@@ -1,3 +1,6 @@
+import type { TagProps } from "@telegraph/tag";
+import type { TextProps } from "@telegraph/typography";
+import type { ReactNode } from "react";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Toggle } from ".";
@@ -150,5 +153,19 @@ describe("Toggle types", () => {
     // It renders `Tag as={as || "label"}`, so the default element has to be
     // `"label"` or props the rendered element accepts are rejected.
     <Toggle.Indicator htmlFor="switch-id" />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Text<T>` / `typeof Tag<T>`.
+  // Nothing else fails if a rename picks the wrong upstream type.
+  it("derives its sub-component props from the upstream exported types", () => {
+    expectTypeOf<ToggleLabelProps<"label">>().toEqualTypeOf<
+      TextProps<"label"> & { hidden?: boolean }
+    >();
+    expectTypeOf<ToggleIndicatorProps<"label">>().toEqualTypeOf<
+      TagProps<"label"> & {
+        enabledContent?: ReactNode;
+        disabledContent?: ReactNode;
+      }
+    >();
   });
 });

--- a/packages/toggle/src/Toggle/Toggle.tsx
+++ b/packages/toggle/src/Toggle/Toggle.tsx
@@ -2,15 +2,14 @@ import { Button, type ButtonRootProps } from "@telegraph/button";
 import {
   type PolymorphicPropsWithTgphRef,
   type RemappedOmit,
-  type TgphComponentProps,
   type TgphElement,
   VisuallyHidden,
   useControllableState,
 } from "@telegraph/helpers";
 import { Icon } from "@telegraph/icon";
 import { Stack, type StackProps } from "@telegraph/layout";
-import { Tag } from "@telegraph/tag";
-import { Text } from "@telegraph/typography";
+import { Tag, type TagProps } from "@telegraph/tag";
+import { Text, type TextProps } from "@telegraph/typography";
 import { CheckCircle2, Circle } from "lucide-react";
 import {
   type ReactNode,
@@ -213,9 +212,7 @@ const Switch = ({ as, className, style, ...props }: SwitchProps) => {
   );
 };
 
-export type LabelProps<T extends TgphElement = "label"> = TgphComponentProps<
-  typeof Text<T>
-> & {
+export type LabelProps<T extends TgphElement = "label"> = TextProps<T> & {
   hidden?: boolean;
 };
 
@@ -227,10 +224,7 @@ const Label = <T extends TgphElement = "label">(labelProps: LabelProps<T>) => {
     ...props
   } = labelProps as LabelProps<"label">;
   const context = useContext(ToggleContext);
-  const textProps = props as RemappedOmit<
-    TgphComponentProps<typeof Text<"label">>,
-    "as" | "style"
-  >;
+  const textProps = props as RemappedOmit<TextProps<"label">, "as" | "style">;
 
   if (hidden) {
     return (
@@ -271,11 +265,10 @@ const Label = <T extends TgphElement = "label">(labelProps: LabelProps<T>) => {
 
 // `= "label"`, matching the element it renders below. `"span"` rejected
 // props the rendered element accepts, such as `htmlFor`.
-export type IndicatorProps<T extends TgphElement = "label"> =
-  TgphComponentProps<typeof Tag<T>> & {
-    enabledContent?: ReactNode;
-    disabledContent?: ReactNode;
-  };
+export type IndicatorProps<T extends TgphElement = "label"> = TagProps<T> & {
+  enabledContent?: ReactNode;
+  disabledContent?: ReactNode;
+};
 
 const Indicator = <T extends TgphElement = "label">(
   indicatorProps: IndicatorProps<T>,
@@ -295,7 +288,7 @@ const Indicator = <T extends TgphElement = "label">(
   const size = INDICATOR_SIZE_MAP[context.size];
   // No `Omit`: it would flatten Tag's discriminated `onRemove`/`onCopy` union
   // into a shape no branch accepts.
-  const tagProps = props as TgphComponentProps<typeof Tag<"label">>;
+  const tagProps = props as TagProps<"label">;
 
   return (
     <Tag

--- a/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.stories.tsx
@@ -1,9 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Button } from "@telegraph/button";
-import type { TgphComponentProps } from "@telegraph/helpers";
 import { Stack } from "@telegraph/layout";
 
-import { Tooltip as TelegraphTooltip } from "./Tooltip";
+import { Tooltip as TelegraphTooltip, type TooltipProps } from "./Tooltip";
 import { TooltipGroupProvider } from "./Tooltip.hooks";
 
 const meta: Meta = {
@@ -59,7 +58,7 @@ const meta: Meta = {
 
 export default meta;
 
-type Story = StoryObj<TgphComponentProps<typeof TelegraphTooltip>>;
+type Story = StoryObj<TooltipProps>;
 
 export const Default: Story = {
   render: ({ ...args }) => {

--- a/packages/tooltip/src/Tooltip/Tooltip.test-d.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.test-d.tsx
@@ -1,3 +1,5 @@
+import type { RemappedOmit } from "@telegraph/helpers";
+import type { StackProps } from "@telegraph/layout";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Tooltip, TooltipGroupProvider } from ".";
@@ -136,5 +138,13 @@ describe("Tooltip types", () => {
     <TooltipGroupProvider>
       <span>child</span>
     </TooltipGroupProvider>;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Stack<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives labelProps from Stack's exported props type", () => {
+    expectTypeOf<TooltipBaseProps<"div">["labelProps"]>().toEqualTypeOf<
+      RemappedOmit<StackProps<"div">, "as"> | undefined
+    >();
   });
 });

--- a/packages/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/Tooltip/Tooltip.tsx
@@ -2,7 +2,6 @@ import { Tooltip as BaseTooltip } from "@base-ui/react/tooltip";
 import {
   type CSSPropertiesWithVars,
   type RemappedOmit,
-  type TgphComponentProps,
   type TgphElement,
   callLegacyDismissHandlers,
   createTgphBaseUIRender,
@@ -108,7 +107,7 @@ export type TooltipBaseProps<T extends TgphElement = "div"> = {
   children?: ReactNode;
   label?: ReactNode;
   // Drop `as`: the popup label always renders `motion.div` (KNO-14501).
-  labelProps?: RemappedOmit<TgphComponentProps<typeof Stack<T>>, "as">;
+  labelProps?: RemappedOmit<StackProps<T>, "as">;
   enabled?: boolean;
   // When true, prevents focus events from instantly opening the tooltip. This
   // preserves delayed hover behavior when Select/Combobox move DOM focus on hover.

--- a/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test-d.tsx
+++ b/packages/truncate/src/TooltipIfTruncated/TooltipIfTruncated.test-d.tsx
@@ -1,3 +1,4 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { TooltipIfTruncated } from ".";
@@ -67,5 +68,13 @@ describe("TooltipIfTruncated types", () => {
     >
       <span>Some text</span>
     </TooltipIfTruncated>;
+  });
+
+  // TruncatedText's `tooltipProps` reaches these through the exported alias
+  // rather than `TgphComponentProps<typeof TooltipIfTruncated>` (KNO-14778).
+  it("is exactly the component's own props", () => {
+    expectTypeOf<TooltipIfTruncatedProps>().toEqualTypeOf<
+      TgphComponentProps<typeof TooltipIfTruncated>
+    >();
   });
 });

--- a/packages/truncate/src/TruncatedText/TruncatedText.test-d.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.test-d.tsx
@@ -1,4 +1,7 @@
+import type { TextProps } from "@telegraph/typography";
 import { describe, expectTypeOf, it } from "vitest";
+
+import type { TooltipIfTruncatedProps } from "../TooltipIfTruncated";
 
 import { TruncatedText } from ".";
 import type {
@@ -127,5 +130,17 @@ describe("TruncatedText types", () => {
       aria-label="truncated"
       data-testid="truncated"
     />;
+  });
+
+  // Pins the KNO-14778 swap: these were `typeof Text<T>`, and nothing
+  // else fails if a rename picks the wrong upstream type.
+  it("derives its base props from the upstream exported types", () => {
+    expectTypeOf<TruncatedTextProps<"p">>().toExtend<TextProps<"p">>();
+    expectTypeOf<TruncatedTextProps<"p">["size"]>().toEqualTypeOf<
+      TextProps<"p">["size"]
+    >();
+    expectTypeOf<TruncatedTextProps<"p">["tooltipProps"]>().toEqualTypeOf<
+      Partial<TooltipIfTruncatedProps> | undefined
+    >();
   });
 });

--- a/packages/truncate/src/TruncatedText/TruncatedText.tsx
+++ b/packages/truncate/src/TruncatedText/TruncatedText.tsx
@@ -1,8 +1,11 @@
-import type { TgphComponentProps, TgphElement } from "@telegraph/helpers";
-import { Text } from "@telegraph/typography";
+import type { TgphElement } from "@telegraph/helpers";
+import { Text, type TextProps } from "@telegraph/typography";
 import { type ComponentPropsWithoutRef, type ReactNode, type Ref } from "react";
 
-import { TooltipIfTruncated } from "../TooltipIfTruncated";
+import {
+  TooltipIfTruncated,
+  type TooltipIfTruncatedProps,
+} from "../TooltipIfTruncated";
 
 import {
   middleIsTruncated,
@@ -156,7 +159,7 @@ const LTR_ISOLATE = { direction: "ltr", unicodeBidi: "isolate" } as const;
 // ── Public component ────────────────────────────────────────────────────────
 
 export type TruncatedTextProps<T extends TgphElement = "span"> = {
-  tooltipProps?: Partial<TgphComponentProps<typeof TooltipIfTruncated>>;
+  tooltipProps?: Partial<TooltipIfTruncatedProps>;
   /**
    * `truncate` (default) clips the end, `fruncate` the start, and `middle`
    * elides the middle — all with native `text-overflow: ellipsis`, so they clip
@@ -174,7 +177,7 @@ export type TruncatedTextProps<T extends TgphElement = "span"> = {
   split?: Split;
   /** `middle` mode: which end stays whole; the other truncates (one ellipsis). */
   priority?: TruncatePriority;
-} & TgphComponentProps<typeof Text<T>>;
+} & TextProps<T>;
 
 const TruncatedText = <T extends TgphElement = "span">(
   truncatedTextProps: TruncatedTextProps<T>,

--- a/packages/typography/src/Code/Code.test-d.tsx
+++ b/packages/typography/src/Code/Code.test-d.tsx
@@ -1,3 +1,5 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import type { BoxProps } from "@telegraph/layout";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Code } from ".";
@@ -80,5 +82,27 @@ describe("Code types", () => {
     <Code as="code" data-testid="code" onClick={() => {}}>
       children
     </Code>;
+  });
+
+  // See the matching test in Text.test-d.tsx.
+  it("inherits Box's props at Box's own types", () => {
+    expectTypeOf<CodeProps<"pre">["p"]>().toEqualTypeOf<BoxProps<"pre">["p"]>();
+    expectTypeOf<CodeProps<"pre">["bg"]>().toEqualTypeOf<
+      BoxProps<"pre">["bg"]
+    >();
+    expectTypeOf<CodeProps<"pre">["tgphRef"]>().toEqualTypeOf<
+      BoxProps<"pre">["tgphRef"]
+    >();
+  });
+
+  // Code has no downstream consumer today, but `CodeProps` is the name callers
+  // are pointed at (KNO-14778), so it has to keep meaning the same thing.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<CodeProps<"code">>().toEqualTypeOf<
+      TgphComponentProps<typeof Code<"code">>
+    >();
+    expectTypeOf<CodeProps<"pre">>().toEqualTypeOf<
+      TgphComponentProps<typeof Code<"pre">>
+    >();
   });
 });

--- a/packages/typography/src/Code/Code.tsx
+++ b/packages/typography/src/Code/Code.tsx
@@ -1,10 +1,9 @@
 import {
   OptionalAsPropConfig,
   RemappedOmit,
-  TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Box, type BoxProps } from "@telegraph/layout";
 import { useStyleEngine } from "@telegraph/style-engine";
 import clsx from "clsx";
 
@@ -19,7 +18,7 @@ type BaseCodeProps = Omit<StyleProps, "color"> & {
 };
 
 export type CodeProps<T extends TgphElement = "code"> = BaseCodeProps &
-  RemappedOmit<TgphComponentProps<typeof Box<T>>, keyof BaseCodeProps> &
+  RemappedOmit<BoxProps<T>, keyof BaseCodeProps> &
   OptionalAsPropConfig<T>;
 
 const Code = <T extends TgphElement = "code">({

--- a/packages/typography/src/Heading/Heading.test-d.tsx
+++ b/packages/typography/src/Heading/Heading.test-d.tsx
@@ -1,3 +1,5 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import type { BoxProps } from "@telegraph/layout";
 import { describe, expectTypeOf, it } from "vitest";
 
 import { Heading } from ".";
@@ -81,5 +83,29 @@ describe("Heading types", () => {
     <Heading as="h2" data-testid="heading" onClick={() => {}}>
       children
     </Heading>;
+  });
+
+  // See the matching test in Text.test-d.tsx.
+  it("inherits Box's props at Box's own types", () => {
+    expectTypeOf<HeadingProps<"h3">["p"]>().toEqualTypeOf<
+      BoxProps<"h3">["p"]
+    >();
+    expectTypeOf<HeadingProps<"h3">["bg"]>().toEqualTypeOf<
+      BoxProps<"h3">["bg"]
+    >();
+    expectTypeOf<HeadingProps<"h3">["tgphRef"]>().toEqualTypeOf<
+      BoxProps<"h3">["tgphRef"]
+    >();
+  });
+
+  // Downstream packages reach these props through the exported alias, not
+  // `TgphComponentProps<typeof Heading<T>>` (KNO-14778). They must not drift.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<HeadingProps<"h2">>().toEqualTypeOf<
+      TgphComponentProps<typeof Heading<"h2">>
+    >();
+    expectTypeOf<HeadingProps<"h3">>().toEqualTypeOf<
+      TgphComponentProps<typeof Heading<"h3">>
+    >();
   });
 });

--- a/packages/typography/src/Heading/Heading.tsx
+++ b/packages/typography/src/Heading/Heading.tsx
@@ -1,10 +1,9 @@
 import {
   OptionalAsPropConfig,
   RemappedOmit,
-  TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Box, type BoxProps } from "@telegraph/layout";
 import { useStyleEngine } from "@telegraph/style-engine";
 import clsx from "clsx";
 
@@ -16,7 +15,7 @@ type BaseHeadingProps = Omit<StyleProps, "color"> & {
 };
 
 export type HeadingProps<T extends TgphElement = "h2"> = BaseHeadingProps &
-  RemappedOmit<TgphComponentProps<typeof Box<T>>, keyof BaseHeadingProps> &
+  RemappedOmit<BoxProps<T>, keyof BaseHeadingProps> &
   OptionalAsPropConfig<T>;
 
 const Heading = <T extends TgphElement = "h2">({

--- a/packages/typography/src/Text/Text.test-d.tsx
+++ b/packages/typography/src/Text/Text.test-d.tsx
@@ -1,3 +1,5 @@
+import type { TgphComponentProps } from "@telegraph/helpers";
+import type { BoxProps } from "@telegraph/layout";
 import type { CSSProperties } from "react";
 import { describe, expectTypeOf, it } from "vitest";
 
@@ -104,5 +106,32 @@ describe("Text types", () => {
       // @ts-expect-error not a CSS property
       style={{ colr: "red" }}
     />;
+  });
+
+  // The passthrough is `BoxProps<T>` (KNO-14778). Swapping that source back to
+  // a deferred `ComponentProps` widens these to `any` without failing tsc.
+  it("inherits Box's props at Box's own types", () => {
+    expectTypeOf<TextProps<"p">["p"]>().toEqualTypeOf<BoxProps<"p">["p"]>();
+    expectTypeOf<TextProps<"p">["bg"]>().toEqualTypeOf<BoxProps<"p">["bg"]>();
+    expectTypeOf<TextProps<"p">["rounded"]>().toEqualTypeOf<
+      BoxProps<"p">["rounded"]
+    >();
+    expectTypeOf<TextProps<"p">["tgphRef"]>().toEqualTypeOf<
+      BoxProps<"p">["tgphRef"]
+    >();
+  });
+
+  // Downstream packages reach these props through the exported alias, not
+  // `TgphComponentProps<typeof Text<T>>` (KNO-14778). They must not drift.
+  it("is exactly the component's own props", () => {
+    expectTypeOf<TextProps<"span">>().toEqualTypeOf<
+      TgphComponentProps<typeof Text<"span">>
+    >();
+    expectTypeOf<TextProps<"p">>().toEqualTypeOf<
+      TgphComponentProps<typeof Text<"p">>
+    >();
+    expectTypeOf<TextProps<"label">>().toEqualTypeOf<
+      TgphComponentProps<typeof Text<"label">>
+    >();
   });
 });

--- a/packages/typography/src/Text/Text.tsx
+++ b/packages/typography/src/Text/Text.tsx
@@ -1,10 +1,9 @@
 import {
   OptionalAsPropConfig,
   RemappedOmit,
-  TgphComponentProps,
   TgphElement,
 } from "@telegraph/helpers";
-import { Box } from "@telegraph/layout";
+import { Box, type BoxProps } from "@telegraph/layout";
 import { useStyleEngine } from "@telegraph/style-engine";
 import clsx from "clsx";
 
@@ -16,7 +15,7 @@ type BaseTextProps = Omit<StyleProps, "color"> & {
 };
 
 export type TextProps<T extends TgphElement = "span"> = BaseTextProps &
-  RemappedOmit<TgphComponentProps<typeof Box<T>>, keyof BaseTextProps> &
+  RemappedOmit<BoxProps<T>, keyof BaseTextProps> &
   OptionalAsPropConfig<T>;
 
 const Text = <T extends TgphElement = "span">({


### PR DESCRIPTION
### What changed?

- 52 sites in 13 packages swap `TgphComponentProps<typeof X<T>>` for the `XProps<T>` each package exports
- no type actually changed. the dashboard compiles the same against main's build and this one
- new `*.test-d.tsx` cases fail if any of those swaps picked the wrong type
- one deliberate exception: button's `IconProps` keeps `internal_iconType`, so it stays wider than icon's
- Storybook args for `Popover.Content` and `Tooltip` now include the `div` attributes they render
- a flaky combobox Escape test now waits for focus, not `aria-expanded`
- it failed on `main` too, so this branch is not the cause
- colliding names import under the file's `Telegraph*` alias, and every wrapper around a swap is untouched

### Why?

`TgphComponentProps` is just `React.ComponentProps`. Use it on a component whose element type is still a type parameter, and TypeScript has nothing to resolve. TypeScript substitutes the constraint, which is every element type at once. The result accepts any prop you pass, so prop checking stops. Each package already exports a props type without that hole, so this uses those.

### Checklist

- [x] **Changeset added.** Run `yarn changeset` and describe the change (or add an empty changeset for infra-only PRs).
- [ ] **README updated for API changes.** If this PR adds, removes, or changes a component's public props, has the package README been updated to match?
- [x] **Invalid prop usage still fails type-checking.** If this PR restricts a prop's allowed values, is there a `*.test-d.tsx` case asserting the invalid usage fails to compile, not just that valid usage does?
- [ ] **Storybook stories updated.** Do new or changed props/variants have corresponding stories so reviewers can visually verify them?
