### PR TITLE
feat(combobox): support externally virtualized options

### DIFF
--- a/.changeset/combobox-external-virtualization.md
+++ b/.changeset/combobox-external-virtualization.md
@@ -1,0 +1,16 @@
+---
+"@telegraph/combobox": minor
+---
+
+feat(combobox): support externally virtualized options
+
+`Combobox.Root` accepts an `options` collection for consumers that mount only a
+window of `Combobox.Option` children (e.g. TanStack Virtual). Base UI then
+derives each row's navigation index from that collection instead of the mounted
+DOM order, so ArrowUp/ArrowDown advance exactly one option across a window
+boundary without pinning the whole prefix of the list.
+
+Passing `options` implies `manualFiltering`, keeps `onItemHighlighted` reporting
+the correct string value with a collection-relative `details.index` to drive the
+virtualizer, and resolves the trigger label for a selected option the window
+never mounts. Comboboxes that do not pass `options` are unaffected.

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -94,6 +94,7 @@ The root component that manages the state and context for the combobox.
 | `required`           | `boolean`                                                   | `false`      | Require a selection before form submission             |
 | `name`               | `string`                                                    | `undefined`  | Submit the selected value with this field name         |
 | `manualFiltering`    | `boolean`                                                   | automatic    | Show rendered options without the built-in text filter; controlled Search enables it by default |
+| `options`            | `ComboboxOption[]`                                          | `undefined`  | The full ordered collection, when you mount only a window of the options. See [External Virtualization](#external-virtualization) |
 | `onItemHighlighted`  | `(value: string \| undefined, details: ComboboxHighlightDetails) => void` | `undefined` | Called when virtual option focus changes               |
 | `selectionMode`      | `"single" \| "multiple" \| "none"`                         | inferred     | Select one, select many, or accept free text           |
 | `inputValue`         | `string`                                                    | `undefined`  | Controlled text for `Combobox.Input` or `Combobox.Search` |
@@ -320,6 +321,99 @@ export const AsyncCombobox = () => {
 };
 ```
 
+### External Virtualization
+
+Pass `options` when the list is too long to mount. Render only the visible
+window of `Combobox.Option` children and give `Combobox.Root` the whole ordered
+collection. Base UI numbers each row against that collection instead of the
+mounted DOM, so one arrow press moves one option as rows scroll in and out.
+
+Without `options`, a virtualizer that unmounts earlier rows makes Base UI
+renumber the mounted ones. A single `ArrowDown` can then jump several options.
+
+```tsx
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { Combobox, type ComboboxOption } from "@telegraph/combobox";
+import { Box } from "@telegraph/layout";
+import { useRef, useState } from "react";
+
+export const VirtualizedCombobox = ({
+  channels,
+}: {
+  channels: ComboboxOption[];
+}) => {
+  const [value, setValue] = useState<string | undefined>(undefined);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: channels.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 32,
+    overscan: 8,
+  });
+
+  return (
+    <Combobox.Root
+      value={value}
+      onValueChange={setValue}
+      options={channels}
+      onItemHighlighted={(_value, details) => {
+        if (details.index >= 0) virtualizer.scrollToIndex(details.index);
+      }}
+    >
+      <Combobox.Trigger />
+      <Combobox.Content>
+        <Combobox.Options tgphRef={scrollRef} maxHeight="64">
+          <Box
+            w="full"
+            position="relative"
+            style={{ height: `${virtualizer.getTotalSize()}px` }}
+          >
+            {virtualizer.getVirtualItems().map((row) => {
+              const option = channels[row.index];
+              if (!option) return null;
+              return (
+                <Box
+                  key={option.value}
+                  w="full"
+                  position="absolute"
+                  top="0"
+                  left="0"
+                  style={{
+                    height: `${row.size}px`,
+                    transform: `translateY(${row.start}px)`,
+                  }}
+                >
+                  <Combobox.Option value={option.value}>
+                    {option.label}
+                  </Combobox.Option>
+                </Box>
+              );
+            })}
+          </Box>
+        </Combobox.Options>
+        <Combobox.Empty />
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+```
+
+Four rules come with `options`:
+
+1. Filtering is yours. Root forces `manualFiltering` on, because Telegraph's
+   filter reads only the mounted rows. Pass the collection already narrowed.
+2. Labels come from the collection, not the children. Set `label` on an entry
+   where the trigger needs more than the raw value.
+3. Scrolling is yours. Base UI cannot scroll to a row it has not mounted, so
+   drive the virtualizer from `details.index`.
+4. Every mounted option needs an entry, action rows included. A missing row
+   stays reachable by mouse but not by keyboard. `Combobox.Create` is exempt
+   and carries its own index.
+
+`Combobox.Options` is the scroll container. Pass it to the virtualizer with
+`tgphRef` and give it a bounded height.
+
 ### Create New Options
 
 ```tsx
@@ -445,13 +539,15 @@ export const CustomTrigger = () => (
 - `aria-controls` - Links trigger to dropdown
 - `aria-selected` - Indicates selected options
 - `role="listbox"` and `role="option"` - On dropdown and options
+- `aria-setsize` and `aria-posinset` - On options when `options` is set, so the
+  count reflects the whole collection rather than the mounted window
 
 ### Best Practices
 
 1. **Provide labels**: Use clear, descriptive placeholders
 2. **Handle loading states**: Show loading indicators during async operations
 3. **Error feedback**: Use the `errored` prop and provide error messages
-4. **Reasonable limits**: Consider pagination for large option lists
+4. **Long lists**: Virtualize with `options`, or split the list across pages
 
 ## Complete Component Reference
 
@@ -563,7 +659,8 @@ The `legacyBehavior` prop and `{ value, label }` selection objects were removed.
 Store only the option value in state. The trigger derives its display text from
 the matching mounted `Combobox.Option`, using its `label`, then its children,
 then its value. Async and paginated lists must keep the selected item mounted as
-an Option so the trigger can display its label.
+an Option so the trigger can display its label. A list that passes `options`
+does not. The trigger reads the label from the collection instead.
 
 ## References
 

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@knocklabs/typescript-config": "^0.0.2",
+    "@tanstack/react-virtual": "^3.14.11",
     "@telegraph/postcss-config": "workspace:^",
     "@telegraph/vite-config": "workspace:^",
     "@types/react": "^19.2.18",

--- a/packages/combobox/src/Combobox/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox/Combobox.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "@telegraph/button";
 import type { TgphComponentProps } from "@telegraph/helpers";
 import { Box, Stack } from "@telegraph/layout";
 import { Modal } from "@telegraph/modal";
 import { Text } from "@telegraph/typography";
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { Combobox as TelegraphCombobox } from "../Combobox";
 
@@ -840,6 +841,99 @@ export const FreeTextAutocomplete: Story = {
                   {channel}
                 </TelegraphCombobox.Option>
               ))}
+            </TelegraphCombobox.Options>
+            <TelegraphCombobox.Empty />
+          </TelegraphCombobox.Content>
+        </TelegraphCombobox.Root>
+      </Box>
+    );
+  },
+};
+
+// TanStack Virtual mounts only the visible rows, while `options` carries the
+// whole collection. Base UI numbers rows against the collection, so one arrow
+// press moves one option even as rows scroll in and out. Filtering and
+// scrolling both become the consumer's work.
+const VIRTUAL_CHANNELS = Array.from({ length: 5000 }, (_, index) => ({
+  value: `channel-${index}`,
+  label: `#channel-${index}`,
+}));
+
+const VIRTUAL_ROW_HEIGHT = 32;
+
+export const ExternalVirtualization: Story = {
+  render: ({ ...args }) => {
+    // eslint-disable-next-line
+    const [value, setValue] = useState<string | undefined>("channel-1234");
+    // eslint-disable-next-line
+    const [query, setQuery] = useState("");
+    // eslint-disable-next-line
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    // eslint-disable-next-line
+    const options = useMemo(
+      () =>
+        query
+          ? VIRTUAL_CHANNELS.filter((channel) =>
+              channel.label.toLowerCase().includes(query.toLowerCase()),
+            )
+          : VIRTUAL_CHANNELS,
+      [query],
+    );
+
+    // eslint-disable-next-line
+    const virtualizer = useVirtualizer({
+      count: options.length,
+      getScrollElement: () => scrollRef.current,
+      estimateSize: () => VIRTUAL_ROW_HEIGHT,
+      overscan: 8,
+    });
+
+    return (
+      <Box w="80">
+        <TelegraphCombobox.Root
+          {...args}
+          value={value}
+          onValueChange={setValue}
+          options={options}
+          placeholder="Select a channel"
+          onItemHighlighted={(_highlightedValue, details) => {
+            if (details.index >= 0) {
+              virtualizer.scrollToIndex(details.index);
+            }
+          }}
+        >
+          <TelegraphCombobox.Trigger />
+          <TelegraphCombobox.Content>
+            <TelegraphCombobox.Search value={query} onValueChange={setQuery} />
+            <TelegraphCombobox.Options tgphRef={scrollRef} maxHeight="64">
+              <Box
+                w="full"
+                position="relative"
+                style={{ height: `${virtualizer.getTotalSize()}px` }}
+              >
+                {virtualizer.getVirtualItems().map((row) => {
+                  const option = options[row.index];
+                  if (!option) return null;
+                  return (
+                    <Box
+                      key={option.value}
+                      w="full"
+                      position="absolute"
+                      top="0"
+                      left="0"
+                      style={{
+                        height: `${row.size}px`,
+                        transform: `translateY(${row.start}px)`,
+                      }}
+                    >
+                      <TelegraphCombobox.Option value={option.value}>
+                        {option.label}
+                      </TelegraphCombobox.Option>
+                    </Box>
+                  );
+                })}
+              </Box>
             </TelegraphCombobox.Options>
             <TelegraphCombobox.Empty />
           </TelegraphCombobox.Content>

--- a/packages/combobox/src/Combobox/Combobox.test-d.tsx
+++ b/packages/combobox/src/Combobox/Combobox.test-d.tsx
@@ -180,6 +180,32 @@ describe("Combobox types", () => {
     >().toEqualTypeOf<string>();
   });
 
+  it("types the external virtualization collection", () => {
+    expectTypeOf<ComboboxRootProps<string>["options"]>().not.toBeAny();
+    // Values stay strings — Base UI's object item values never surface here.
+    expectTypeOf<
+      NonNullable<ComboboxRootProps<string>["options"]>[number]["value"]
+    >().toEqualTypeOf<string>();
+    expectTypeOf<
+      NonNullable<ComboboxRootProps<string>["options"]>[number]["label"]
+    >().not.toBeAny();
+
+    // Virtualization is orthogonal to how the combobox remembers a selection,
+    // so the collection has the same shape in every mode.
+    expectTypeOf<ComboboxRootProps<Array<string>>["options"]>().toEqualTypeOf<
+      ComboboxRootProps<string>["options"]
+    >();
+
+    // The index a consumer feeds to its virtualizer rides on the highlight
+    // details, so it must be a number rather than an optional/any.
+    expectTypeOf<ComboboxHighlightDetails["index"]>().toEqualTypeOf<number>();
+
+    <Combobox.Root
+      options={[{ value: "a" }, { value: "b", label: "B" }]}
+      onItemHighlighted={(_value, details) => details.index}
+    />;
+  });
+
   it("reports undefined when a single selection is cleared", () => {
     expectTypeOf<ComboboxRootProps<string>["onValueChange"]>().toEqualTypeOf<
       ((value: string | undefined) => void) | undefined

--- a/packages/combobox/src/Combobox/Combobox.tsx
+++ b/packages/combobox/src/Combobox/Combobox.tsx
@@ -130,7 +130,23 @@ type RootSharedProps = {
   ) => void;
   // The value to scroll to when the combobox opens if no value is selected.
   // Useful for long lists where you want to start at a specific position.
+  // Root ignores this when `options` is set. The virtualizer owns scrolling.
   defaultScrollToValue?: string;
+  // --- Additive: external virtualization -----------------------------------
+  // The full ordered collection, for a consumer that mounts only a window of
+  // `Combobox.Option` children (e.g. TanStack Virtual). Base UI indexes rows
+  // against this list instead of the mounted DOM, so arrow keys still move one
+  // option at a time across a window boundary. Passing it means:
+  // - Filtering is yours. Root forces `manualFiltering` on.
+  // - Labels come from here, not the children, so a selected option outside the
+  //   window still resolves. Set `label` where the trigger needs more than the
+  //   raw value.
+  // - Scrolling is yours. Drive the virtualizer from `details.index` on
+  //   `onItemHighlighted`.
+  // - Every mounted option needs an entry, action rows included. A missing row
+  //   stays reachable by mouse but not by keyboard. `Combobox.Create` is exempt
+  //   and carries its own index.
+  options?: Array<DefinedOption>;
   // --- Additive: segmented pages -------------------------------------------
   // Active page. Uncontrolled defaults to the first `Combobox.PageButton`.
   page?: string;
@@ -225,8 +241,14 @@ type RootImplementationProps = RootChildrenProps &
     selectionMode?: ComboboxSelectionMode;
   };
 
+type ExternalCollection = {
+  options: Array<DefinedOption>;
+  indexByValue: Map<string, number>;
+};
+
 export const ComboboxContext = createContext<
-  Omit<RootImplementationProps, "children"> & {
+  // `options` below is the resolved collection, not the raw prop.
+  Omit<RootImplementationProps, "children" | "options"> & {
     contentId: string;
     triggerId: string;
     open: boolean;
@@ -250,7 +272,11 @@ export const ComboboxContext = createContext<
     onEscapeKeyDownRef?: RefObject<
       ((event: KeyboardEvent) => void) | undefined
     >;
+    // For label resolution: the consumer's collection, or the mounted children.
     options: Array<DefinedOption>;
+    // Present only when the consumer owns the collection. Parts read its
+    // presence as "only a window of the options is mounted".
+    externalCollection?: ExternalCollection;
     manualFiltering: boolean;
     defaultScrollToValue?: string;
     // Explicit Base UI registry index for a Create row rendered outside Options.
@@ -359,6 +385,7 @@ const RootImplementation = ({
   manualFiltering: manualFilteringProp,
   onItemHighlighted: onItemHighlightedProp,
   defaultScrollToValue,
+  options: optionsProp,
   page: pageProp,
   defaultPage: defaultPageProp,
   onPageChange: onPageChangeProp,
@@ -387,9 +414,25 @@ const RootImplementation = ({
   >(undefined);
   const optionCloseOnClickRef = useRef(false);
 
-  const options = useMemo(() => {
+  const childOptions = useMemo(() => {
     return getOptions({ children, isOptionElement, isOptionsElement });
   }, [children]);
+
+  const externalCollection = useMemo<ExternalCollection | undefined>(() => {
+    if (!optionsProp) return undefined;
+    const indexByValue = new Map<string, number>();
+    optionsProp.forEach((option, index) => {
+      // First occurrence wins, like Base UI's `findItemIndex`. `new Map(...)`
+      // would keep the last and disagree on a duplicated value.
+      if (!indexByValue.has(option.value))
+        indexByValue.set(option.value, index);
+    });
+    return { options: optionsProp, indexByValue };
+  }, [optionsProp]);
+  const isExternallyVirtualized = externalCollection !== undefined;
+
+  // The children cannot describe an option the window never mounts.
+  const options = externalCollection?.options ?? childOptions;
 
   const searchControl = useMemo(() => findSearchControl(children), [children]);
   const searchControlsFiltering =
@@ -397,11 +440,17 @@ const RootImplementation = ({
     searchControl?.onValueChange !== undefined;
   // A controlled Search historically replaced Telegraph's filter. Preserve
   // that behavior unless Root explicitly chooses its filtering mode.
-  const manualFiltering = manualFilteringProp ?? searchControlsFiltering;
+  // A collection forces it on. Telegraph's filter reads only mounted rows, so
+  // hiding one leaves a gap Base UI still counts and arrow keys land on nothing.
+  const manualFiltering = isExternallyVirtualized
+    ? true
+    : (manualFilteringProp ?? searchControlsFiltering);
 
-  // Whether a `Combobox.Create` is rendered. It mounts a matching row that isn't
-  // part of `options`, so `filteredItems` must reserve a slot for it (below).
-  const hasCreate = useMemo(() => childrenContainCreate(children), [children]);
+  // The `Combobox.Create` row, when one is rendered. It mounts a row that is not
+  // part of `options`, so `filteredItems` reserves a slot for it below. Create
+  // hides itself when the query is already one of its `values`, so the slot has
+  // to follow the same rule.
+  const createControl = useMemo(() => findCreateControl(children), [children]);
 
   // Whether a `Combobox.Input` anchor is rendered (input-as-trigger arrangement)
   // instead of the button `Combobox.Trigger`.
@@ -555,7 +604,10 @@ const RootImplementation = ({
     // Manual filtering and free-text modes without list autocomplete leave the
     // rendered options unchanged. The query still drives Create and clear.
     const query = shouldFilterOptions ? activeSearchQuery : "";
-    const values = scopedOptions
+    // The collection arrives pre-narrowed, since it forces `manualFiltering`,
+    // so the filter below is a pass-through for it.
+    const source = externalCollection?.options ?? scopedOptions;
+    const values = source
       .filter(
         (option) =>
           !query ||
@@ -575,16 +627,27 @@ const RootImplementation = ({
     // it navigable. Use the typed query (`activeSearchQuery`) rather than the
     // filter `query` (forced empty under manualFiltering, and the wrong field in
     // free-text mode) so Create stays navigable in every arrangement.
-    // Over-reserving when Create is hidden (its value already exists) is harmless.
+    // Reserving a slot Create does not fill leaves a dead index: with a
+    // collection this list also sizes `listRef`, so arrow keys would land on a
+    // row that is not there.
     const createQuery = activeSearchQuery;
     let nextCreateIndex: number | undefined;
-    if (createQuery && hasCreate) {
+    const createRenders =
+      createControl !== undefined &&
+      !createControl.values?.includes(createQuery);
+    if (createQuery && createRenders) {
       nextCreateIndex = values.length;
       values.push(createQuery);
     }
 
     return { filteredItems: values, createIndex: nextCreateIndex };
-  }, [scopedOptions, activeSearchQuery, hasCreate, shouldFilterOptions]);
+  }, [
+    externalCollection,
+    scopedOptions,
+    activeSearchQuery,
+    createControl,
+    shouldFilterOptions,
+  ]);
   // Open state, kept controllable like the old menu-backed implementation. This
   // mirrors `useControllableState` (same no-op-on-equal and updater semantics)
   // but threads Base UI's change `details` to the consumer's `onOpenChange` as an
@@ -906,6 +969,7 @@ const RootImplementation = ({
         errored,
         layout,
         options,
+        externalCollection,
         manualFiltering,
         autocompleteMode,
         defaultScrollToValue,
@@ -940,7 +1004,12 @@ const RootImplementation = ({
           }
           // Children mode: options are mounted `Combobox.Item`s; this list only
           // re-seeds the type-to-filter highlight and bounds it to the rows.
-          filteredItems={filteredItems}
+          // With a collection it goes over as `items` instead. See the
+          // Combobox root below.
+          filteredItems={isExternallyVirtualized ? undefined : filteredItems}
+          items={isExternallyVirtualized ? filteredItems : undefined}
+          filter={isExternallyVirtualized ? null : undefined}
+          virtualized={isExternallyVirtualized}
           itemToStringValue={itemToStringLabel}
           autoHighlight={autoHighlightProp ?? false}
           openOnInputClick={openOnInputClickProp}
@@ -997,7 +1066,14 @@ const RootImplementation = ({
           // only exists so Base UI re-seeds the type-to-filter highlight per
           // keystroke and bounds it to the mounted rows. See the `filteredItems`
           // memo above for why it is computed conservatively.
-          filteredItems={filteredItems}
+          filteredItems={isExternallyVirtualized ? undefined : filteredItems}
+          // `items`, not `filteredItems`, is what sizes Base UI's navigation
+          // bounds (`listRef.current.length`) to the whole collection. Without
+          // it `virtualized` cannot keep one arrow press to one option.
+          // `filter={null}` stops a second filter pass shifting the indexes.
+          items={isExternallyVirtualized ? filteredItems : undefined}
+          filter={isExternallyVirtualized ? null : undefined}
+          virtualized={isExternallyVirtualized}
           itemToStringLabel={itemToStringLabel}
           modal={modal}
           disabled={disabled}
@@ -1647,10 +1723,13 @@ const Options = <T extends TgphElement = "div">({
   const optionsRef = useRef<HTMLDivElement>(null);
   const composedRef = useComposedRefs<unknown>(tgphRef, optionsRef);
 
-  // Scroll to the selected option or defaultScrollToValue when the combobox opens.
+  // Scroll to the selected option or defaultScrollToValue when the combobox
+  // opens. With a collection the target is usually unmounted and the consumer's
+  // virtualizer owns the scroll position, so skip it.
+  const isExternallyVirtualized = context.externalCollection !== undefined;
   useEffect(() => {
     let rafId: number | undefined;
-    if (context.open && optionsRef.current) {
+    if (!isExternallyVirtualized && context.open && optionsRef.current) {
       // Small delay to ensure the DOM has rendered
       rafId = requestAnimationFrame(() => {
         const selectedValue = isSingleSelect(context.value)
@@ -1690,7 +1769,12 @@ const Options = <T extends TgphElement = "div">({
     return () => {
       if (rafId !== undefined) cancelAnimationFrame(rafId);
     };
-  }, [context.open, context.value, context.defaultScrollToValue]);
+  }, [
+    isExternallyVirtualized,
+    context.open,
+    context.value,
+    context.defaultScrollToValue,
+  ]);
 
   return (
     <BaseCombobox.List
@@ -1803,6 +1887,15 @@ const Option = <T extends TgphElement = "div">({
     ? contextValue.includes(value)
     : contextValue === value;
 
+  // Base UI looks a row's index up by value. An `onSelect` row carries a
+  // sentinel value it never finds, and a row it cannot place gets no id, never
+  // reaches `listRef`, and drops out of keyboard reach. So pass the index.
+  const externalCollection = context.externalCollection;
+  const collectionIndex = externalCollection?.indexByValue.get(value);
+  // A Create row carries its own index and is not in the collection.
+  const positionInCollection =
+    explicitIndex === undefined ? collectionIndex : undefined;
+
   // Depend on the specific stable context values rather than the whole (per-
   // render) context object, so this callback isn't rebuilt every Root render.
   const { closeOnSelect, onValueChange, setOpen } = context;
@@ -1896,7 +1989,7 @@ const Option = <T extends TgphElement = "div">({
       // without matching a real value or the "no selection" state, and their
       // commit is cancelled at the value bridge (see `isOnSelectItemValue`).
       value={onSelect ? ON_SELECT_ITEM_VALUE : value}
-      index={explicitIndex}
+      index={explicitIndex ?? collectionIndex}
       disabled={disabled}
       nativeButton={resolveButtonNativeButton({
         as: props.as ?? "div",
@@ -1913,6 +2006,18 @@ const Option = <T extends TgphElement = "div">({
           // Accessibility attributes
           role="option"
           aria-selected={isSelected ? "true" : "false"}
+          // The mounted rows are a window, so the DOM no longer says how long
+          // the list is or where this row sits in it.
+          aria-setsize={
+            positionInCollection === undefined
+              ? undefined
+              : externalCollection?.options.length
+          }
+          aria-posinset={
+            positionInCollection === undefined
+              ? undefined
+              : positionInCollection + 1
+          }
           // Custom attributes
           data-tgph-combobox-option
           data-tgph-combobox-option-value={value}
@@ -2301,13 +2406,17 @@ const Empty = <T extends TgphElement = "div">({
   const context = useContext(ComboboxContext);
   const [isVisible, setIsVisible] = useState(false);
 
+  // A window can be empty for a frame before the virtualizer measures, while
+  // the collection is full. Require both to be empty.
+  const externalOptionCount = context.externalCollection?.options.length;
+
   useEffect(() => {
     const content = context.contentRef?.current;
     if (!content) return undefined;
 
     const recount = () => {
       const options = content.querySelectorAll("[data-tgph-combobox-option]");
-      setIsVisible(options.length === 0);
+      setIsVisible(options.length === 0 && !externalOptionCount);
     };
 
     recount();
@@ -2318,7 +2427,7 @@ const Empty = <T extends TgphElement = "div">({
     observer.observe(content, { childList: true, subtree: true });
 
     return () => observer.disconnect();
-  }, [context.contentRef]);
+  }, [context.contentRef, externalOptionCount]);
 
   if (isVisible) {
     return (
@@ -2393,17 +2502,22 @@ const Create = <T extends TgphElement = "div">({
 
 // Walk the children for a `Combobox.Create` so the Root's `filteredItems` list
 // can reserve a slot for the row Create mounts (it isn't one of `options`).
-const childrenContainCreate = (children: ReactNode): boolean => {
-  let found = false;
+const findCreateControl = (
+  children: ReactNode,
+): { values?: Array<string> } | undefined => {
+  let found: { values?: Array<string> } | undefined;
   Children.forEach(children, (child) => {
     if (found || !(typeof child === "object" && child !== null)) return;
-    const element = child as ReactElement<{ children?: ReactNode }>;
+    const element = child as ReactElement<{
+      children?: ReactNode;
+      values?: Array<string>;
+    }>;
     if (element.type === Create) {
-      found = true;
+      found = { values: element.props?.values };
       return;
     }
     if (element.props?.children) {
-      found = childrenContainCreate(element.props.children);
+      found = findCreateControl(element.props.children);
     }
   });
   return found;

--- a/packages/combobox/src/Combobox/Combobox.types.ts
+++ b/packages/combobox/src/Combobox/Combobox.types.ts
@@ -12,6 +12,9 @@ export type DefinedOption = {
   label?: string | ReactNode;
 };
 
+// Public name for an entry of `Combobox.Root`'s `options` collection.
+export type ComboboxOption = DefinedOption;
+
 export type ComboboxValue = string | Array<string>;
 
 // How the combobox remembers a selection. `undefined` (the historical default)

--- a/packages/combobox/src/Combobox/ComboboxVirtualization.test.tsx
+++ b/packages/combobox/src/Combobox/ComboboxVirtualization.test.tsx
@@ -1,0 +1,488 @@
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { type ReactNode, useState } from "react";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { Combobox } from "./Combobox";
+import type { ComboboxHighlightDetails, ComboboxOption } from "./index";
+
+// The spec for external virtualization: the consumer owns the full collection
+// and mounts only a window of it.
+
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  // Base UI scrolls the highlighted row into view. jsdom has no implementation.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterAll(() => {
+  // Other suites feature-detect `scrollIntoView` and branch on it.
+  delete (Element.prototype as Partial<Element>).scrollIntoView;
+});
+
+const queryPortalElement = (selector: string) =>
+  document.querySelector(selector);
+const queryPortalElements = (selector: string) =>
+  document.querySelectorAll(selector);
+
+const CHANNELS = Array.from({ length: 200 }, (_, index) => ({
+  value: `channel-${index}`,
+  label: `Channel ${index}`,
+}));
+
+const WINDOW_SIZE = 8;
+
+const indexOfValue = (value: string) => Number(value.replace("channel-", ""));
+
+type HarnessProps = {
+  options?: Array<ComboboxOption>;
+  windowSize?: number;
+  defaultValue?: string;
+  // Off for the cases that must observe a row the window never mounts.
+  followHighlight?: boolean;
+  onItemHighlighted?: (
+    value: string | undefined,
+    details: ComboboxHighlightDetails,
+  ) => void;
+  children?: ReactNode;
+};
+
+// Stands in for TanStack Virtual. It slides a fixed-size window to follow the
+// highlighted index, like `virtualizer.scrollToIndex(details.index)`. It never
+// mounts the prefix from index 0. Pinning that prefix is the workaround this
+// contract removes, so a test that relied on it would prove nothing.
+const VirtualizedCombobox = ({
+  options = CHANNELS,
+  windowSize = WINDOW_SIZE,
+  defaultValue,
+  followHighlight = true,
+  onItemHighlighted,
+  children,
+}: HarnessProps) => {
+  const [start, setStart] = useState(0);
+  const [value, setValue] = useState<string | undefined>(defaultValue);
+  const windowOptions = options.slice(start, start + windowSize);
+
+  return (
+    <Combobox.Root
+      value={value}
+      onValueChange={setValue}
+      options={options}
+      onItemHighlighted={(highlightedValue, details) => {
+        onItemHighlighted?.(highlightedValue, details);
+        if (!followHighlight) return;
+        const index = details.index;
+        if (index < 0) return;
+        setStart((current) => {
+          if (index < current) return index;
+          if (index >= current + windowSize) return index - windowSize + 1;
+          return current;
+        });
+      }}
+    >
+      <Combobox.Trigger />
+      <Combobox.Content>
+        <Combobox.Search />
+        <Combobox.Options>
+          {windowOptions.map((option) => (
+            <Combobox.Option key={option.value} value={option.value}>
+              {option.label}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+        {children}
+      </Combobox.Content>
+    </Combobox.Root>
+  );
+};
+
+const openPopup = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(queryPortalElement("[data-tgph-combobox-trigger]")!);
+  await waitFor(() => {
+    expect(
+      queryPortalElements("[data-tgph-combobox-option]").length,
+    ).toBeGreaterThan(0);
+  });
+};
+
+// Chained, not mapped. Each press must land before the next one is sent.
+const pressArrow = async (
+  user: ReturnType<typeof userEvent.setup>,
+  key: "ArrowDown" | "ArrowUp",
+  times: number,
+) => {
+  await Array.from({ length: times }).reduce(
+    (chain) => chain.then(() => user.keyboard(`{${key}}`)),
+    Promise.resolve(),
+  );
+};
+
+// A re-render can re-report the same row without the highlight having moved.
+const collapseRepeats = (values: Array<string>) =>
+  values.filter((value, index) => value !== values[index - 1]);
+
+describe("Combobox external virtualization", () => {
+  it("mounts only the window while indexing against the whole collection", async () => {
+    const user = userEvent.setup();
+    render(<VirtualizedCombobox />);
+    await openPopup(user);
+
+    expect(queryPortalElements("[data-tgph-combobox-option]").length).toBe(
+      WINDOW_SIZE,
+    );
+
+    // Announces "1 of 200", not "1 of 8".
+    const first = queryPortalElement(
+      "[data-tgph-combobox-option-value='channel-0']",
+    );
+    expect(first?.getAttribute("aria-setsize")).toBe(String(CHANNELS.length));
+    expect(first?.getAttribute("aria-posinset")).toBe("1");
+  });
+
+  it("advances exactly one option per ArrowDown across window boundaries", async () => {
+    const user = userEvent.setup();
+    const highlighted: Array<string> = [];
+    render(
+      <VirtualizedCombobox
+        onItemHighlighted={(value) => {
+          if (value) highlighted.push(value);
+        }}
+      />,
+    );
+    await openPopup(user);
+
+    await pressArrow(user, "ArrowDown", WINDOW_SIZE * 3);
+
+    const path = collapseRepeats(highlighted).map(indexOfValue);
+    // The walk has to cross several window boundaries to mean anything.
+    expect(path.length).toBeGreaterThan(WINDOW_SIZE * 2);
+    path.forEach((index, position) => {
+      if (position === 0) return;
+      expect(index).toBe(path[position - 1]! + 1);
+    });
+
+    // ...without mounting the whole prefix.
+    expect(
+      queryPortalElements("[data-tgph-combobox-option]").length,
+    ).toBeLessThanOrEqual(WINDOW_SIZE);
+  });
+
+  it("retreats exactly one option per ArrowUp across window boundaries", async () => {
+    const user = userEvent.setup();
+    const highlighted: Array<string> = [];
+    render(
+      <VirtualizedCombobox
+        onItemHighlighted={(value) => {
+          if (value) highlighted.push(value);
+        }}
+      />,
+    );
+    await openPopup(user);
+
+    // Walk deep enough to leave the first window, then walk back.
+    await pressArrow(user, "ArrowDown", WINDOW_SIZE * 2);
+    const deepest = collapseRepeats(highlighted).at(-1)!;
+    highlighted.length = 0;
+
+    await pressArrow(user, "ArrowUp", WINDOW_SIZE + 2);
+
+    const path = collapseRepeats(highlighted).map(indexOfValue);
+    expect(path.length).toBeGreaterThan(WINDOW_SIZE);
+    expect(path[0]).toBe(indexOfValue(deepest) - 1);
+    path.forEach((index, position) => {
+      if (position === 0) return;
+      expect(index).toBe(path[position - 1]! - 1);
+    });
+  });
+
+  it("reports the string value of a highlighted row outside the first window", async () => {
+    const user = userEvent.setup();
+    const onItemHighlighted = vi.fn();
+    render(<VirtualizedCombobox onItemHighlighted={onItemHighlighted} />);
+    await openPopup(user);
+
+    await pressArrow(user, "ArrowDown", WINDOW_SIZE * 2);
+
+    const [value, details] = onItemHighlighted.mock.lastCall as [
+      string,
+      ComboboxHighlightDetails,
+    ];
+    expect(typeof value).toBe("string");
+    expect(indexOfValue(value)).toBeGreaterThanOrEqual(WINDOW_SIZE);
+    // The index the consumer feeds to its virtualizer must address the same row.
+    expect(CHANNELS[details.index]?.value).toBe(value);
+  });
+
+  it("renders the selected label when the option is outside the mounted window", async () => {
+    render(
+      <VirtualizedCombobox
+        defaultValue="channel-150"
+        followHighlight={false}
+      />,
+    );
+
+    const trigger = queryPortalElement("[data-tgph-combobox-trigger]");
+    expect(trigger?.textContent).toContain("Channel 150");
+    // The row itself was never mounted, so the label came from the collection.
+    expect(
+      queryPortalElement("[data-tgph-combobox-option-value='channel-150']"),
+    ).toBeFalsy();
+  });
+
+  it("re-seeds the highlight from the top when the collection changes", async () => {
+    const user = userEvent.setup();
+    const highlighted: Array<string> = [];
+
+    const Searchable = () => {
+      const [query, setQuery] = useState("");
+      const matches = CHANNELS.filter((channel) =>
+        channel.label.toLowerCase().includes(query.toLowerCase()),
+      );
+      const [start, setStart] = useState(0);
+      return (
+        <Combobox.Root
+          options={matches}
+          onItemHighlighted={(value, details) => {
+            if (value) highlighted.push(value);
+            const index = details.index;
+            if (index < 0) return;
+            setStart((current) => {
+              if (index < current) return index;
+              if (index >= current + WINDOW_SIZE)
+                return index - WINDOW_SIZE + 1;
+              return current;
+            });
+          }}
+        >
+          <Combobox.Trigger />
+          <Combobox.Content>
+            <Combobox.Search
+              value={query}
+              onValueChange={(next) => {
+                setQuery(next);
+                setStart(0);
+              }}
+            />
+            <Combobox.Options>
+              {matches.slice(start, start + WINDOW_SIZE).map((option) => (
+                <Combobox.Option key={option.value} value={option.value}>
+                  {option.label}
+                </Combobox.Option>
+              ))}
+            </Combobox.Options>
+            <Combobox.Empty />
+          </Combobox.Content>
+        </Combobox.Root>
+      );
+    };
+
+    render(<Searchable />);
+    await openPopup(user);
+
+    await pressArrow(user, "ArrowDown", WINDOW_SIZE * 2);
+    const beforeSearch = collapseRepeats(highlighted).at(-1)!;
+    expect(indexOfValue(beforeSearch)).toBeGreaterThan(WINDOW_SIZE);
+    highlighted.length = 0;
+
+    // Narrowing the collection must not leave the highlight parked at a stale
+    // index deep in the previous list.
+    await user.type(
+      queryPortalElement("[data-tgph-combobox-search]")! as HTMLElement,
+      "Channel 1",
+    );
+
+    await waitFor(() => {
+      expect(
+        queryPortalElement("[data-tgph-combobox-option-value='channel-1']"),
+      ).toBeTruthy();
+    });
+    await user.keyboard("{ArrowDown}");
+
+    const after = collapseRepeats(highlighted).at(-1)!;
+    expect(indexOfValue(after)).toBeLessThan(indexOfValue(beforeSearch));
+  });
+
+  it("shows Empty only when the collection itself is empty", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <VirtualizedCombobox options={CHANNELS}>
+        <Combobox.Empty />
+      </VirtualizedCombobox>,
+    );
+    await openPopup(user);
+    expect(queryPortalElement("[data-tgph-combobox-empty]")).toBeFalsy();
+
+    rerender(
+      <VirtualizedCombobox options={[]}>
+        <Combobox.Empty />
+      </VirtualizedCombobox>,
+    );
+    await waitFor(() => {
+      expect(queryPortalElement("[data-tgph-combobox-empty]")).toBeTruthy();
+    });
+  });
+
+  it("leaves the mounted-children contract untouched without an options collection", async () => {
+    const user = userEvent.setup();
+    render(
+      <Combobox.Root defaultValue="email">
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            <Combobox.Option value="email">Email</Combobox.Option>
+            <Combobox.Option value="sms">SMS</Combobox.Option>
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>,
+    );
+    await openPopup(user);
+
+    // No collection, so no set-size bookkeeping is added to the DOM.
+    const first = queryPortalElement(
+      "[data-tgph-combobox-option-value='email']",
+    );
+    expect(first?.getAttribute("aria-setsize")).toBeNull();
+    expect(first?.getAttribute("aria-posinset")).toBeNull();
+  });
+});
+
+describe("Combobox external virtualization with action rows", () => {
+  // An `onSelect` row commits nothing, so Base UI gives it a sentinel value it
+  // cannot find in the collection. Telegraph has to supply the index instead.
+  const ACTION_VALUE = "clear-all";
+  const ACTION_COLLECTION = [
+    { value: ACTION_VALUE, label: "Clear all" },
+    ...CHANNELS.slice(0, 20),
+  ];
+
+  const WithActionRow = ({ onSelect }: { onSelect: () => void }) => {
+    const [value, setValue] = useState<string | undefined>(undefined);
+    return (
+      <Combobox.Root
+        value={value}
+        onValueChange={setValue}
+        options={ACTION_COLLECTION}
+        closeOnSelect={false}
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Options>
+            <Combobox.Option value={ACTION_VALUE} onSelect={onSelect}>
+              Clear all
+            </Combobox.Option>
+            {CHANNELS.slice(0, 4).map((option) => (
+              <Combobox.Option key={option.value} value={option.value}>
+                {option.label}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+        </Combobox.Content>
+      </Combobox.Root>
+    );
+  };
+
+  it("registers an action row so the keyboard can reach it", async () => {
+    const user = userEvent.setup();
+    render(<WithActionRow onSelect={vi.fn()} />);
+    await openPopup(user);
+
+    const actionRow = queryPortalElement(
+      `[data-tgph-combobox-option-value='${ACTION_VALUE}']`,
+    );
+    // An unregistered row gets no id, so `aria-activedescendant` cannot
+    // address it and arrow keys skip past.
+    expect(actionRow?.getAttribute("id")).toBeTruthy();
+  });
+
+  it("commits an action row with Enter", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<WithActionRow onSelect={onSelect} />);
+    await openPopup(user);
+
+    await pressArrow(user, "ArrowDown", 1);
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("Combobox external virtualization with Create", () => {
+  // The collection also sizes Base UI's navigation bounds, so a slot reserved
+  // for a Create row that never renders leaves an index with no row behind it.
+  const CREATE_COLLECTION = CHANNELS.slice(0, 2);
+  const EXISTING = CREATE_COLLECTION[0]!.label;
+  // Create renders as an option row labelled `Create "<query>"`.
+  const CREATE_ROW = "[data-tgph-combobox-option-label^='Create \"']";
+
+  const WithCreate = ({ onIndex }: { onIndex: (index: number) => void }) => {
+    const [query, setQuery] = useState("");
+    return (
+      <Combobox.Root
+        options={CREATE_COLLECTION}
+        onItemHighlighted={(_value, details) => onIndex(details.index)}
+      >
+        <Combobox.Trigger />
+        <Combobox.Content>
+          <Combobox.Search value={query} onValueChange={setQuery} />
+          <Combobox.Options>
+            {CREATE_COLLECTION.map((option) => (
+              <Combobox.Option key={option.value} value={option.value}>
+                {option.label}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+          <Combobox.Create values={[EXISTING]} onCreate={() => {}} />
+        </Combobox.Content>
+      </Combobox.Root>
+    );
+  };
+
+  it("reserves no navigable slot when Create suppresses itself", async () => {
+    const user = userEvent.setup();
+    const indexes: Array<number> = [];
+    render(<WithCreate onIndex={(index) => indexes.push(index)} />);
+    await openPopup(user);
+
+    // The query is already one of Create's values, so Create renders nothing.
+    await user.type(
+      queryPortalElement("[data-tgph-combobox-search]")! as HTMLElement,
+      EXISTING,
+    );
+    await waitFor(() => {
+      expect(queryPortalElement(CREATE_ROW)).toBeFalsy();
+    });
+
+    indexes.length = 0;
+    await pressArrow(user, "ArrowDown", CREATE_COLLECTION.length + 2);
+
+    // Every highlight has to address a row that exists in the collection.
+    expect(indexes.length).toBeGreaterThan(0);
+    expect(Math.max(...indexes)).toBeLessThan(CREATE_COLLECTION.length);
+  });
+
+  it("still reserves a slot when Create does render", async () => {
+    const user = userEvent.setup();
+    const indexes: Array<number> = [];
+    render(<WithCreate onIndex={(index) => indexes.push(index)} />);
+    await openPopup(user);
+
+    await user.type(
+      queryPortalElement("[data-tgph-combobox-search]")! as HTMLElement,
+      "a brand new value",
+    );
+    await waitFor(() => {
+      expect(queryPortalElement(CREATE_ROW)).toBeTruthy();
+    });
+
+    indexes.length = 0;
+    await pressArrow(user, "ArrowDown", CREATE_COLLECTION.length + 2);
+
+    // Create sits one past the collection and must stay reachable.
+    expect(Math.max(...indexes)).toBe(CREATE_COLLECTION.length);
+  });
+});

--- a/packages/combobox/src/Combobox/index.ts
+++ b/packages/combobox/src/Combobox/index.ts
@@ -20,4 +20,5 @@ export type {
   ComboboxHighlightReason,
   ComboboxHighlightDetails,
   ComboboxActions,
+  ComboboxOption,
 } from "./Combobox.types";

--- a/packages/combobox/src/index.ts
+++ b/packages/combobox/src/index.ts
@@ -18,4 +18,5 @@ export type {
   ComboboxHighlightReason,
   ComboboxHighlightDetails,
   ComboboxActions,
+  ComboboxOption,
 } from "./Combobox";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,6 +3202,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.14.11":
+  version: 3.14.11
+  resolution: "@tanstack/react-virtual@npm:3.14.11"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.17.9"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/604e5018e94508ed755c28c63b9b6243de855f67b1442a577df596aad8154058e471965f9d8f0b9d5d8bb8c8e03e7528533d41afc3a5ae2b620c5340c7338a30
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.17.9":
+  version: 3.17.9
+  resolution: "@tanstack/virtual-core@npm:3.17.9"
+  checksum: 10c0/1ea613b072c910f085989fc71b574ae101b7daad82df248340a45a66e718cedf0d879080c21ab7b5bbbb3c6f6ca477c4e182beb6068a5e3ed4e7ad49714d6742
+  languageName: node
+  linkType: hard
+
 "@telegraph/appearance@workspace:^, @telegraph/appearance@workspace:packages/appearance":
   version: 0.0.0-use.local
   resolution: "@telegraph/appearance@workspace:packages/appearance"
@@ -3277,6 +3296,7 @@ __metadata:
   dependencies:
     "@base-ui/react": "npm:^1.6.0"
     "@knocklabs/typescript-config": "npm:^0.0.2"
+    "@tanstack/react-virtual": "npm:^3.14.11"
     "@telegraph/button": "workspace:^"
     "@telegraph/compose-refs": "workspace:^"
     "@telegraph/helpers": "workspace:^"


### PR DESCRIPTION
### What changed?

- `Combobox.Root` takes an `options` collection, for consumers that mount only a window of `Combobox.Option` children (TanStack Virtual and friends). Base UI indexes rows against that collection instead of the mounted DOM, so ArrowUp/ArrowDown move one option at a time across a window boundary.
- Passing `options` hands Base UI `items`, not just `filteredItems`. Only `items` sizes its navigation bounds (`listRef.current.length`) to the whole collection, which is what `virtualized` needs to work. `filter={null}` stops a second filter pass shifting the indexes.
- Rows get an explicit `index`. Base UI looks an index up by value, and an `onSelect` row carries a sentinel value it never finds in the collection, which would drop that row out of keyboard reach.
- Labels, `aria-setsize`, and `aria-posinset` come from the collection, so a selected option outside the window still resolves on the trigger and screen readers hear "3 of 5000", not "3 of 8".
- `Combobox.Create` reserves its slot only when it actually renders. A slot Create does not fill left a navigable index with no row behind it.
- New `ComboboxVirtualization.test.tsx`, a TanStack Virtual story, type tests, and README docs.

Comboboxes that do not pass `options` are unaffected: `items`/`filter` go over as `undefined`, `virtualized` as `false`, and every new branch collapses to its previous value.

### Why?

`SlackWorkspaceChannelSelector` works around this today by pinning every index from `0` through `highlightedIndex + 1` into the virtualizer's range. That keeps keyboard navigation stable but progressively mounts the whole prefix of the list, which undoes the point of virtualizing. This exposes Base UI's own external-virtualization contract so the workaround can come out.

### Notes

Passing `options` carries three obligations, all documented on the prop and in the README: filtering is the consumer's (it forces `manualFiltering`), scrolling is the consumer's (drive the virtualizer from `onItemHighlighted`'s `details.index`), and every mounted option needs an entry in the collection, action rows included.

`contains Escape only while the popup is open` is flaky on this branch, roughly 1 run in 5. It is pre-existing: it reproduces at the same rate against a pristine `Combobox.tsx` with everything else unchanged. Tracked separately.

### Checklist

- [x] **Changeset added.**
- [x] **README updated for API changes.**
- [x] **Invalid prop usage still fails type-checking.**
- [x] **Storybook stories updated.**

Resolves KNO-15099
